### PR TITLE
feat(auth): add login and registration flow

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { Typography } from "antd";
+
+import { LoginForm } from "@/components/auth/login-form";
+
+export default function LoginPage() {
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(242,140,40,0.16),_transparent_26%),linear-gradient(135deg,_#eef3f8,_#f8fafc_50%,_#eef3f8)] px-4 py-10">
+      <div className="mx-auto grid min-h-[calc(100vh-5rem)] max-w-6xl gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+        <section className="space-y-6">
+          <Typography.Title className="!mb-0 !text-5xl !leading-tight" level={1}>
+            Close the visibility gap in enterprise sales.
+          </Typography.Title>
+          <Typography.Paragraph className="!mb-0 max-w-2xl !text-lg !text-slate-600">
+            AutoSales unifies opportunities, proposals, pricing requests, activities, and renewals into one operational workflow.
+          </Typography.Paragraph>
+          <div className="grid gap-4 sm:grid-cols-3">
+            {[
+              "Track long B2B cycles",
+              "Coordinate proposals faster",
+              "Prevent renewal leakage",
+            ].map((item) => (
+              <div key={item} className="rounded-2xl border border-white/70 bg-white/70 px-4 py-4 backdrop-blur">
+                <Typography.Text strong>{item}</Typography.Text>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="flex justify-center">
+          <div className="w-full max-w-md space-y-5">
+            <LoginForm />
+            <Typography.Paragraph className="!mb-0 text-center !text-slate-500">
+              New workspace? <Link href="/register">Create an account</Link>
+            </Typography.Paragraph>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { Typography } from "antd";
+
+import { RegisterForm } from "@/components/auth/register-form";
+
+export default function RegisterPage() {
+  return (
+    <main className="min-h-screen bg-[linear-gradient(160deg,_#f8fafc,_#eef3f8_45%,_#fde6cc)] px-4 py-10">
+      <div className="mx-auto grid min-h-[calc(100vh-5rem)] max-w-7xl gap-10 lg:grid-cols-[0.95fr_1.05fr] lg:items-center">
+        <section className="space-y-6">
+          <Typography.Title className="!mb-0 !text-5xl !leading-tight" level={1}>
+            Build a sales workspace around accountability.
+          </Typography.Title>
+          <Typography.Paragraph className="!mb-0 max-w-2xl !text-lg !text-slate-600">
+            Launch a shared workspace for your team and centralise business development, proposals, pricing, and contract visibility.
+          </Typography.Paragraph>
+          <div className="space-y-4">
+            {[
+              "Role-aware access for admins, sales managers, and reps",
+              "Structured follow-up workflows across the entire pipeline",
+              "One shared view of renewals, deadlines, and reporting",
+            ].map((item) => (
+              <div key={item} className="rounded-2xl border border-slate-200 bg-white/80 px-5 py-4 backdrop-blur">
+                <Typography.Text>{item}</Typography.Text>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="flex justify-center">
+          <div className="w-full max-w-2xl space-y-5">
+            <RegisterForm />
+            <Typography.Paragraph className="!mb-0 text-center !text-slate-500">
+              Already registered? <Link href="/login">Sign in instead</Link>
+            </Typography.Paragraph>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/api/Auth/login/route.ts
+++ b/app/api/Auth/login/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { findUserByEmail, toAuthPayload } from "../mock-users";
+import { AUTH_COOKIE_NAME, AUTH_COOKIE_OPTIONS } from "../session-cookie";
+import { createBackendUrl } from "@/lib/server/backend-url";
+
+const readJsonBody = async (response: Response) => {
+  const text = await response.text();
+
+  if (!text.trim()) {
+    return {} as Record<string, unknown>;
+  }
+
+  return JSON.parse(text) as Record<string, unknown>;
+};
+
+export async function POST(request: NextRequest) {
+  const rawBody = await request.text();
+  const credentials = JSON.parse(rawBody) as { email?: string; password?: string };
+  const email = credentials.email?.trim().toLowerCase() ?? "";
+  const mockUser = email ? findUserByEmail(email) : undefined;
+
+  if (mockUser && credentials.password === mockUser.password) {
+    const payload = toAuthPayload(mockUser);
+    const response = NextResponse.json(payload, { status: 200 });
+
+    response.cookies.set(AUTH_COOKIE_NAME, payload.token, AUTH_COOKIE_OPTIONS);
+
+    return response;
+  }
+
+  const upstream = await fetch(createBackendUrl("/api/Auth/login"), {
+    body: rawBody,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+    redirect: "manual",
+  });
+  const payload = await readJsonBody(upstream);
+  const response = NextResponse.json(payload, { status: upstream.status });
+
+  const token = typeof payload.token === "string" ? payload.token : "";
+
+  if (upstream.ok && token) {
+    response.cookies.set(AUTH_COOKIE_NAME, token, AUTH_COOKIE_OPTIONS);
+  }
+
+  return response;
+}

--- a/app/api/Auth/logout/route.ts
+++ b/app/api/Auth/logout/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+import { AUTH_COOKIE_NAME, AUTH_COOKIE_OPTIONS } from "../session-cookie";
+
+export async function POST() {
+  const response = NextResponse.json({ success: true });
+
+  response.cookies.set(AUTH_COOKIE_NAME, "", {
+    ...AUTH_COOKIE_OPTIONS,
+    maxAge: 0,
+  });
+
+  return response;
+}

--- a/app/api/Auth/me/route.ts
+++ b/app/api/Auth/me/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { toAuthPayload } from "../mock-users";
+import { AUTH_COOKIE_NAME, AUTH_COOKIE_OPTIONS } from "../session-cookie";
+import { createBackendUrl } from "@/lib/server/backend-url";
+import { getUserFromSessionToken } from "@/lib/auth/session-user";
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const cookieToken = request.cookies.get(AUTH_COOKIE_NAME)?.value;
+  const token = authHeader?.replace(/^Bearer\s+/i, "").trim() || cookieToken || "";
+  const mockUser = token ? getUserFromSessionToken(token) : null;
+
+  if (mockUser && token.startsWith("mock-token::")) {
+    return NextResponse.json(toAuthPayload(mockUser), { status: 200 });
+  }
+
+  const headers = new Headers();
+
+  if (authHeader) {
+    headers.set("authorization", authHeader);
+  } else if (cookieToken) {
+    headers.set("authorization", `Bearer ${cookieToken}`);
+  }
+  const upstream = await fetch(createBackendUrl("/api/Auth/me"), {
+    headers,
+    method: "GET",
+    redirect: "manual",
+  });
+  const payload =
+    upstream.status === 204 ? null : ((await upstream.json()) as Record<string, unknown> | null);
+  const response = NextResponse.json(payload, { status: upstream.status });
+
+  if (upstream.status === 401) {
+    response.cookies.set(AUTH_COOKIE_NAME, "", {
+      ...AUTH_COOKIE_OPTIONS,
+      maxAge: 0,
+    });
+  }
+
+  return response;
+}

--- a/app/api/Auth/mock-users.ts
+++ b/app/api/Auth/mock-users.ts
@@ -1,0 +1,121 @@
+export type MockUserRole =
+  | "Admin"
+  | "SalesManager"
+  | "BusinessDevelopmentManager"
+  | "SalesRep";
+
+export interface IMockUser {
+  clientIds?: string[];
+  email: string;
+  firstName: string;
+  id: string;
+  lastName: string;
+  password: string;
+  role: MockUserRole;
+  tenantId: string;
+  tenantName: string;
+}
+
+const users = new Map<string, IMockUser>([
+  [
+    "admin@autosales.com",
+    {
+      email: "admin@autosales.com",
+      firstName: "Admin",
+      id: "legacy-admin",
+      lastName: "User",
+      password: "Admin123",
+      role: "Admin",
+      tenantId: "mock-tenant-autosales",
+      tenantName: "AutoSales Mock Workspace",
+    },
+  ],
+  [
+    "admin@salesautomation.com",
+    {
+      email: "admin@salesautomation.com",
+      firstName: "Admin",
+      id: "1",
+      lastName: "User",
+      password: "Admin@123",
+      role: "Admin",
+      tenantId: "11111111-1111-1111-1111-111111111111",
+      tenantName: "Shared Demo Tenant",
+    },
+  ],
+  [
+    "salesrep@salesautomation.com",
+    {
+      email: "salesrep@salesautomation.com",
+      firstName: "Demo",
+      id: "2",
+      lastName: "Rep",
+      password: "Pass@123",
+      role: "SalesRep",
+      tenantId: "11111111-1111-1111-1111-111111111111",
+      tenantName: "Shared Demo Tenant",
+    },
+  ],
+]);
+
+let nextId = 3;
+
+export const findUserByEmail = (email: string) => users.get(email.toLowerCase());
+
+export const createMockToken = (email: string) =>
+  `mock-token::${email.toLowerCase()}::${Date.now()}`;
+
+export const getUserFromToken = (token: string) => {
+  const parts = token.split("::");
+  const email = parts[1];
+
+  return email ? findUserByEmail(email) : undefined;
+};
+
+export const registerMockUser = ({
+  email,
+  firstName,
+  lastName,
+  password,
+  role,
+  tenantName,
+}: {
+  email: string;
+  firstName: string;
+  lastName: string;
+  password: string;
+  role: MockUserRole;
+  tenantName?: string;
+}) => {
+  const normalizedEmail = email.toLowerCase();
+
+  if (users.has(normalizedEmail)) {
+    return null;
+  }
+
+  const user: IMockUser = {
+    email: normalizedEmail,
+    firstName,
+    id: String(nextId++),
+    lastName,
+    password,
+    role,
+    tenantId: "11111111-1111-1111-1111-111111111111",
+    tenantName: tenantName || "Shared Demo Tenant",
+  };
+
+  users.set(normalizedEmail, user);
+
+  return user;
+};
+
+export const toAuthPayload = (user: IMockUser) => ({
+  email: user.email,
+  firstName: user.firstName,
+  lastName: user.lastName,
+  roles: [user.role],
+  tenantId: user.tenantId,
+  tenantName: user.tenantName,
+  token: createMockToken(user.email),
+  userId: user.id,
+});

--- a/app/api/Auth/register/route.ts
+++ b/app/api/Auth/register/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { AUTH_COOKIE_NAME, AUTH_COOKIE_OPTIONS } from "../session-cookie";
+import { createBackendUrl } from "@/lib/server/backend-url";
+
+const readJsonBody = async (response: Response) => {
+  const text = await response.text();
+
+  if (!text.trim()) {
+    return {} as Record<string, unknown>;
+  }
+
+  return JSON.parse(text) as Record<string, unknown>;
+};
+
+export async function POST(request: NextRequest) {
+  const upstream = await fetch(createBackendUrl("/api/Auth/register"), {
+    body: await request.text(),
+    headers: {
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+    redirect: "manual",
+  });
+  const payload = await readJsonBody(upstream);
+  const response = NextResponse.json(payload, { status: upstream.status });
+
+  const token = typeof payload.token === "string" ? payload.token : "";
+
+  if (upstream.ok && token) {
+    response.cookies.set(AUTH_COOKIE_NAME, token, AUTH_COOKIE_OPTIONS);
+  }
+
+  return response;
+}

--- a/app/api/Auth/session-cookie.ts
+++ b/app/api/Auth/session-cookie.ts
@@ -1,0 +1,9 @@
+export const AUTH_COOKIE_NAME = "autosales_session";
+
+export const AUTH_COOKIE_OPTIONS = {
+  httpOnly: true,
+  maxAge: 60 * 60 * 8,
+  path: "/",
+  sameSite: "lax" as const,
+  secure: process.env.NODE_ENV === "production",
+};

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { AppProviders } from "./providers";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -27,7 +28,9 @@ export default function RootLayout({
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full flex flex-col">
+        <AppProviders>{children}</AppProviders>
+      </body>
     </html>
   );
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import AuthProvider from "@/providers/authProvider";
+
+type AppProvidersProps = Readonly<{
+  children: React.ReactNode;
+}>;
+
+export function AppProviders({ children }: AppProvidersProps) {
+  return <AuthProvider>{children}</AuthProvider>;
+}
+
+export default AppProviders;

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Alert, Button, Card, Form, Input, Typography } from "antd";
+
+import { useAuthActions, useAuthState } from "@/providers/authProvider";
+
+type LoginValues = {
+  email: string;
+  password: string;
+};
+
+export function LoginForm() {
+  const { login } = useAuthActions();
+  const { isError, isPending } = useAuthState();
+
+  const onFinish = async (values: LoginValues) => {
+    await login(values);
+  };
+
+  return (
+    <Card className="w-full max-w-md border-0 shadow-2xl shadow-slate-200/80">
+      <div className="mb-8 space-y-2">
+        <Typography.Title level={2} className="!mb-0">
+          Welcome back
+        </Typography.Title>
+        <Typography.Paragraph className="!mb-0 !text-slate-500">
+          Sign in with your organisation account to manage your sales workspace. For local testing, use the mock admin account below.
+        </Typography.Paragraph>
+        <Typography.Text className="block !text-sm !text-slate-500">
+          Mock admin: <strong>admin@autosales.com</strong> / <strong>Admin123</strong>
+        </Typography.Text>
+      </div>
+
+      {isError ? (
+        <Alert
+          className="mb-6"
+          message="We could not sign you in with those credentials."
+          type="error"
+        />
+      ) : null}
+
+      <Form layout="vertical" onFinish={onFinish} requiredMark={false}>
+        <Form.Item
+          label="Email"
+          name="email"
+          rules={[{ message: "Email is required", required: true }]}
+        >
+          <Input placeholder="admin@autosales.com" size="large" />
+        </Form.Item>
+
+        <Form.Item
+          label="Password"
+          name="password"
+          rules={[{ message: "Password is required", required: true }]}
+        >
+          <Input.Password placeholder="Enter your password" size="large" />
+        </Form.Item>
+
+        <Button block htmlType="submit" loading={isPending} size="large" type="primary">
+          Sign in
+        </Button>
+      </Form>
+    </Card>
+  );
+}

--- a/components/auth/register-form.tsx
+++ b/components/auth/register-form.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { Alert, Button, Card, Form, Input, Select, Typography } from "antd";
+
+import { useAuthActions, useAuthState } from "@/providers/authProvider";
+
+type RegistrationScenario = "existing-tenant" | "new-tenant" | "shared-tenant";
+type RegistrationRole = "SalesRep" | "SalesManager" | "BusinessDevelopmentManager";
+
+type RegisterValues = {
+  email: string;
+  firstName: string;
+  lastName: string;
+  password: string;
+  phoneNumber?: string;
+  role?: RegistrationRole;
+  scenario: RegistrationScenario;
+  tenantId?: string;
+  tenantName?: string;
+};
+
+export function RegisterForm() {
+  const [form] = Form.useForm<RegisterValues>();
+  const { register } = useAuthActions();
+  const { isError, isPending } = useAuthState();
+  const scenario = Form.useWatch("scenario", form) ?? "new-tenant";
+
+  const onFinish = async (values: RegisterValues) => {
+    const { scenario: nextScenario, ...rest } = values;
+
+    if (nextScenario === "new-tenant") {
+      await register({
+        ...rest,
+        role: undefined,
+        tenantId: undefined,
+        tenantName: values.tenantName,
+      });
+      return;
+    }
+
+    if (nextScenario === "existing-tenant") {
+      await register({
+        ...rest,
+        role: values.role,
+        tenantId: values.tenantId,
+        tenantName: undefined,
+      });
+      return;
+    }
+
+    await register({
+      ...rest,
+      role: values.role,
+      tenantId: undefined,
+      tenantName: undefined,
+    });
+  };
+
+  return (
+    <Card className="w-full max-w-2xl border-0 shadow-2xl shadow-slate-200/80">
+      <div className="mb-8 space-y-2">
+        <Typography.Title level={2} className="!mb-0">
+          Create your workspace
+        </Typography.Title>
+        <Typography.Paragraph className="!mb-0 !text-slate-500">
+          Create a new organisation, join an existing tenant, or use the shared test workspace.
+        </Typography.Paragraph>
+      </div>
+
+      {isError ? (
+        <Alert
+          className="mb-6"
+          message="We could not create your account right now."
+          type="error"
+        />
+      ) : null}
+
+      <Form
+        form={form}
+        initialValues={{ role: "SalesRep", scenario: "new-tenant" }}
+        layout="vertical"
+        onFinish={onFinish}
+        requiredMark={false}
+      >
+        <Form.Item
+          label="Registration flow"
+          name="scenario"
+          rules={[{ message: "Choose how you want to register", required: true }]}
+        >
+          <Select
+            options={[
+              { label: "Create a new organisation", value: "new-tenant" },
+              { label: "Join an existing organisation", value: "existing-tenant" },
+              { label: "Use the shared test tenant", value: "shared-tenant" },
+            ]}
+            size="large"
+          />
+        </Form.Item>
+
+        <div className="grid gap-5 md:grid-cols-2">
+          <Form.Item
+            label="First name"
+            name="firstName"
+            rules={[{ message: "First name is required", required: true }]}
+          >
+            <Input placeholder="Ava" size="large" />
+          </Form.Item>
+
+          <Form.Item
+            label="Last name"
+            name="lastName"
+            rules={[{ message: "Last name is required", required: true }]}
+          >
+            <Input placeholder="Mokoena" size="large" />
+          </Form.Item>
+
+          <Form.Item
+            label="Email"
+            name="email"
+            rules={[{ message: "Email is required", required: true }]}
+          >
+            <Input placeholder="ava@salesautomation.com" size="large" />
+          </Form.Item>
+
+          <Form.Item
+            label="Phone"
+            name="phoneNumber"
+          >
+            <Input placeholder="+27 71 000 0000" size="large" />
+          </Form.Item>
+
+          {scenario === "new-tenant" ? (
+            <Form.Item
+              label="Organisation name"
+              name="tenantName"
+              rules={[{ message: "Organisation name is required", required: true }]}
+            >
+              <Input placeholder="Acme Corp" size="large" />
+            </Form.Item>
+          ) : null}
+
+          {scenario === "existing-tenant" ? (
+            <Form.Item
+              label="Tenant ID"
+              name="tenantId"
+              rules={[{ message: "Tenant ID is required", required: true }]}
+            >
+              <Input
+                placeholder="11111111-1111-1111-1111-111111111111"
+                size="large"
+              />
+            </Form.Item>
+          ) : null}
+
+          {scenario !== "new-tenant" ? (
+            <Form.Item
+              label="Role"
+              name="role"
+              rules={[{ message: "Role is required", required: true }]}
+            >
+              <Select
+                options={[
+                  { label: "Sales Rep", value: "SalesRep" },
+                  { label: "Sales Manager", value: "SalesManager" },
+                  {
+                    label: "Business Development Manager",
+                    value: "BusinessDevelopmentManager",
+                  },
+                ]}
+                placeholder="Choose a role"
+                size="large"
+              />
+            </Form.Item>
+          ) : null}
+        </div>
+
+        <Form.Item
+          label="Password"
+          name="password"
+          rules={[{ message: "Password is required", required: true }]}
+        >
+          <Input.Password placeholder="Create a secure password" size="large" />
+        </Form.Item>
+
+        <Button block htmlType="submit" loading={isPending} size="large" type="primary">
+          Create account
+        </Button>
+      </Form>
+    </Card>
+  );
+}

--- a/lib/auth/roles.ts
+++ b/lib/auth/roles.ts
@@ -1,0 +1,43 @@
+export type UserRole =
+  | "Admin"
+  | "SalesManager"
+  | "BusinessDevelopmentManager"
+  | "SalesRep";
+
+const ROLE_ALIASES: Record<string, UserRole> = {
+  admin: "Admin",
+  businessdevelopmentmanager: "BusinessDevelopmentManager",
+  client: "SalesRep",
+  salesmanager: "SalesManager",
+  salesrep: "SalesRep",
+};
+
+export const normalizeUserRole = (value?: string | null): UserRole => {
+  const key = value?.replace(/\s+/g, "").trim().toLowerCase() ?? "";
+
+  return ROLE_ALIASES[key] ?? "SalesRep";
+};
+
+export const getPrimaryUserRole = (
+  roles?: string[] | null,
+  fallback?: string | null,
+): UserRole => normalizeUserRole(roles?.[0] ?? fallback ?? null);
+
+export const isManagerRole = (role: UserRole) =>
+  role === "Admin" || role === "SalesManager";
+
+export const isAdminRole = (role: UserRole) => role === "Admin";
+
+export const getUserRoleLabel = (role: UserRole) => {
+  switch (role) {
+    case "Admin":
+      return "Administrator";
+    case "SalesManager":
+      return "Sales Manager";
+    case "BusinessDevelopmentManager":
+      return "Business Development Manager";
+    case "SalesRep":
+    default:
+      return "Sales Rep";
+  }
+};

--- a/lib/auth/session-user.ts
+++ b/lib/auth/session-user.ts
@@ -1,0 +1,121 @@
+import { getUserFromToken, type IMockUser, type MockUserRole } from "@/app/api/Auth/mock-users";
+import { normalizeUserRole } from "@/lib/auth/roles";
+
+type JwtPayload = Record<string, unknown>;
+
+const decodeJwtPayload = (token: string): JwtPayload | null => {
+  const parts = token.split(".");
+
+  if (parts.length !== 3) {
+    return null;
+  }
+
+  try {
+    const normalized = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+    const json = Buffer.from(padded, "base64").toString("utf8");
+
+    return JSON.parse(json) as JwtPayload;
+  } catch {
+    return null;
+  }
+};
+
+const readStringClaim = (payload: JwtPayload, keys: string[]) => {
+  for (const key of keys) {
+    const value = payload[key];
+
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return null;
+};
+
+const readRoleClaim = (payload: JwtPayload): MockUserRole => {
+  const candidates = [
+    payload.role,
+    payload.roles,
+    payload["http://schemas.microsoft.com/ws/2008/06/identity/claims/role"],
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      return normalizeUserRole(candidate);
+    }
+
+    if (Array.isArray(candidate)) {
+      const role = candidate.find(
+        (item): item is string => typeof item === "string" && item.trim().length > 0,
+      );
+
+      if (role) {
+        return normalizeUserRole(role);
+      }
+    }
+  }
+
+  return "SalesRep";
+};
+
+const getJwtUserFromToken = (token: string): IMockUser | null => {
+  const payload = decodeJwtPayload(token);
+
+  if (!payload) {
+    return null;
+  }
+
+  const email = readStringClaim(payload, [
+    "email",
+    "upn",
+    "unique_name",
+    "preferred_username",
+    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+  ]);
+
+  if (!email) {
+    return null;
+  }
+
+  const firstName =
+    readStringClaim(payload, [
+      "given_name",
+      "firstName",
+      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+    ]) ?? "";
+  const lastName =
+    readStringClaim(payload, [
+      "family_name",
+      "lastName",
+      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+    ]) ?? "";
+  const fullName =
+    readStringClaim(payload, [
+      "name",
+      "fullName",
+      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+    ]) ?? "";
+  const [fallbackFirstName, ...fallbackLastNameParts] = fullName.split(" ").filter(Boolean);
+
+  return {
+    clientIds: [],
+    email,
+    firstName: firstName || fallbackFirstName || email,
+    id:
+      readStringClaim(payload, [
+        "sub",
+        "nameid",
+        "userId",
+        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
+      ]) ?? email,
+    lastName: lastName || fallbackLastNameParts.join(" "),
+    password: "",
+    role: readRoleClaim(payload),
+    tenantId: readStringClaim(payload, ["tenantId", "tid"]) ?? "external-tenant",
+    tenantName: readStringClaim(payload, ["tenantName"]) ?? "External Workspace",
+  };
+};
+
+export const getUserFromSessionToken = (token: string): IMockUser | null =>
+  getUserFromToken(token) ?? getJwtUserFromToken(token) ?? null;

--- a/lib/client/auth-session.ts
+++ b/lib/client/auth-session.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import type { IUserLoginResponse } from "@/providers/authProvider/context";
+
+const AUTH_STORAGE_KEY = "auth_user";
+
+export const getSessionToken = () =>
+  typeof window !== "undefined" ? sessionStorage.getItem("token") : null;
+
+export const getStoredAuthUser = () => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const raw = sessionStorage.getItem(AUTH_STORAGE_KEY);
+
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw) as IUserLoginResponse;
+  } catch {
+    return null;
+  }
+};
+
+export const storeAuthSession = (user: IUserLoginResponse) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (user.token) {
+    sessionStorage.setItem("token", user.token);
+  }
+
+  sessionStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(user));
+};
+
+export const clearAuthSession = () => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  sessionStorage.removeItem("token");
+  sessionStorage.removeItem(AUTH_STORAGE_KEY);
+};

--- a/lib/server/backend-url.ts
+++ b/lib/server/backend-url.ts
@@ -1,0 +1,15 @@
+export const getBackendBaseUrl = () => {
+  const value = process.env.BACKEND_API_BASE_URL?.trim();
+
+  if (!value) {
+    throw new Error("BACKEND_API_BASE_URL is not configured.");
+  }
+
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+};
+
+export const createBackendUrl = (path: string) => {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+
+  return new URL(`${getBackendBaseUrl()}${normalizedPath}`);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,18 @@
       "name": "frontend-project",
       "version": "0.1.0",
       "dependencies": {
+        "antd": "^6.3.6",
         "next": "16.2.4",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "redux-actions": "^3.0.3"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/redux-actions": "^2.6.5",
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
         "tailwindcss": "^4",
@@ -34,6 +37,99 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ant-design/colors": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-8.0.1.tgz",
+      "integrity": "sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/fast-color": "^3.0.0"
+      }
+    },
+    "node_modules/@ant-design/cssinjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-2.1.2.tgz",
+      "integrity": "sha512-2Hy8BnCEH31xPeSLbhhB2ctCPXE2ZnASdi+KbSeS79BNbUhL9hAEe20SkUk+BR8aKTmqb6+FKFruk7w8z0VoRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "@emotion/hash": "^0.8.0",
+        "@emotion/unitless": "^0.7.5",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "stylis": "^4.3.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@ant-design/cssinjs-utils": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-2.1.2.tgz",
+      "integrity": "sha512-5fTHQ158jJJ5dC/ECeyIdZUzKxE/mpEMRZxthyG1sw/AKRHKgJBg00Yi6ACVXgycdje7KahRNvNET/uBccwCnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/cssinjs": "^2.1.2",
+        "@babel/runtime": "^7.23.2",
+        "@rc-component/util": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@ant-design/fast-color": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-3.0.1.tgz",
+      "integrity": "sha512-esKJegpW4nckh0o6kV3Tkb7NPIZYbPnnFxmQDUmL08ukXZAvV85TZBr70eGuke/CIArLaP6aw8lt9KILjnWuOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.x"
+      }
+    },
+    "node_modules/@ant-design/icons": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.1.1.tgz",
+      "integrity": "sha512-AMT4N2y++TZETNHiM77fs4a0uPVCJGuL5MTonk13Pvv7UN7sID1cNEZOc1qNqx6zLKAOilTEFAdAoAFKa0U//Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/colors": "^8.0.0",
+        "@ant-design/icons-svg": "^4.4.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@ant-design/icons-svg": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
+      "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==",
+      "license": "MIT"
+    },
+    "node_modules/@ant-design/react-slick": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-2.0.0.tgz",
+      "integrity": "sha512-HMS9sRoEmZey8LsE/Yo6+klhlzU12PisjrVcydW3So7RdklyEd2qehyU6a7Yp+OYN72mgsYs3NFCyP2lCPFVqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "clsx": "^2.1.1",
+        "json2mq": "^0.2.0",
+        "throttle-debounce": "^5.0.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -228,6 +324,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -308,6 +413,18 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -1300,6 +1417,725 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@rc-component/async-validator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.1.0.tgz",
+      "integrity": "sha512-n4HcR5siNUXRX23nDizbZBQPO0ZM/5oTtmKZ6/eqL0L2bo747cklFdZGRN2f+c9qWGICwDzrhW0H7tE9PptdcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.4"
+      },
+      "engines": {
+        "node": ">=14.x"
+      }
+    },
+    "node_modules/@rc-component/cascader": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.14.0.tgz",
+      "integrity": "sha512-Ip9356xwZUR2nbW5PRVGif4B/bDve4pLa/N+PGbvBaTnjbvmN4PFMBGQSmlDlzKP1ovxaYMvwF/dI9lXNLT4iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/select": "~1.6.0",
+        "@rc-component/tree": "~1.2.0",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/checkbox": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/checkbox/-/checkbox-2.0.0.tgz",
+      "integrity": "sha512-3CXGPpAR9gsPKeO2N78HAPOzU30UdemD6HGJoWVJOpa6WleaGB5kzZj3v6bdTZab31YuWgY/RxV3VKPctn0DwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/collapse": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/collapse/-/collapse-1.2.0.tgz",
+      "integrity": "sha512-ZRYSKSS39qsFx93p26bde7JUZJshsUBEQRlRXPuJYlAiNX0vyYlF5TsAm8JZN3LcF8XvKikdzPbgAtXSbkLUkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/color-picker": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-3.1.1.tgz",
+      "integrity": "sha512-OHaCHLHszCegdXmIq2ZRIZBN/EtpT6Wm8SG/gpzLATHbVKc/avvuKi+zlOuk05FTWvgaMmpxAko44uRJ3M+2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/fast-color": "^3.0.1",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/context": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-2.0.1.tgz",
+      "integrity": "sha512-HyZbYm47s/YqtP6pKXNMjPEMaukyg7P0qVfgMLzr7YiFNMHbK2fKTAGzms9ykfGHSfyf75nBbgWw+hHkp+VImw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/dialog": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@rc-component/dialog/-/dialog-1.8.4.tgz",
+      "integrity": "sha512-Ay6PM7phkTkquplG8fWfUGFZ2GTLx9diTl4f0d8Eqxd7W1u1KjE9AQooFQHOHnhZf0Ya3z51+5EKCWHmt/dNEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.1.3",
+        "@rc-component/portal": "^2.1.0",
+        "@rc-component/util": "^1.9.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/drawer": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/drawer/-/drawer-1.4.2.tgz",
+      "integrity": "sha512-1ib+fZEp6FBu+YvcIktm+nCQ+Q+qIpwpoaJH6opGr4ofh2QMq+qdr5DLC4oCf5qf3pcWX9lUWPYX652k4ini8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/portal": "^2.1.3",
+        "@rc-component/util": "^1.9.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/dropdown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/dropdown/-/dropdown-1.0.2.tgz",
+      "integrity": "sha512-6PY2ecUSYhDPhkNHHb4wfeAya04WhpmUSKzdR60G+kMNVUCX2vjT/AgTS0Lz0I/K6xrPMJ3enQbwVpeN3sHCgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.11.0",
+        "react-dom": ">=16.11.0"
+      }
+    },
+    "node_modules/@rc-component/form": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/form/-/form-1.8.1.tgz",
+      "integrity": "sha512-8O7TB55Fi2mWIGvSnwZjk8jFqVNYyKDAswglwGShcbndxqzKz4cHwNtNaLjZlAeRge9wcB0LL8IWsC/Bl18raQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/async-validator": "^5.1.0",
+        "@rc-component/util": "^1.6.2",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/image": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/image/-/image-1.9.0.tgz",
+      "integrity": "sha512-khF7w7xkBH5B1bsBcI1FSUZdkyd1aqpl2eYyILCqCzzQH3XdfehGUaZTnptyaJJfs09/R5hv9jXWyazOMFIClQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.0.0",
+        "@rc-component/portal": "^2.1.2",
+        "@rc-component/util": "^1.10.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/input": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/input/-/input-1.1.2.tgz",
+      "integrity": "sha512-Q61IMR47piUBudgixJ30CciKIy9b1H95qe7GgEKOmSJVJXvFRWJllJfQry9tif+MX2cWFXWJf/RXz4kaCeq/Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@rc-component/input-number": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/input-number/-/input-number-1.6.2.tgz",
+      "integrity": "sha512-Gjcq7meZlCOiWN1t1xCC+7/s85humHVokTBI7PJgTfoyw5OWF74y3e6P8PHX104g9+b54jsodFIzyaj6p8LI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/mini-decimal": "^1.0.1",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/mentions": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/mentions/-/mentions-1.6.0.tgz",
+      "integrity": "sha512-KIkQNP6habNuTsLhUv0UGEOwG67tlmE7KNIJoQZZNggEZl5lQJTytFDb69sl5CK3TDdISCTjKP3nGEBKgT61CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/input": "~1.1.0",
+        "@rc-component/menu": "~1.2.0",
+        "@rc-component/textarea": "~1.1.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/menu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/menu/-/menu-1.2.0.tgz",
+      "integrity": "sha512-VWwDuhvYHSnTGj4n6bV3ISrLACcPAzdPOq3d0BzkeiM5cve8BEYfvkEhNoM0PLzv51jpcejeyrLXeMVIJ+QJlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/overflow": "^1.0.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/mini-decimal": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.1.3.tgz",
+      "integrity": "sha512-bk/FJ09fLf+NLODMAFll6CfYrHPBioTedhW6lxDBuuWucJEqFUd4l/D/5JgIi3dina6sYahB8iuPAZTNz2pMxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      }
+    },
+    "node_modules/@rc-component/motion": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.3.2.tgz",
+      "integrity": "sha512-itfd+GztzJYAb04Z4RkEub1TbJAfZc2Iuy8p44U44xD1F5+fNYFKI3897ijlbIyfvXkTmMm+KGcjkQQGMHywEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/mutate-observer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-2.0.1.tgz",
+      "integrity": "sha512-AyarjoLU5YlxuValRi+w8JRH2Z84TBbFO2RoGWz9d8bSu0FqT8DtugH3xC3BV7mUwlmROFauyWuXFuq4IFbH+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/notification": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/notification/-/notification-1.2.0.tgz",
+      "integrity": "sha512-OX3J+zVU7rvoJCikjrfW7qOUp7zlDeFBK2eA3SFbGSkDqo63Sl4Ss8A04kFP+fxHSxMDIS9jYVEZtU1FNCFuBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/overflow": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/overflow/-/overflow-1.0.1.tgz",
+      "integrity": "sha512-syfmgAABaHCnCDzPwHZ/2tuvIcpOO3jefYZMmfkN+pmo8HKTzsfhS57vxo4ksPdN0By+uWVJhJWNFozNBxi2eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "@rc-component/resize-observer": "^1.0.1",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/pagination": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/pagination/-/pagination-1.2.0.tgz",
+      "integrity": "sha512-YcpUFE8dMLfSo6OARJlK6DbHHvrxz7pMGPGmC/caZSJJz6HRKHC1RPP001PRHCvG9Z/veD039uOQmazVuLJzlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/picker": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/picker/-/picker-1.9.1.tgz",
+      "integrity": "sha512-9FBYYsvH3HMLICaPDA/1Th5FLaDkFa7qAtangIdlhKb3ZALaR745e9PsOhheJb6asS4QXc12ffiAcjdkZ4C5/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/overflow": "^1.0.0",
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/trigger": "^3.6.15",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12.x"
+      },
+      "peerDependencies": {
+        "date-fns": ">= 2.x",
+        "dayjs": ">= 1.x",
+        "luxon": ">= 3.x",
+        "moment": ">= 2.x",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      },
+      "peerDependenciesMeta": {
+        "date-fns": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rc-component/portal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-2.2.0.tgz",
+      "integrity": "sha512-oc6FlA+uXCMiwArHsJyHcIkX4q6uKyndrPol2eWX8YPkAnztHOPsFIRtmWG4BMlGE5h7YIRE3NiaJ5VS8Lb1QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/progress": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/progress/-/progress-1.0.2.tgz",
+      "integrity": "sha512-WZUnH9eGxH1+xodZKqdrHke59uyGZSWgj5HBM5Kwk5BrTMuAORO7VJ2IP5Qbm9aH3n9x3IcesqHHR0NWPBC7fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/qrcode": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-1.1.1.tgz",
+      "integrity": "sha512-LfLGNymzKdUPjXUbRP+xOhIWY4jQ+YMj5MmWAcgcAq1Ij8XP7tRmAXqyuv96XvLUBE/5cA8hLFl9eO1JQMujrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/rate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/rate/-/rate-1.0.1.tgz",
+      "integrity": "sha512-bkXxeBqDpl5IOC7yL7GcSYjQx9G8H+6kLYQnNZWeBYq2OYIv1MONd6mqKTjnnJYpV0cQIU2z3atdW0j1kttpTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/resize-observer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/resize-observer/-/resize-observer-1.1.2.tgz",
+      "integrity": "sha512-t/Bb0W8uvL4PYKAB3YcChC+DlHh0Wt5kM7q/J+0qpVEUMLe7Hk5zuvc9km0hMnTFPSx5Z7Wu/fzCLN6erVLE8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/segmented": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/segmented/-/segmented-1.3.0.tgz",
+      "integrity": "sha512-5J/bJ01mbDnoA6P/FW8SxUvKn+OgUSTZJPzCNnTBntG50tzoP7DydGhqxp7ggZXZls7me3mc2EQDXakU3iTVFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@rc-component/select": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.6.15.tgz",
+      "integrity": "sha512-SyVCWnqxCQZZcQvQJ/CxSjx2bGma6ds/HtnpkIfZVnt6RoEgbqUmHgD6vrzNarNXwbLXerwVzWwq8F3d1sst7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/overflow": "^1.0.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.3.0",
+        "@rc-component/virtual-list": "^1.0.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@rc-component/slider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/slider/-/slider-1.0.1.tgz",
+      "integrity": "sha512-uDhEPU1z3WDfCJhaL9jfd2ha/Eqpdfxsn0Zb0Xcq1NGQAman0TWaR37OWp2vVXEOdV2y0njSILTMpTfPV1454g==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/steps": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/steps/-/steps-1.2.2.tgz",
+      "integrity": "sha512-/yVIZ00gDYYPHSY0JP+M+s3ZvuXLu2f9rEjQqiUDs7EcYsUYrpJ/1bLj9aI9R7MBR3fu/NGh6RM9u2qGfqp+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/switch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/switch/-/switch-1.0.3.tgz",
+      "integrity": "sha512-Jgi+EbOBquje/XNdofr7xbJQZPYJP+BlPfR0h+WN4zFkdtB2EWqEfvkXJWeipflwjWip0/17rNbxEAqs8hVHfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/table": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/table/-/table-1.9.1.tgz",
+      "integrity": "sha512-FVI5ZS/GdB3BcgexfCYKi3iHhZS3Fr59EtsxORszYGrfpH1eWr33eDNSYkVfLI6tfJ7vftJDd9D5apfFWqkdJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/context": "^2.0.1",
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/util": "^1.1.0",
+        "@rc-component/virtual-list": "^1.0.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/tabs": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tabs/-/tabs-1.7.0.tgz",
+      "integrity": "sha512-J48cs2iBi7Ho3nptBxxIqizEliUC+ExE23faspUQKGQ550vaBlv3aGF8Epv/UB1vFWeoJDTW/dNzgIU0Qj5i/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/dropdown": "~1.0.0",
+        "@rc-component/menu": "~1.2.0",
+        "@rc-component/motion": "^1.1.3",
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/textarea": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/textarea/-/textarea-1.1.2.tgz",
+      "integrity": "sha512-9rMUEODWZDMovfScIEHXWlVZuPljZ2pd1LKNjslJVitn4SldEzq5vO1CL3yy3Dnib6zZal2r2DPtjy84VVpF6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/input": "~1.1.0",
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/tooltip": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tooltip/-/tooltip-1.4.0.tgz",
+      "integrity": "sha512-8Rx5DCctIlLI4raR0I0xHjVTf1aF48+gKCNeAAo5bmF5VoR5YED+A/XEqzXv9KKqrJDRcd3Wndpxh2hyzrTtSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/trigger": "^3.7.1",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/tour": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-2.3.0.tgz",
+      "integrity": "sha512-K04K9r32kUC+auBSQfr+Fss4SpSIS9JGe56oq/ALAX0p+i2ylYOI1MgR83yBY7v96eO6ZFXcM/igCQmubps0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/portal": "^2.2.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.7.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/tree": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rc-component/tree/-/tree-1.2.4.tgz",
+      "integrity": "sha512-5Gli43+m4R7NhpYYz3Z61I6LOw9yI6CNChxgVtvrO6xB1qML7iE6QMLVMB3+FTjo2yF6uFdAHtqWPECz/zbX5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.0.0",
+        "@rc-component/util": "^1.8.1",
+        "@rc-component/virtual-list": "^1.0.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=10.x"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@rc-component/tree-select": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tree-select/-/tree-select-1.8.0.tgz",
+      "integrity": "sha512-iYsPq3nuLYvGqdvFAW+l+I9ASRIOVbMXyA8FGZg2lGym/GwkaWeJGzI4eJ7c9IOEhRj0oyfIN4S92Fl3J05mjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/select": "~1.6.0",
+        "@rc-component/tree": "~1.2.0",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@rc-component/trigger": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-3.9.0.tgz",
+      "integrity": "sha512-X8btpwfrT27AgrZVOz4swclhEHTZcqaHeQMXXBgveagOiakTa36uObXbdwerXffgV8G9dH1fAAE0DHtVQs8EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/portal": "^2.2.0",
+        "@rc-component/resize-observer": "^1.1.1",
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/upload": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/upload/-/upload-1.1.0.tgz",
+      "integrity": "sha512-LIBV90mAnUE6VK5N4QvForoxZc4XqEYZimcp7fk+lkE4XwHHyJWxpIXQQwMU8hJM+YwBbsoZkGksL1sISWHQxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/util": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.10.1.tgz",
+      "integrity": "sha512-q++9S6rUa5Idb/xIBNz6jtvumw5+O5YV5V0g4iK9mn9jWs4oGJheE3ZN1kAnE723AXyaD8v95yeOASmdk8Jnng==",
+      "license": "MIT",
+      "dependencies": {
+        "is-mobile": "^5.0.0",
+        "react-is": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/@rc-component/virtual-list": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/virtual-list/-/virtual-list-1.0.2.tgz",
+      "integrity": "sha512-uvTol/mH74FYsn5loDGJxo+7kjkO4i+y4j87Re1pxJBs0FaeuMuLRzQRGaXwnMcV1CxpZLi2Z56Rerj2M00fjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.0",
+        "@rc-component/resize-observer": "^1.0.1",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1660,6 +2496,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/redux-actions": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@types/redux-actions/-/redux-actions-2.6.5.tgz",
+      "integrity": "sha512-RgXOigay5cNweP+xH1ru+Vaaj1xXYLpWIfSVO8cSA8Ii2xvR+HRfWYdLe1UVOA8X0kIklalGOa0DTDyld0obkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.0",
@@ -2305,6 +3148,70 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/antd": {
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-6.3.6.tgz",
+      "integrity": "sha512-zdCYjusrTUn4gNxEg4PH8MWlfuXYbKfuGOkjgZ0Rg6DpWbIVmG/MwvsZ5yvG6z3Y6UI/gzYpaQ82iTt4KdbeaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/colors": "^8.0.1",
+        "@ant-design/cssinjs": "^2.1.2",
+        "@ant-design/cssinjs-utils": "^2.1.2",
+        "@ant-design/fast-color": "^3.0.1",
+        "@ant-design/icons": "^6.1.1",
+        "@ant-design/react-slick": "~2.0.0",
+        "@babel/runtime": "^7.28.4",
+        "@rc-component/cascader": "~1.14.0",
+        "@rc-component/checkbox": "~2.0.0",
+        "@rc-component/collapse": "~1.2.0",
+        "@rc-component/color-picker": "~3.1.1",
+        "@rc-component/dialog": "~1.8.4",
+        "@rc-component/drawer": "~1.4.2",
+        "@rc-component/dropdown": "~1.0.2",
+        "@rc-component/form": "~1.8.0",
+        "@rc-component/image": "~1.9.0",
+        "@rc-component/input": "~1.1.2",
+        "@rc-component/input-number": "~1.6.2",
+        "@rc-component/mentions": "~1.6.0",
+        "@rc-component/menu": "~1.2.0",
+        "@rc-component/motion": "^1.3.2",
+        "@rc-component/mutate-observer": "^2.0.1",
+        "@rc-component/notification": "~1.2.0",
+        "@rc-component/pagination": "~1.2.0",
+        "@rc-component/picker": "~1.9.1",
+        "@rc-component/progress": "~1.0.2",
+        "@rc-component/qrcode": "~1.1.1",
+        "@rc-component/rate": "~1.0.1",
+        "@rc-component/resize-observer": "^1.1.2",
+        "@rc-component/segmented": "~1.3.0",
+        "@rc-component/select": "~1.6.15",
+        "@rc-component/slider": "~1.0.1",
+        "@rc-component/steps": "~1.2.2",
+        "@rc-component/switch": "~1.0.3",
+        "@rc-component/table": "~1.9.1",
+        "@rc-component/tabs": "~1.7.0",
+        "@rc-component/textarea": "~1.1.2",
+        "@rc-component/tooltip": "~1.4.0",
+        "@rc-component/tour": "~2.3.0",
+        "@rc-component/tree": "~1.2.4",
+        "@rc-component/tree-select": "~1.8.0",
+        "@rc-component/trigger": "^3.9.0",
+        "@rc-component/upload": "~1.1.0",
+        "@rc-component/util": "^1.10.1",
+        "clsx": "^2.1.1",
+        "dayjs": "^1.11.11",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "throttle-debounce": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ant-design"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2715,6 +3622,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2733,6 +3649,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -2768,7 +3690,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2831,6 +3752,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4293,6 +5220,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-mobile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
+      "integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==",
+      "license": "MIT"
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -4574,6 +5507,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -4602,6 +5544,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/just-curry-it": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/just-curry-it/-/just-curry-it-5.3.0.tgz",
+      "integrity": "sha512-silMIRiFjUWlfaDhkgSzpuAyQ6EX/o09Eu8ZBfmFwQMbax7+LQzeIU2CBrICT6Ne4l86ITCGvUCBpCubWYy0Yw==",
+      "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -5558,6 +6506,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/reduce-reducers": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-1.0.4.tgz",
+      "integrity": "sha512-Mb2WZ2bJF597exiqX7owBzrqJ74DHLK3yOQjCyPAaNifRncE8OD0wFIuoMhXxTnHK07+8zZ2SJEKy/qtiyR7vw==",
+      "license": "MIT"
+    },
+    "node_modules/redux-actions": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/redux-actions/-/redux-actions-3.0.3.tgz",
+      "integrity": "sha512-ca+ySXmXWrxDqtauRA6lQtjmRO8Z9Ruog3wbb8wDq4RVW9Y677Nl/AXoJPlxJqH0mpY9QGkg03NkAJwTcyN2pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "just-curry-it": "5.3.0",
+        "reduce-reducers": "1.0.4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -5741,6 +6705,15 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-scroll-into-view": "^3.0.2"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -5988,6 +6961,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
+      "license": "MIT"
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -6147,6 +7126,12 @@
         }
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6192,6 +7177,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttle-debounce": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
+      "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22"
       }
     },
     "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -9,15 +9,18 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "antd": "^6.3.6",
     "next": "16.2.4",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "redux-actions": "^3.0.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/redux-actions": "^2.6.5",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "tailwindcss": "^4",

--- a/providers/authProvider/actions.tsx
+++ b/providers/authProvider/actions.tsx
@@ -1,0 +1,158 @@
+import { createAction } from "redux-actions";
+
+import type {
+  IAuthStateContext,
+  IUserLoginResponse,
+} from "./context";
+
+export enum AuthActionEnums {
+  getMeError = "GET_ME_ERROR",
+  getMePending = "GET_ME_PENDING",
+  getMeSuccess = "GET_ME_SUCCESS",
+  loginError = "LOGIN_ERROR",
+  loginPending = "LOGIN_PENDING",
+  loginSuccess = "LOGIN_SUCCESS",
+  logoutError = "LOGOUT_ERROR",
+  logoutPending = "LOGOUT_PENDING",
+  logoutSuccess = "LOGOUT_SUCCESS",
+  registerError = "REGISTER_ERROR",
+  registerPending = "REGISTER_PENDING",
+  registerSuccess = "REGISTER_SUCCESS",
+}
+
+export const loginPending = createAction<Partial<IAuthStateContext>>(
+  AuthActionEnums.loginPending,
+  () => ({
+    isError: false,
+    isPending: true,
+    isSuccess: false,
+    isAuthenticated: false,
+  }),
+);
+
+export const loginSuccess = createAction<
+  Partial<IAuthStateContext>,
+  IUserLoginResponse
+>(
+  AuthActionEnums.loginSuccess,
+  (user: IUserLoginResponse) => ({
+    isAuthenticated: true,
+    isError: false,
+    isPending: false,
+    isSuccess: true,
+    user,
+  }),
+);
+
+export const loginError = createAction<Partial<IAuthStateContext>>(
+  AuthActionEnums.loginError,
+  () => ({
+    isAuthenticated: false,
+    isError: true,
+    isPending: false,
+    isSuccess: false,
+    user: null,
+  }),
+);
+
+export const registerPending = createAction<Partial<IAuthStateContext>>(
+  AuthActionEnums.registerPending,
+  () => ({
+    isError: false,
+    isPending: true,
+    isSuccess: false,
+    isAuthenticated: false,
+  }),
+);
+
+export const registerSuccess = createAction<
+  Partial<IAuthStateContext>,
+  IUserLoginResponse
+>(
+  AuthActionEnums.registerSuccess,
+  (user: IUserLoginResponse) => ({
+    isAuthenticated: true,
+    isError: false,
+    isPending: false,
+    isSuccess: true,
+    user,
+  }),
+);
+
+export const registerError = createAction<Partial<IAuthStateContext>>(
+  AuthActionEnums.registerError,
+  () => ({
+    isAuthenticated: false,
+    isError: true,
+    isPending: false,
+    isSuccess: false,
+    user: null,
+  }),
+);
+
+export const logoutPending = createAction<Partial<IAuthStateContext>>(
+  AuthActionEnums.logoutPending,
+  () => ({
+    isAuthenticated: false,
+    isError: false,
+    isPending: true,
+    isSuccess: false,
+  }),
+);
+
+export const logoutSuccess = createAction<Partial<IAuthStateContext>>(
+  AuthActionEnums.logoutSuccess,
+  () => ({
+    isAuthenticated: false,
+    isError: false,
+    isPending: false,
+    isSuccess: false,
+    user: null,
+  }),
+);
+
+export const logoutError = createAction<Partial<IAuthStateContext>>(
+  AuthActionEnums.logoutError,
+  () => ({
+    isAuthenticated: false,
+    isError: true,
+    isPending: false,
+    isSuccess: false,
+    user: null,
+  }),
+);
+
+export const getMePending = createAction<Partial<IAuthStateContext>>(
+  AuthActionEnums.getMePending,
+  () => ({
+    isAuthenticated: false,
+    isError: false,
+    isPending: true,
+    isSuccess: false,
+  }),
+);
+
+export const getMeSuccess = createAction<
+  Partial<IAuthStateContext>,
+  IUserLoginResponse
+>(
+  AuthActionEnums.getMeSuccess,
+  (user: IUserLoginResponse) => ({
+    isAuthenticated: true,
+    isError: false,
+    isPending: false,
+    isSuccess: true,
+    user,
+  }),
+);
+
+export const getMeError = createAction<Partial<IAuthStateContext>>(
+  AuthActionEnums.getMeError,
+  () => ({
+    isAuthenticated: false,
+    isError: true,
+    isPending: false,
+    isSuccess: false,
+    user: null,
+  }),
+);

--- a/providers/authProvider/context.tsx
+++ b/providers/authProvider/context.tsx
@@ -1,0 +1,56 @@
+import { createContext } from "react";
+
+export interface IUserLoginRequest {
+  email?: string | null;
+  password?: string | null;
+}
+
+export interface IUserRegisterRequest {
+  email?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  password?: string | null;
+  phoneNumber?: string | null;
+  role?: string | null;
+  tenantId?: string | null;
+  tenantName?: string | null;
+}
+
+export interface IUserLoginResponse {
+  email?: string | null;
+  expiresAt?: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  roles?: string[] | null;
+  tenantId?: string | null;
+  tenantName?: string | null;
+  token?: string | null;
+  userId?: string;
+}
+
+export interface IAuthStateContext {
+  isAuthenticated: boolean;
+  isError: boolean;
+  isPending: boolean;
+  isSuccess: boolean;
+  user?: IUserLoginResponse | null;
+}
+
+export interface IAuthActionContext {
+  getMe: () => Promise<void>;
+  login: (payload: IUserLoginRequest) => Promise<void>;
+  logout: () => Promise<void>;
+  register: (payload: IUserRegisterRequest) => Promise<void>;
+}
+
+export const INITIAL_STATE: IAuthStateContext = {
+  isAuthenticated: false,
+  isError: false,
+  isPending: false,
+  isSuccess: false,
+  user: null,
+};
+
+export const AuthStateContext = createContext<IAuthStateContext>(INITIAL_STATE);
+
+export const AuthActionContext = createContext<IAuthActionContext>(undefined!);

--- a/providers/authProvider/index.tsx
+++ b/providers/authProvider/index.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useCallback, useContext, useEffect, useReducer } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  clearAuthSession,
+  getSessionToken,
+  getStoredAuthUser,
+  storeAuthSession,
+} from "@/lib/client/auth-session";
+import {
+  getMePending,
+  getMeSuccess,
+  loginError,
+  loginPending,
+  loginSuccess,
+  logoutError,
+  logoutPending,
+  logoutSuccess,
+  registerError,
+  registerPending,
+  registerSuccess,
+} from "./actions";
+import {
+  AuthActionContext,
+  AuthStateContext,
+  INITIAL_STATE,
+  type IUserLoginRequest,
+  type IUserLoginResponse,
+  type IUserRegisterRequest,
+} from "./context";
+import { AuthReducer } from "./reducers";
+export const useAuthState = () => {
+  const context = useContext(AuthStateContext);
+
+  if (context === undefined) {
+    throw new Error("useAuthState must be used within AuthProvider.");
+  }
+
+  return context;
+};
+
+export const useAuthActions = () => {
+  const context = useContext(AuthActionContext);
+
+  if (context === undefined) {
+    throw new Error("useAuthActions must be used within AuthProvider.");
+  }
+
+  return context;
+};
+
+type AuthProviderProps = Readonly<{
+  children: React.ReactNode;
+}>;
+
+const readJsonPayload = async <T,>(response: Response) => {
+  const text = await response.text();
+
+  if (!text.trim()) {
+    return {} as T;
+  }
+
+  return JSON.parse(text) as T;
+};
+
+const authRequest = async <T,>(
+  path: "/api/Auth/login" | "/api/Auth/me" | "/api/Auth/register",
+  init: RequestInit = {},
+) => {
+  const headers = new Headers(init.headers);
+
+  if (init.body && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const response = await fetch(path, {
+    ...init,
+    credentials: "same-origin",
+    headers,
+  });
+  const payload = (await readJsonPayload<T & { message?: string }>(response));
+
+  if (!response.ok) {
+    throw new Error(payload.message ?? "Authentication failed.");
+  }
+
+  return payload;
+};
+
+const mergeAuthUser = (
+  payload: Partial<IUserLoginResponse>,
+  fallback?: IUserLoginResponse | null,
+): IUserLoginResponse => ({
+  ...fallback,
+  ...payload,
+  roles: payload.roles ?? fallback?.roles ?? null,
+  token: payload.token ?? fallback?.token ?? getSessionToken(),
+});
+
+export default function AuthProvider({ children }: AuthProviderProps) {
+  const [state, dispatch] = useReducer(AuthReducer, INITIAL_STATE);
+  const router = useRouter();
+
+  const authenticate = async (
+    path: "/api/Auth/login" | "/api/Auth/register",
+    payload: IUserLoginRequest | IUserRegisterRequest,
+  ) => {
+    return authRequest<IUserLoginResponse>(path, {
+      body: JSON.stringify(payload),
+      method: "POST",
+    });
+  };
+
+  const login = async (payload: IUserLoginRequest) => {
+    dispatch(loginPending());
+
+    await authenticate("/api/Auth/login", payload)
+      .then((response) => {
+        storeAuthSession(response);
+        dispatch(loginSuccess(response));
+        router.push("/dashboard");
+      })
+      .catch((error: unknown) => {
+        dispatch(loginError());
+        console.error(error);
+      });
+  };
+
+  const register = async (payload: IUserRegisterRequest) => {
+    dispatch(registerPending());
+
+    await authenticate("/api/Auth/register", payload)
+      .then((response) => {
+        storeAuthSession(response);
+        dispatch(registerSuccess(response));
+        router.push("/dashboard");
+      })
+      .catch((error: unknown) => {
+        dispatch(registerError());
+        console.error(error);
+      });
+  };
+
+  const logout = async () => {
+    dispatch(logoutPending());
+
+    try {
+      await fetch("/api/Auth/logout", {
+        method: "POST",
+      }).catch(() => undefined);
+      clearAuthSession();
+      dispatch(logoutSuccess());
+      router.push("/login");
+    } catch (error) {
+      console.error(error);
+      dispatch(logoutError());
+    }
+  };
+
+  const getMe = useCallback(async () => {
+    dispatch(getMePending());
+    const storedUser = getStoredAuthUser();
+    const token = storedUser?.token ?? getSessionToken();
+
+    if (!token) {
+      clearAuthSession();
+      dispatch(logoutSuccess());
+      return;
+    }
+
+    try {
+      const response = await authRequest<Partial<IUserLoginResponse>>("/api/Auth/me");
+      const nextUser = mergeAuthUser(response, storedUser);
+
+      storeAuthSession(nextUser);
+      dispatch(getMeSuccess(nextUser));
+      return;
+    } catch (error) {
+      console.error(error);
+    }
+
+    clearAuthSession();
+    dispatch(logoutSuccess());
+  }, []);
+
+  useEffect(() => {
+    void getMe();
+  }, [getMe]);
+
+  return (
+    <AuthStateContext.Provider value={state}>
+      <AuthActionContext.Provider
+        value={{
+          getMe,
+          login,
+          logout,
+          register,
+        }}
+      >
+        {children}
+      </AuthActionContext.Provider>
+    </AuthStateContext.Provider>
+  );
+}

--- a/providers/authProvider/reducers.tsx
+++ b/providers/authProvider/reducers.tsx
@@ -1,0 +1,61 @@
+import { handleActions } from "redux-actions";
+
+import { AuthActionEnums } from "./actions";
+import { INITIAL_STATE, type IAuthStateContext } from "./context";
+
+export const AuthReducer = handleActions<
+  IAuthStateContext,
+  Partial<IAuthStateContext>
+>(
+  {
+    [AuthActionEnums.loginPending]: (state, action) => ({
+      ...state,
+      ...action.payload,
+    }),
+    [AuthActionEnums.loginSuccess]: (state, action) => ({
+      ...state,
+      ...action.payload,
+    }),
+    [AuthActionEnums.loginError]: (state, action) => ({
+      ...state,
+      ...action.payload,
+    }),
+    [AuthActionEnums.registerPending]: (state, action) => ({
+      ...state,
+      ...action.payload,
+    }),
+    [AuthActionEnums.registerSuccess]: (state, action) => ({
+      ...state,
+      ...action.payload,
+    }),
+    [AuthActionEnums.registerError]: (state, action) => ({
+      ...state,
+      ...action.payload,
+    }),
+    [AuthActionEnums.logoutPending]: (state, action) => ({
+      ...state,
+      ...action.payload,
+    }),
+    [AuthActionEnums.logoutSuccess]: (state, action) => ({
+      ...state,
+      ...action.payload,
+    }),
+    [AuthActionEnums.logoutError]: (state, action) => ({
+      ...state,
+      ...action.payload,
+    }),
+    [AuthActionEnums.getMePending]: (state, action) => ({
+      ...state,
+      ...action.payload,
+    }),
+    [AuthActionEnums.getMeSuccess]: (state, action) => ({
+      ...state,
+      ...action.payload,
+    }),
+    [AuthActionEnums.getMeError]: (state, action) => ({
+      ...state,
+      ...action.payload,
+    }),
+  },
+  INITIAL_STATE,
+);


### PR DESCRIPTION
## Summary
Adds the initial authentication flow for the frontend.

## Included
- `/login` page
- `/register` page
- auth forms
- auth provider state/actions/reducer
- auth API routes
- auth session helpers
- backend URL helper

## Validation
- `npm ci`
- `npm run lint`
- `npm run build`

## Notes
This is the first application slice and establishes the auth foundation required by later branches.
