### PR TITLE
feat(dashboard): add workspace shell and route views

### DIFF
--- a/app/dashboard/(routes)/activities/page.tsx
+++ b/app/dashboard/(routes)/activities/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { ActivitiesPanel } from "@/components/dashboard/activities-panel";
+import { PageIntro } from "@/components/dashboard/page-intro";
+import { ActivityProviderPage } from "@/providers/pageProviders";
+
+function ActivitiesPageContent() {
+  return (
+    <div className="space-y-6">
+      <PageIntro />
+      <ActivitiesPanel />
+    </div>
+  );
+}
+
+export default function ActivitiesPage() {
+  return (
+    <ActivityProviderPage>
+      <ActivitiesPageContent />
+    </ActivityProviderPage>
+  );
+}

--- a/app/dashboard/(routes)/assistant/page.tsx
+++ b/app/dashboard/(routes)/assistant/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { AssistantPanel } from "@/components/dashboard/assistant-panel";
+import { PageIntro } from "@/components/dashboard/page-intro";
+import { AssistantProvider } from "@/providers/pageProviders";
+
+function AssistantPageContent() {
+  return (
+    <div className="space-y-6">
+      <PageIntro />
+      <AssistantPanel />
+    </div>
+  );
+}
+
+export default function AssistantPage() {
+  return (
+    <AssistantProvider>
+      <AssistantPageContent />
+    </AssistantProvider>
+  );
+}

--- a/app/dashboard/(routes)/clients/page.tsx
+++ b/app/dashboard/(routes)/clients/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { ClientsPanel } from "@/components/dashboard/clients-panel";
+import { PageIntro } from "@/components/dashboard/page-intro";
+import { ClientProvider } from "@/providers/pageProviders";
+
+function ClientsPageContent() {
+  return (
+    <div className="space-y-6">
+      <PageIntro />
+      <ClientsPanel />
+    </div>
+  );
+}
+
+export default function ClientsPage() {
+  return (
+    <ClientProvider>
+      <ClientsPageContent />
+    </ClientProvider>
+  );
+}

--- a/app/dashboard/(routes)/contacts/page.tsx
+++ b/app/dashboard/(routes)/contacts/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { ContactsPanel } from "@/components/dashboard/contacts-panel";
+import { PageIntro } from "@/components/dashboard/page-intro";
+import { ContactProvider } from "@/providers/pageProviders";
+
+function ContactsPageContent() {
+  return (
+    <div className="space-y-6">
+      <PageIntro />
+      <ContactsPanel />
+    </div>
+  );
+}
+
+export default function ContactsPage() {
+  return (
+    <ContactProvider>
+      <ContactsPageContent />
+    </ContactProvider>
+  );
+}

--- a/app/dashboard/(routes)/contracts/page.tsx
+++ b/app/dashboard/(routes)/contracts/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { PageIntro } from "@/components/dashboard/page-intro";
+import { RenewalsPanel } from "@/components/dashboard/renewals-panel";
+import { ContractProvider } from "@/providers/pageProviders";
+
+function ContractsPageContent() {
+  return (
+    <div className="space-y-6">
+      <PageIntro />
+      <RenewalsPanel />
+    </div>
+  );
+}
+
+export default function ContractsPage() {
+  return (
+    <ContractProvider>
+      <ContractsPageContent />
+    </ContractProvider>
+  );
+}

--- a/app/dashboard/(routes)/documents/page.tsx
+++ b/app/dashboard/(routes)/documents/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { DocumentsPanel } from "@/components/dashboard/documents-panel";
+import { PageIntro } from "@/components/dashboard/page-intro";
+import { DocumentProvider } from "@/providers/pageProviders";
+
+function DocumentsPageContent() {
+  return (
+    <div className="space-y-6">
+      <PageIntro />
+      <DocumentsPanel />
+    </div>
+  );
+}
+
+export default function DocumentsPage() {
+  return (
+    <DocumentProvider>
+      <DocumentsPageContent />
+    </DocumentProvider>
+  );
+}

--- a/app/dashboard/(routes)/notes/page.tsx
+++ b/app/dashboard/(routes)/notes/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { NotesPanel } from "@/components/dashboard/notes-panel";
+import { PageIntro } from "@/components/dashboard/page-intro";
+import { NoteProvider } from "@/providers/pageProviders";
+
+function NotesPageContent() {
+  return (
+    <div className="space-y-6">
+      <PageIntro />
+      <NotesPanel />
+    </div>
+  );
+}
+
+export default function NotesPage() {
+  return (
+    <NoteProvider>
+      <NotesPageContent />
+    </NoteProvider>
+  );
+}

--- a/app/dashboard/(routes)/opportunities/page.tsx
+++ b/app/dashboard/(routes)/opportunities/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { OpportunitiesPanel } from "@/components/dashboard/opportunities-panel";
+import { PageIntro } from "@/components/dashboard/page-intro";
+import { OpportunityProvider } from "@/providers/pageProviders";
+
+function OpportunitiesPageContent() {
+  return (
+    <div className="space-y-6">
+      <PageIntro />
+      <OpportunitiesPanel />
+    </div>
+  );
+}
+
+export default function OpportunitiesPage() {
+  return (
+    <OpportunityProvider>
+      <OpportunitiesPageContent />
+    </OpportunityProvider>
+  );
+}

--- a/app/dashboard/(routes)/pricing-requests/page.tsx
+++ b/app/dashboard/(routes)/pricing-requests/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { PageIntro } from "@/components/dashboard/page-intro";
+import { PricingRequestsPanel } from "@/components/dashboard/pricing-requests-panel";
+import { PricingRequestProvider } from "@/providers/pageProviders";
+
+function PricingRequestsPageContent() {
+  return (
+    <div className="space-y-6">
+      <PageIntro />
+      <PricingRequestsPanel />
+    </div>
+  );
+}
+
+export default function PricingRequestsPage() {
+  return (
+    <PricingRequestProvider>
+      <PricingRequestsPageContent />
+    </PricingRequestProvider>
+  );
+}

--- a/app/dashboard/(routes)/profile/page.tsx
+++ b/app/dashboard/(routes)/profile/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { PageIntro } from "@/components/dashboard/page-intro";
+import { ProfilePanel } from "@/components/dashboard/profile-panel";
+import { ProfileProvider } from "@/providers/pageProviders";
+
+function ProfilePageContent() {
+  return (
+    <div className="space-y-6">
+      <PageIntro />
+      <ProfilePanel />
+    </div>
+  );
+}
+
+export default function ProfilePage() {
+  return (
+    <ProfileProvider>
+      <ProfilePageContent />
+    </ProfileProvider>
+  );
+}

--- a/app/dashboard/(routes)/proposals/page.tsx
+++ b/app/dashboard/(routes)/proposals/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { PageIntro } from "@/components/dashboard/page-intro";
+import { ProposalsPanel } from "@/components/dashboard/proposals-panel";
+import { ProposalProvider } from "@/providers/pageProviders";
+
+function ProposalsPageContent() {
+  return (
+    <div className="space-y-6">
+      <PageIntro />
+      <ProposalsPanel />
+    </div>
+  );
+}
+
+export default function ProposalsPage() {
+  return (
+    <ProposalProvider>
+      <ProposalsPageContent />
+    </ProposalProvider>
+  );
+}

--- a/app/dashboard/(routes)/reports/page.tsx
+++ b/app/dashboard/(routes)/reports/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { PageIntro } from "@/components/dashboard/page-intro";
+import { ReportsPanel } from "@/components/dashboard/reports-panel";
+import { ReportProvider } from "@/providers/pageProviders";
+
+function ReportsPageContent() {
+  return (
+    <div className="space-y-6">
+      <PageIntro />
+      <ReportsPanel />
+    </div>
+  );
+}
+
+export default function ReportsPage() {
+  return (
+    <ReportProvider>
+      <ReportsPageContent />
+    </ReportProvider>
+  );
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,0 +1,9 @@
+import { DashboardFrame } from "@/components/dashboard/dashboard-frame";
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <DashboardFrame>{children}</DashboardFrame>;
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,20 @@
+import { DashboardMetrics } from "@/components/dashboard/dashboard-metrics";
+import { PageIntro } from "@/components/dashboard/page-intro";
+import { DashboardProvider } from "@/providers/pageProviders";
+
+function DashboardPageContent() {
+  return (
+    <div className="space-y-6">
+      <PageIntro />
+      <DashboardMetrics />
+    </div>
+  );
+}
+
+export default function DashboardPage() {
+  return (
+    <DashboardProvider>
+      <DashboardPageContent />
+    </DashboardProvider>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,26 +1,442 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@theme inline {
+  --background: #eef3f8;
+  --foreground: #1f2937;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+html,
+body {
+  min-height: 100%;
 }
 
 body {
-  background: var(--background);
+  background:
+    radial-gradient(circle at top left, rgba(242, 140, 40, 0.12), transparent 22%),
+    linear-gradient(180deg, #eef3f8 0%, #f7f9fc 100%);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-geist-sans), sans-serif;
+}
+
+.dashboard-shell {
+  min-height: 100vh;
+  position: relative;
+}
+
+.dashboard-sidebar {
+  inset: 0 auto 0 0;
+  position: fixed;
+  transform: translateX(0);
+  transition:
+    transform 280ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 280ms ease;
+  width: 300px;
+  z-index: 50;
+}
+
+.dashboard-sidebar--collapsed {
+  box-shadow: none;
+  transform: translateX(calc(-100% - 20px));
+}
+
+.dashboard-sidebar-backdrop {
+  background: rgba(15, 23, 42, 0.22);
+  inset: 0;
+  opacity: 1;
+  pointer-events: auto;
+  position: fixed;
+  transition: opacity 220ms ease;
+  z-index: 40;
+}
+
+.dashboard-sidebar-backdrop--hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.dashboard-main {
+  min-height: 100vh;
+  padding-left: 300px;
+  transition: padding-left 280ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.dashboard-main--expanded {
+  padding-left: 0;
+}
+
+.dashboard-table-card {
+  min-width: 0;
+}
+
+.dashboard-table-card .ant-card-head {
+  align-items: flex-start;
+}
+
+.dashboard-table-card .ant-card-head-wrapper {
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.dashboard-table-card .ant-card-extra {
+  margin-inline-start: 0;
+  max-width: 100%;
+  white-space: normal;
+}
+
+.dashboard-responsive-table,
+.dashboard-responsive-table .ant-table-wrapper,
+.dashboard-responsive-table .ant-spin-nested-loading,
+.dashboard-responsive-table .ant-spin-container {
+  max-width: 100%;
+  min-width: 0;
+}
+
+.dashboard-responsive-table .ant-table-container {
+  max-width: 100%;
+}
+
+.dashboard-responsive-table .ant-table-cell {
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.dashboard-table-shell {
+  overflow: hidden;
+  position: relative;
+}
+
+.dashboard-table-shell--busy .dashboard-responsive-table {
+  opacity: 0.72;
+  transition: opacity 180ms ease;
+}
+
+.dashboard-table-progress {
+  background: linear-gradient(90deg, rgba(242, 140, 40, 0), rgba(242, 140, 40, 0.9), rgba(53, 92, 125, 0));
+  border-radius: 9999px;
+  height: 3px;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transform: scaleX(0.35);
+  transform-origin: left;
+  transition: opacity 180ms ease;
+}
+
+.dashboard-table-shell--busy .dashboard-table-progress {
+  animation: dashboard-progress-scan 1.1s ease-in-out infinite;
+  opacity: 1;
+}
+
+.assistant-rich-text {
+  line-height: 1.7;
+}
+
+.assistant-rich-text > :first-child {
+  margin-top: 0;
+}
+
+.assistant-rich-text > :last-child {
+  margin-bottom: 0;
+}
+
+.assistant-rich-text h1,
+.assistant-rich-text h2,
+.assistant-rich-text h3,
+.assistant-rich-text h4,
+.assistant-rich-text h5,
+.assistant-rich-text h6 {
+  font-weight: 700;
+  line-height: 1.35;
+  margin: 1rem 0 0.5rem;
+}
+
+.assistant-rich-text h1 {
+  font-size: 1.5rem;
+}
+
+.assistant-rich-text h2 {
+  font-size: 1.3rem;
+}
+
+.assistant-rich-text h3 {
+  font-size: 1.1rem;
+}
+
+.assistant-rich-text p,
+.assistant-rich-text ul,
+.assistant-rich-text ol,
+.assistant-rich-text pre,
+.assistant-rich-text hr,
+.assistant-rich-text .assistant-table-wrap,
+.assistant-rich-text .assistant-math-block {
+  margin: 0.8rem 0;
+}
+
+.assistant-rich-text ul,
+.assistant-rich-text ol {
+  padding-left: 1.4rem;
+}
+
+.assistant-rich-text li + li {
+  margin-top: 0.35rem;
+}
+
+.assistant-rich-text hr {
+  border: 0;
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.assistant-rich-text code {
+  background: rgba(148, 163, 184, 0.18);
+  border-radius: 0.45rem;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.92em;
+  padding: 0.15rem 0.35rem;
+}
+
+.assistant-rich-text pre {
+  background: rgba(15, 23, 42, 0.92);
+  border-radius: 1rem;
+  color: #e2e8f0;
+  overflow-x: auto;
+  padding: 1rem;
+}
+
+.assistant-rich-text pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+}
+
+.assistant-rich-text .assistant-rich-link {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
+.assistant-rich-text .assistant-table-wrap {
+  overflow-x: auto;
+}
+
+.assistant-rich-text table {
+  border-collapse: collapse;
+  font-size: 0.95rem;
+  min-width: 100%;
+}
+
+.assistant-rich-text th,
+.assistant-rich-text td {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 0.6rem 0.7rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.assistant-rich-text th {
+  background: rgba(148, 163, 184, 0.1);
+  font-weight: 700;
+}
+
+.assistant-rich-text .assistant-math-inline,
+.assistant-rich-text .assistant-math-block {
+  background: rgba(148, 163, 184, 0.12);
+  border-radius: 0.75rem;
+  font-family: var(--font-geist-mono), monospace;
+}
+
+.assistant-rich-text .assistant-math-inline {
+  padding: 0.1rem 0.35rem;
+}
+
+.assistant-rich-text .assistant-math-block {
+  overflow-x: auto;
+  padding: 0.9rem 1rem;
+  white-space: pre-wrap;
+}
+
+.dashboard-animated-table .ant-table {
+  animation: dashboard-table-enter 220ms ease-out;
+}
+
+.dashboard-animated-table .ant-table-tbody > tr.dashboard-table-row--fresh > td {
+  animation: dashboard-row-fresh 1.8s ease-out;
+}
+
+.dashboard-kanban-card {
+  overflow: hidden;
+}
+
+.dashboard-kanban-card .ant-card-head {
+  border-bottom: 1px solid rgba(226, 232, 240, 0.9);
+}
+
+.dashboard-kanban-card .ant-card-body {
+  overflow: hidden;
+}
+
+.dashboard-kanban-scroll {
+  align-items: start;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.dashboard-kanban-lane {
+  max-width: none;
+  min-width: 0;
+}
+
+.dashboard-kanban-lane-body {
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.95) 0%, rgba(241, 245, 249, 0.96) 100%);
+  border: 1px solid rgba(203, 213, 225, 0.95);
+  border-radius: 1.5rem;
+  height: 31rem;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 0.9rem;
+}
+
+.dashboard-kanban-lane-body--active {
+  background: linear-gradient(180deg, rgba(255, 247, 237, 0.98) 0%, rgba(255, 237, 213, 0.9) 100%);
+  border-color: rgba(251, 146, 60, 0.85);
+  box-shadow: inset 0 0 0 1px rgba(251, 146, 60, 0.18);
+}
+
+.dashboard-kanban-card-item {
+  background: #ffffff;
+  border: 1px solid rgba(226, 232, 240, 0.95);
+  border-radius: 1.15rem;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+  padding: 0.95rem;
+}
+
+.dashboard-kanban-empty-state {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px dashed rgba(203, 213, 225, 0.95);
+  border-radius: 1rem;
+  color: rgb(148 163 184);
+  display: flex;
+  justify-content: center;
+  min-height: 7rem;
+  padding: 1rem;
+  text-align: center;
+}
+
+.dashboard-reassignment-deals-select .ant-select-selector {
+  align-items: flex-start;
+  min-height: 4rem !important;
+  padding-bottom: 0.7rem !important;
+  padding-top: 0.7rem !important;
+}
+
+.dashboard-reassignment-deals-select .ant-select-selection-overflow {
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.dashboard-reassignment-deals-select.ant-select-multiple .ant-select-selection-item,
+.dashboard-reassignment-deals-select.ant-select-multiple .ant-select-selection-overflow-item {
+  max-width: 100%;
+}
+
+.dashboard-reassignment-option {
+  padding: 0.15rem 0;
+}
+
+.dashboard-reassignment-deals-tag {
+  background: rgba(31, 54, 92, 0.08);
+  border: 1px solid rgba(79, 124, 172, 0.22);
+  border-radius: 9999px;
+  color: rgb(31 54 92);
+  display: inline-flex;
+  font-size: 0.85rem;
+  font-weight: 600;
+  max-width: 100%;
+  padding: 0.3rem 0.7rem;
+}
+
+@keyframes dashboard-progress-scan {
+  0% {
+    transform: translateX(-45%) scaleX(0.35);
+  }
+
+  50% {
+    transform: translateX(12%) scaleX(0.72);
+  }
+
+  100% {
+    transform: translateX(45%) scaleX(0.35);
+  }
+}
+
+@keyframes dashboard-table-enter {
+  0% {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes dashboard-row-fresh {
+  0% {
+    background: rgba(242, 140, 40, 0.16);
+    transform: translateY(8px);
+  }
+
+  55% {
+    background: rgba(242, 140, 40, 0.1);
+  }
+
+  100% {
+    background: transparent;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1279px) {
+  .dashboard-kanban-scroll {
+    display: flex;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: 0.35rem;
+    scroll-snap-type: x proximity;
+  }
+
+  .dashboard-kanban-lane {
+    flex: 0 0 min(82vw, 260px);
+    max-width: min(82vw, 260px);
+    min-width: min(82vw, 260px);
+    scroll-snap-align: start;
+  }
+}
+
+@media (max-width: 1023px) {
+  .dashboard-main,
+  .dashboard-main--expanded {
+    padding-left: 0;
+  }
+
+  .dashboard-sidebar {
+    box-shadow: 0 28px 80px rgba(15, 23, 42, 0.28);
+  }
+  .dashboard-kanban-lane-body {
+    height: 26rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .dashboard-sidebar-backdrop {
+    display: none;
+  }
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import AuthProvider from "@/providers/authProvider";
+import Providers from "@/providers";
 
 type AppProvidersProps = Readonly<{
   children: React.ReactNode;
 }>;
 
 export function AppProviders({ children }: AppProvidersProps) {
-  return <AuthProvider>{children}</AuthProvider>;
+  return <Providers>{children}</Providers>;
 }
 
 export default AppProviders;

--- a/components/dashboard/activities-panel.tsx
+++ b/components/dashboard/activities-panel.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { Button, Checkbox, Tag, Typography } from "antd";
+import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
+import { useState } from "react";
+
+import { type IActivity } from "@/providers/salesTypes";
+import { useActivityActions, useActivityState } from "@/providers/activityProvider";
+import ActivityForm from "./activity-form";
+import { AnimatedDashboardTable } from "./animated-dashboard-table";
+
+const typeColors: Record<string, string> = {
+  Call: "#355c7d",
+  Email: "#4f7cac",
+  Meeting: "#f97316",
+  Task: "#94a3b8",
+};
+
+export function ActivitiesPanel() {
+  const { activities } = useActivityState();
+  const { deleteActivity, updateActivity } = useActivityActions();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const columns = [
+    {
+      dataIndex: "type",
+      key: "type",
+      render: (type: string) => <Tag color={typeColors[type] || "#64748b"}>{type}</Tag>,
+      title: "Type",
+    },
+    {
+      dataIndex: "title",
+      key: "title",
+      title: "Follow-up",
+    },
+    {
+      dataIndex: "dueDate",
+      key: "dueDate",
+      title: "Due date",
+    },
+    {
+      key: "completed",
+      render: (completed: boolean, record: IActivity) => (
+        <Checkbox
+          checked={completed}
+          onChange={(event) =>
+            updateActivity(record.id, {
+              completed: event.target.checked,
+              status: event.target.checked ? "Completed" : "Scheduled",
+            })
+          }
+        />
+      ),
+      title: "Done",
+      dataIndex: "completed",
+    },
+    {
+      key: "actions",
+      render: (_: unknown, record: IActivity) => (
+        <div className="space-x-2">
+          <Button
+            icon={<EditOutlined />}
+            onClick={() => setEditingId(record.id)}
+            size="small"
+            type="text"
+          />
+          <Button
+            danger
+            icon={<DeleteOutlined />}
+            onClick={() => deleteActivity(record.id)}
+            size="small"
+            type="text"
+          />
+        </div>
+      ),
+      title: "Actions",
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="space-y-1">
+          <Typography.Title className="!m-0" level={4}>
+            Follow-ups ({activities.length})
+          </Typography.Title>
+          <Typography.Text className="!text-slate-500">
+            Calls, emails, meetings, and tasks tied to live deals.
+          </Typography.Text>
+        </div>
+        <Button icon={<PlusOutlined />} onClick={() => setIsModalOpen(true)} type="primary">
+          Add follow-up
+        </Button>
+      </div>
+
+      <AnimatedDashboardTable
+        columns={columns}
+        dataSource={activities}
+        emptyDescription="No follow-ups"
+        isBusy={isSubmitting}
+        rowKey="id"
+      />
+
+      <ActivityForm
+        editingId={editingId}
+        isOpen={isModalOpen || editingId !== null}
+        isSubmitting={isSubmitting}
+        onClose={() => {
+          setIsModalOpen(false);
+          setEditingId(null);
+        }}
+        onSubmitStart={() => setIsSubmitting(true)}
+        onSubmitEnd={() => setIsSubmitting(false)}
+      />
+    </div>
+  );
+}

--- a/components/dashboard/activity-form.tsx
+++ b/components/dashboard/activity-form.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { Form, Input, Modal, Select } from "antd";
+import { useEffect } from "react";
+
+import { ActivityStatus, ActivityType, type IActivity } from "@/providers/salesTypes";
+import { useActivityActions, useActivityState } from "@/providers/activityProvider";
+import { useDashboardState } from "@/providers/dashboardProvider";
+import { useOpportunityState } from "@/providers/opportunityProvider";
+import { useProposalState } from "@/providers/proposalProvider";
+
+interface ActivityFormProps {
+  isOpen: boolean;
+  isSubmitting?: boolean;
+  editingId: string | null;
+  onClose: () => void;
+  onSubmitStart?: () => void;
+  onSubmitEnd?: () => void;
+}
+
+export default function ActivityForm({
+  isOpen,
+  isSubmitting = false,
+  editingId,
+  onClose,
+  onSubmitStart,
+  onSubmitEnd,
+}: ActivityFormProps) {
+  const [form] = Form.useForm();
+  const { activities } = useActivityState();
+  const { opportunities } = useOpportunityState();
+  const { proposals } = useProposalState();
+  const { teamMembers } = useDashboardState();
+  const { addActivity, updateActivity } = useActivityActions();
+
+  useEffect(() => {
+    if (editingId) {
+      const activity = activities.find((item) => item.id === editingId);
+      if (activity) {
+        form.setFieldsValue({
+          ...activity,
+          relatedTo: activity.relatedToId,
+        });
+      }
+    } else {
+      form.resetFields();
+    }
+  }, [activities, editingId, form, isOpen]);
+
+  const handleSubmit = async (values: {
+    assignedToId?: string;
+    description?: string;
+    dueDate: string;
+    relatedTo?: string;
+    title: string;
+    type: ActivityType;
+  }) => {
+    onSubmitStart?.();
+
+    try {
+      const owner = teamMembers.find((member) => member.id === values.assignedToId);
+      const data: IActivity = {
+        assignedToId: values.assignedToId,
+        assignedToName: owner?.name,
+        completed: false,
+        description: values.description ?? "",
+        dueDate: values.dueDate,
+        id: editingId || Date.now().toString(),
+        priority: 2,
+        relatedToId: values.relatedTo || "",
+        relatedToType: 2,
+        status: ActivityStatus.Scheduled,
+        subject: values.title,
+        title: values.title,
+        type: values.type,
+      };
+
+      if (editingId) {
+        await updateActivity(editingId, data);
+      } else {
+        await addActivity(data);
+      }
+
+      onClose();
+      form.resetFields();
+    } finally {
+      onSubmitEnd?.();
+    }
+  };
+
+  return (
+    <Modal
+      onCancel={onClose}
+      onOk={() => form.submit()}
+      okButtonProps={{ loading: isSubmitting }}
+      open={isOpen}
+      title={editingId ? "Edit follow-up" : "Add follow-up"}
+    >
+      <Form className="pt-4" form={form} layout="vertical" onFinish={handleSubmit}>
+        <Form.Item
+          label="Type"
+          name="type"
+          rules={[{ message: "Please select type", required: true }]}
+        >
+          <Select
+            options={[
+              { label: "Call", value: ActivityType.Call },
+              { label: "Email", value: ActivityType.Email },
+              { label: "Meeting", value: ActivityType.Meeting },
+              { label: "Task", value: ActivityType.Task },
+            ]}
+          />
+        </Form.Item>
+
+        <Form.Item
+          label="Title"
+          name="title"
+          rules={[{ message: "Please enter title", required: true }]}
+        >
+          <Input placeholder="e.g., Follow-up call with client" />
+        </Form.Item>
+
+        <Form.Item label="Description" name="description">
+          <Input.TextArea placeholder="Additional details" rows={3} />
+        </Form.Item>
+
+        <Form.Item
+          label="Due date"
+          name="dueDate"
+          rules={[{ message: "Please enter due date", required: true }]}
+        >
+          <Input type="date" />
+        </Form.Item>
+
+        <Form.Item label="Owner" name="assignedToId">
+          <Select
+            options={teamMembers.map((member) => ({
+              label: `${member.name} (${member.availabilityPercent}% free)`,
+              value: member.id,
+            }))}
+            placeholder="Select an owner"
+          />
+        </Form.Item>
+
+        <Form.Item label="Related deal" name="relatedTo">
+          <Select
+            options={[
+              ...opportunities.map((opportunity) => ({
+                label: `Opportunity: ${opportunity.name || opportunity.title}`,
+                value: opportunity.id,
+              })),
+              ...proposals.map((proposal) => ({
+                label: `Proposal: ${proposal.title}`,
+                value: proposal.id,
+              })),
+            ]}
+            placeholder="Select opportunity or proposal"
+          />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/components/dashboard/animated-dashboard-table.tsx
+++ b/components/dashboard/animated-dashboard-table.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { Empty, Skeleton, Table } from "antd";
+import type { TableProps } from "antd";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type AnimatedDashboardTableProps<T extends object> = Pick<
+  TableProps<T>,
+  "columns" | "pagination" | "rowKey" | "scroll" | "size"
+> & {
+  className?: string;
+  dataSource: T[];
+  emptyDescription: string;
+  isBusy?: boolean;
+};
+
+const ROW_HIGHLIGHT_DURATION_MS = 1800;
+const INITIAL_EMPTY_DELAY_MS = 450;
+
+const normalizeRowKey = <T extends object>(
+  record: T,
+  index: number,
+  rowKey?: TableProps<T>["rowKey"],
+) => {
+  if (typeof rowKey === "function") {
+    return String(rowKey(record));
+  }
+
+  if (typeof rowKey === "string") {
+    const value = record[rowKey as keyof T];
+    return String(value ?? index);
+  }
+
+  return String(index);
+};
+
+export function AnimatedDashboardTable<T extends object>({
+  className,
+  columns,
+  dataSource,
+  emptyDescription,
+  isBusy = false,
+  pagination = false,
+  rowKey,
+  scroll,
+  size = "middle",
+}: AnimatedDashboardTableProps<T>) {
+  const [canShowEmpty, setCanShowEmpty] = useState(dataSource.length > 0);
+  const [highlightedKeys, setHighlightedKeys] = useState<string[]>([]);
+  const previousKeysRef = useRef<string[]>([]);
+
+  useEffect(() => {
+    if (dataSource.length > 0 || canShowEmpty) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setCanShowEmpty(true);
+    }, INITIAL_EMPTY_DELAY_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [canShowEmpty, dataSource.length]);
+
+  const resolvedKeys = useMemo(
+    () => dataSource.map((record, index) => normalizeRowKey(record, index, rowKey)),
+    [dataSource, rowKey],
+  );
+
+  useEffect(() => {
+    const previousKeys = new Set(previousKeysRef.current);
+    const addedKeys =
+      previousKeysRef.current.length === 0
+        ? []
+        : resolvedKeys.filter((key) => !previousKeys.has(key));
+
+    previousKeysRef.current = resolvedKeys;
+
+    if (addedKeys.length === 0) {
+      return;
+    }
+
+    setHighlightedKeys((current) => [...new Set([...current, ...addedKeys])]);
+
+    const timer = window.setTimeout(() => {
+      setHighlightedKeys([]);
+    }, ROW_HIGHLIGHT_DURATION_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [resolvedKeys]);
+
+  const tableClassName = [
+    "dashboard-responsive-table",
+    "dashboard-animated-table",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const showSkeleton = dataSource.length === 0 && !canShowEmpty;
+
+  return (
+    <div
+      className={`dashboard-table-shell ${isBusy ? "dashboard-table-shell--busy" : ""}`}
+    >
+      <Table<T>
+        className={tableClassName}
+        columns={columns}
+        dataSource={dataSource}
+        locale={{
+          emptyText: showSkeleton ? (
+            <div className="px-3 py-4">
+              <Skeleton
+                active
+                paragraph={{ rows: 4 }}
+                title={false}
+              />
+            </div>
+          ) : (
+            <Empty description={emptyDescription} />
+          ),
+        }}
+        pagination={pagination}
+        rowClassName={(record, index) =>
+          highlightedKeys.includes(normalizeRowKey(record, index, rowKey))
+            ? "dashboard-table-row--fresh"
+            : ""
+        }
+        rowKey={rowKey}
+        scroll={scroll}
+        size={size}
+      />
+      <div className="dashboard-table-progress" />
+    </div>
+  );
+}

--- a/components/dashboard/assistant-panel.tsx
+++ b/components/dashboard/assistant-panel.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+import { Alert, Button, Card, Input, Spin, Tag, Typography } from "antd";
+import {
+  DeleteOutlined,
+  RobotOutlined,
+  SafetyCertificateOutlined,
+  SendOutlined,
+} from "@ant-design/icons";
+import { useEffect, useState } from "react";
+
+import { getPrimaryUserRole, getUserRoleLabel, isManagerRole } from "@/lib/auth/roles";
+import { getSessionToken } from "@/lib/client/backend-api";
+import { clearSessionDraft, readSessionDraft, writeSessionDraft } from "@/lib/client/session-drafts";
+import { useAuthState } from "@/providers/authProvider";
+import type { UserRole } from "@/providers/salesTypes";
+import { ASSISTANT_PANEL_DRAFT_KEY, ASSISTANT_PANEL_MESSAGES_KEY } from "./draft-storage";
+import { AssistantRichText } from "./assistant-rich-text";
+
+type AssistantMessage = {
+  content: string;
+  mutations?: Array<{
+    entityId: string;
+    entityType: "client" | "opportunity" | "proposal";
+    operation: "create";
+    title: string;
+  }>;
+  role: "assistant" | "user";
+  trace?: Array<{
+    arguments: Record<string, unknown>;
+    outputPreview: string;
+    tool: string;
+  }>;
+};
+
+const MAX_VISIBLE_MESSAGES = 12;
+
+const getIntroMessage = (role: UserRole) =>
+  isManagerRole(role)
+    ? "I can help with pipeline risk, next actions, proposal bottlenecks, renewal risk, workload pressure, workspace search, and creating new clients, opportunities, or draft proposals when you ask explicitly."
+    : "I can help with your assigned opportunities, proposal progress, pricing requests, activities, workspace search, and creating new opportunities or draft proposals when you ask explicitly.";
+
+export function AssistantPanel() {
+  const { user } = useAuthState();
+  const role = getPrimaryUserRole(user?.roles);
+  const [draft, setDraft] = useState(() => readSessionDraft<string>(ASSISTANT_PANEL_DRAFT_KEY) ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [assistantMode, setAssistantMode] = useState<"groq" | "offline" | "openai" | null>(null);
+  const [assistantReason, setAssistantReason] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [messages, setMessages] = useState<AssistantMessage[]>(
+    () => readSessionDraft<AssistantMessage[]>(ASSISTANT_PANEL_MESSAGES_KEY) ?? [],
+  );
+  const [statusLabel, setStatusLabel] = useState("Awaiting your question");
+
+  const resetConversation = () => {
+    setDraft("");
+    setMessages([]);
+    setError(null);
+    clearSessionDraft(ASSISTANT_PANEL_DRAFT_KEY);
+    clearSessionDraft(ASSISTANT_PANEL_MESSAGES_KEY);
+  };
+
+  const suggestedPrompts =
+    role === "SalesRep"
+      ? [
+          "What assigned work needs my attention first?",
+          "Which pricing request or proposal is blocked?",
+          "Summarize my pipeline in plain language.",
+          "Create a new opportunity for an existing client.",
+          "Create a draft proposal for an existing opportunity.",
+        ]
+      : [
+          "Which deals need action first this week?",
+          "Where is the biggest renewal risk right now?",
+          "Who looks overloaded and what should I reassign?",
+          "Create a new opportunity for an existing client.",
+          "Create a draft proposal for an existing opportunity.",
+          "Search the workspace for a client, proposal, or contract.",
+      ];
+
+  useEffect(() => {
+    if (draft) {
+      writeSessionDraft(ASSISTANT_PANEL_DRAFT_KEY, draft);
+      return;
+    }
+
+    clearSessionDraft(ASSISTANT_PANEL_DRAFT_KEY);
+  }, [draft]);
+
+  useEffect(() => {
+    if (messages.length > 0) {
+      writeSessionDraft(ASSISTANT_PANEL_MESSAGES_KEY, messages);
+      return;
+    }
+
+    clearSessionDraft(ASSISTANT_PANEL_MESSAGES_KEY);
+  }, [messages]);
+
+  useEffect(() => {
+    let isActive = true;
+
+    const loadAssistantStatus = async () => {
+      try {
+        const token = getSessionToken();
+        const response = await fetch("/api/assistant/status", {
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        });
+        const payload = (await response.json()) as {
+          isConfigured?: boolean;
+          message?: string;
+          mode?: "groq" | "offline" | "openai";
+          model?: string;
+          reason?: string | null;
+        };
+
+        if (!response.ok || !isActive) {
+          if (isActive) {
+            setAssistantMode("offline");
+            setAssistantReason(
+              payload.reason ?? payload.message ?? "Assistant access is not authorized.",
+            );
+            setStatusLabel("Assistant access unavailable");
+          }
+          return;
+        }
+
+        setAssistantMode(payload.mode ?? null);
+        setAssistantReason(payload.reason ?? null);
+        setStatusLabel(
+          payload.mode === "offline"
+            ? "Offline mode available"
+            : "Secure access ready",
+        );
+      } catch {
+        if (!isActive) {
+          return;
+        }
+
+        setAssistantMode("offline");
+        setAssistantReason("Assistant status could not be verified.");
+        setStatusLabel("Offline secure mode - status unavailable");
+      }
+    };
+
+    void loadAssistantStatus();
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
+
+  const sendMessage = async (content: string) => {
+    const trimmed = content.trim();
+
+    if (!trimmed || isSubmitting) {
+      return;
+    }
+
+    const nextMessages = [
+      ...messages,
+      {
+        content: trimmed,
+        role: "user" as const,
+      },
+    ].slice(-MAX_VISIBLE_MESSAGES);
+
+    setMessages(nextMessages);
+    setDraft("");
+    clearSessionDraft(ASSISTANT_PANEL_DRAFT_KEY);
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const token = getSessionToken();
+      const response = await fetch("/api/assistant", {
+        body: JSON.stringify({ messages: nextMessages }),
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        method: "POST",
+      });
+
+      const payload = (await response.json()) as {
+        message?: string;
+        mode?: string;
+        model?: string;
+        mutations?: Array<{
+          entityId: string;
+          entityType: "client" | "opportunity" | "proposal";
+          operation: "create";
+          title: string;
+        }>;
+        scopeLabel?: string;
+        trace?: Array<{
+          arguments: Record<string, unknown>;
+          outputPreview: string;
+          tool: string;
+        }>;
+      };
+
+      if (!response.ok) {
+        throw new Error(payload.message ?? "The assistant request failed.");
+      }
+
+      setMessages((current) =>
+        [
+          ...current,
+          {
+            content: payload.message ?? "No assistant response was returned.",
+            mutations: payload.mutations ?? [],
+            role: "assistant" as const,
+            trace: payload.trace ?? [],
+          },
+        ].slice(-MAX_VISIBLE_MESSAGES),
+      );
+
+      if ((payload.mutations?.length ?? 0) > 0) {
+        window.dispatchEvent(
+          new CustomEvent("mock-workspace-updated", {
+            detail: payload.mutations,
+          }),
+        );
+      }
+      setStatusLabel(
+        payload.mode === "offline"
+          ? "Offline mode available"
+          : payload.scopeLabel ?? "Secure access ready",
+      );
+    } catch (requestError) {
+      setError(
+        requestError instanceof Error
+          ? requestError.message
+          : "The assistant could not process this request.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 xl:grid-cols-[1.35fr_0.65fr]">
+        <Card className="min-w-0 border-slate-200">
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <RobotOutlined className="text-slate-600" />
+                <Typography.Title className="!mb-0 !text-slate-900" level={4}>
+                  Secure sales assistant
+                </Typography.Title>
+              </div>
+              <Typography.Text className="block !text-slate-500">
+                {statusLabel}
+              </Typography.Text>
+            </div>
+            <Tag color={isManagerRole(role) ? "#f28c28" : "#4f7cac"}>
+              {isManagerRole(role) ? "Manager scope" : `${getUserRoleLabel(role)} scope`}
+            </Tag>
+          </div>
+
+          <div className="space-y-3">
+            {messages.length === 0 ? (
+              <div className="rounded-3xl bg-slate-50 p-4 text-slate-700">
+                <AssistantRichText className="text-slate-700" content={getIntroMessage(role)} />
+              </div>
+            ) : null}
+
+            {messages.map((message, index) => (
+              <div
+                className={`rounded-3xl p-4 ${
+                  message.role === "assistant"
+                    ? "bg-slate-50 text-slate-700"
+                    : "bg-[#1f365c] text-white"
+                }`}
+                key={`${message.role}-${index}`}
+              >
+                <AssistantRichText
+                  className={message.role === "assistant" ? "text-slate-700" : "text-white"}
+                  content={message.content}
+                />
+                {message.role === "assistant" && message.trace?.length ? (
+                  <details className="mt-3 rounded-2xl border border-slate-200 bg-white/70 px-3 py-2 text-sm text-slate-600">
+                    <summary className="cursor-pointer font-medium text-slate-700">
+                      View assistant trace
+                    </summary>
+                    <div className="mt-3 space-y-3">
+                      {message.trace.map((step, stepIndex) => (
+                        <div
+                          className="rounded-2xl border border-slate-200 bg-slate-50 p-3"
+                          key={`${step.tool}-${stepIndex}`}
+                        >
+                          <Typography.Text strong>{step.tool}</Typography.Text>
+                          <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words text-xs text-slate-600">
+                            {JSON.stringify(step.arguments, null, 2)}
+                          </pre>
+                          <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words text-xs text-slate-500">
+                            {step.outputPreview}
+                          </pre>
+                        </div>
+                      ))}
+                    </div>
+                  </details>
+                ) : null}
+              </div>
+            ))}
+
+            {isSubmitting ? (
+              <div className="flex items-center gap-3 rounded-3xl bg-slate-50 p-4 text-slate-500">
+                <Spin size="small" />
+                <span>Reviewing authorized workspace data...</span>
+              </div>
+            ) : null}
+          </div>
+
+          <div className="mt-5 space-y-3">
+            <Input.TextArea
+              onChange={(event) => setDraft(event.target.value)}
+              onPressEnter={(event) => {
+                if (!event.shiftKey) {
+                  event.preventDefault();
+                  void sendMessage(draft);
+                }
+              }}
+              placeholder="Ask for pipeline advice, account status, follow-ups, workspace search, or ask me to create a client, opportunity, or draft proposal."
+              rows={4}
+              value={draft}
+            />
+
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex flex-wrap gap-2">
+                {suggestedPrompts.map((prompt) => (
+                  <Button key={prompt} onClick={() => void sendMessage(prompt)}>
+                    {prompt}
+                  </Button>
+                ))}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  disabled={messages.length === 0 && !draft}
+                  icon={<DeleteOutlined />}
+                  onClick={resetConversation}
+                >
+                  Reset chat
+                </Button>
+                <Button
+                  icon={<SendOutlined />}
+                  loading={isSubmitting}
+                  onClick={() => void sendMessage(draft)}
+                  type="primary"
+                >
+                  Send
+                </Button>
+              </div>
+            </div>
+
+            {error ? <Alert description={error} showIcon title="Assistant request failed." type="error" /> : null}
+          </div>
+        </Card>
+
+        <div className="space-y-4">
+          {assistantMode === "offline" ? (
+            <Alert
+              showIcon
+              title="Live assistant is not configured yet."
+              type="warning"
+              description={
+                assistantReason
+                  ? `${assistantReason} Add it to .env.local and restart the Next.js server.`
+                  : "Add OPENAI_API_KEY or GROQ_API_KEY to .env.local and restart the Next.js server."
+              }
+            />
+          ) : null}
+
+          <Card className="border-slate-200">
+            <div className="flex items-start gap-3">
+              <SafetyCertificateOutlined className="mt-1 text-[#f28c28]" />
+              <div className="space-y-2">
+                <Typography.Title className="!mb-0" level={5}>
+                  Security posture
+                </Typography.Title>
+                <Typography.Paragraph className="!mb-0 !text-slate-600">
+                  Every assistant request is authorized on the server using your bearer token before any data is exposed to the model.
+                </Typography.Paragraph>
+                <Typography.Paragraph className="!mb-0 !text-slate-600">
+                  Responses are constrained by your tenant and your role, with manager-focused or contributor-focused guidance depending on your permissions.
+                </Typography.Paragraph>
+              </div>
+            </div>
+          </Card>
+
+          <Card className="border-slate-200" title="What You Can Ask">
+            <div className="space-y-3 text-sm text-slate-600">
+              <p>Pipeline priority and next actions</p>
+              <p>Proposal status and blockers</p>
+              <p>Renewal risk and deadline pressure</p>
+              <p>Follow-ups, workload pressure, and role-appropriate business summaries</p>
+              <p>Workspace search across clients, opportunities, proposals, contracts, notes, documents, pricing requests, and renewals</p>
+              <p>Create a new client, opportunity, or draft proposal when you provide enough detail</p>
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/assistant-rich-text.tsx
+++ b/components/dashboard/assistant-rich-text.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+const escapeHtml = (value: string) =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+
+const applyInlineFormatting = (value: string) => {
+  let html = escapeHtml(value);
+
+  html = html.replace(
+    /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+    '<a href="$2" target="_blank" rel="noreferrer" class="assistant-rich-link">$1</a>',
+  );
+  html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
+  html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  html = html.replace(/\*([^*]+)\*/g, "<em>$1</em>");
+  html = html.replace(/\\\((.+?)\\\)/g, '<span class="assistant-math-inline">$1</span>');
+
+  return html;
+};
+
+const isTableSeparator = (line: string) =>
+  /^\s*\|?(\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$/.test(line);
+
+const splitTableCells = (line: string) =>
+  line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
+
+const renderTable = (lines: string[]) => {
+  const [headerLine, , ...rowLines] = lines;
+  const headers = splitTableCells(headerLine);
+  const rows = rowLines.map(splitTableCells);
+
+  const headHtml = headers
+    .map((cell) => `<th>${applyInlineFormatting(cell)}</th>`)
+    .join("");
+  const bodyHtml = rows
+    .map(
+      (row) =>
+        `<tr>${row
+          .map((cell) => `<td>${applyInlineFormatting(cell)}</td>`)
+          .join("")}</tr>`,
+    )
+    .join("");
+
+  return `<div class="assistant-table-wrap"><table><thead><tr>${headHtml}</tr></thead><tbody>${bodyHtml}</tbody></table></div>`;
+};
+
+const renderList = (lines: string[]) => {
+  const ordered = /^\s*\d+\.\s+/.test(lines[0]);
+  const tag = ordered ? "ol" : "ul";
+  const items = lines
+    .map((line) =>
+      line.replace(/^\s*(?:[-*]|\d+\.)\s+/, ""),
+    )
+    .map((item) => `<li>${applyInlineFormatting(item)}</li>`)
+    .join("");
+
+  return `<${tag}>${items}</${tag}>`;
+};
+
+const renderParagraph = (lines: string[]) =>
+  `<p>${lines.map((line) => applyInlineFormatting(line)).join("<br />")}</p>`;
+
+const renderMarkdown = (content: string) => {
+  const normalized = content.replace(/\r\n/g, "\n").trim();
+
+  if (!normalized) {
+    return "";
+  }
+
+  const lines = normalized.split("\n");
+  const blocks: string[] = [];
+
+  for (let index = 0; index < lines.length; ) {
+    const currentLine = lines[index].trimEnd();
+
+    if (!currentLine.trim()) {
+      index += 1;
+      continue;
+    }
+
+    if (currentLine.startsWith("```")) {
+      const codeLines: string[] = [];
+      const language = currentLine.slice(3).trim();
+      index += 1;
+
+      while (index < lines.length && !lines[index].trimStart().startsWith("```")) {
+        codeLines.push(lines[index]);
+        index += 1;
+      }
+
+      index += 1;
+      blocks.push(
+        `<pre><code class="${language ? `language-${escapeHtml(language)}` : ""}">${escapeHtml(codeLines.join("\n"))}</code></pre>`,
+      );
+      continue;
+    }
+
+    if (/^---+$/.test(currentLine.trim())) {
+      blocks.push("<hr />");
+      index += 1;
+      continue;
+    }
+
+    if (/^#{1,6}\s+/.test(currentLine)) {
+      const level = currentLine.match(/^#+/)?.[0].length ?? 1;
+      const text = currentLine.replace(/^#{1,6}\s+/, "");
+      blocks.push(`<h${level}>${applyInlineFormatting(text)}</h${level}>`);
+      index += 1;
+      continue;
+    }
+
+    if (currentLine.trim().startsWith("\\[")) {
+      const mathLines = [currentLine];
+      index += 1;
+
+      while (index < lines.length && !lines[index].includes("\\]")) {
+        mathLines.push(lines[index]);
+        index += 1;
+      }
+
+      if (index < lines.length) {
+        mathLines.push(lines[index]);
+        index += 1;
+      }
+
+      blocks.push(
+        `<div class="assistant-math-block">${escapeHtml(mathLines.join("\n"))}</div>`,
+      );
+      continue;
+    }
+
+    if (
+      currentLine.includes("|") &&
+      index + 1 < lines.length &&
+      isTableSeparator(lines[index + 1])
+    ) {
+      const tableLines = [currentLine, lines[index + 1]];
+      index += 2;
+
+      while (index < lines.length && lines[index].includes("|") && lines[index].trim()) {
+        tableLines.push(lines[index]);
+        index += 1;
+      }
+
+      blocks.push(renderTable(tableLines));
+      continue;
+    }
+
+    if (/^\s*(?:[-*]|\d+\.)\s+/.test(currentLine)) {
+      const listLines: string[] = [];
+
+      while (index < lines.length && /^\s*(?:[-*]|\d+\.)\s+/.test(lines[index])) {
+        listLines.push(lines[index]);
+        index += 1;
+      }
+
+      blocks.push(renderList(listLines));
+      continue;
+    }
+
+    const paragraphLines: string[] = [];
+
+    while (index < lines.length) {
+      const nextLine = lines[index];
+      const trimmed = nextLine.trim();
+
+      if (
+        !trimmed ||
+        trimmed.startsWith("```") ||
+        /^#{1,6}\s+/.test(trimmed) ||
+        /^---+$/.test(trimmed) ||
+        /^\s*(?:[-*]|\d+\.)\s+/.test(nextLine) ||
+        trimmed.startsWith("\\[") ||
+        (trimmed.includes("|") &&
+          index + 1 < lines.length &&
+          isTableSeparator(lines[index + 1]))
+      ) {
+        break;
+      }
+
+      paragraphLines.push(trimmed);
+      index += 1;
+    }
+
+    blocks.push(renderParagraph(paragraphLines));
+  }
+
+  return blocks.join("");
+};
+
+export function AssistantRichText({
+  className,
+  content,
+}: Readonly<{
+  className?: string;
+  content: string;
+}>) {
+  return (
+    <div
+      className={["assistant-rich-text", className].filter(Boolean).join(" ")}
+      dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }}
+    />
+  );
+}

--- a/components/dashboard/boxfusion-logo.tsx
+++ b/components/dashboard/boxfusion-logo.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+export function BoxfusionLogo({ size = 40 }: { size?: number }) {
+  return (
+    <svg
+      aria-hidden
+      fill="none"
+      height={size}
+      viewBox="0 0 48 48"
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect fill="#E7EDF4" height="48" rx="14" width="48" />
+      <path
+        d="M12 30.5L24 10L36 30.5L30.2 30.5L24 19.6L17.8 30.5H12Z"
+        fill="#1F365C"
+      />
+      <path
+        d="M24 19.6L30.2 30.5H36L24 38L12 30.5H17.8L24 19.6Z"
+        fill="#F28C28"
+      />
+      <circle cx="24" cy="30.5" fill="#FFFFFF" r="2.6" />
+    </svg>
+  );
+}

--- a/components/dashboard/client-form.tsx
+++ b/components/dashboard/client-form.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { Form, Input, InputNumber, Modal, Select } from "antd";
+import { useEffect } from "react";
+
+import { clearSessionDraft, readSessionDraft, writeSessionDraft } from "@/lib/client/session-drafts";
+import { OpportunityStage, type IClient } from "@/providers/salesTypes";
+import { useContactState } from "@/providers/contactProvider";
+import { getClientFormDraftKey } from "./draft-storage";
+
+type ClientFormValues = {
+  contactEmail?: string;
+  contactFirstName?: string;
+  contactLastName?: string;
+  contactPhoneNumber?: string;
+  contactPosition?: string;
+  expectedCloseDate?: string;
+  industry: string;
+  name: string;
+  opportunityDescription?: string;
+  opportunityStage?: OpportunityStage;
+  opportunityTitle?: string;
+  opportunityValue?: number;
+  segment?: string;
+};
+
+interface ClientFormProps {
+  isOpen: boolean;
+  isSubmitting?: boolean;
+  editingClient: IClient | null;
+  onClose: () => void;
+  onSave: (values: ClientFormValues) => Promise<void> | void;
+}
+
+export function ClientForm({
+  isOpen,
+  isSubmitting = false,
+  editingClient,
+  onClose,
+  onSave,
+}: ClientFormProps) {
+  const [form] = Form.useForm<ClientFormValues>();
+  const { contacts } = useContactState();
+  const draftKey = getClientFormDraftKey(editingClient?.id);
+
+  useEffect(() => {
+    const savedDraft = readSessionDraft<Partial<ClientFormValues>>(draftKey);
+
+    if (editingClient) {
+      const primaryContact = contacts.find(
+        (contact) =>
+          contact.clientId === editingClient.id && contact.isPrimaryContact,
+      );
+
+      form.setFieldsValue({
+        contactEmail: primaryContact?.email,
+        contactFirstName: primaryContact?.firstName,
+        contactLastName: primaryContact?.lastName,
+        contactPhoneNumber: primaryContact?.phoneNumber,
+        contactPosition: primaryContact?.position,
+        industry: editingClient.industry,
+        name: editingClient.name,
+        segment: editingClient.segment,
+      });
+    } else {
+      form.resetFields();
+      form.setFieldsValue({
+        opportunityStage: OpportunityStage.New,
+      });
+    }
+
+    if (savedDraft) {
+      form.setFieldsValue(savedDraft);
+    }
+  }, [contacts, draftKey, editingClient, form, isOpen]);
+
+  const handleFinish = async (values: ClientFormValues) => {
+    await onSave(values);
+    clearSessionDraft(draftKey);
+  };
+
+  return (
+    <Modal
+      onCancel={onClose}
+      onOk={() => form.submit()}
+      okButtonProps={{ loading: isSubmitting }}
+      open={isOpen}
+      title={editingClient ? "Edit client" : "Add client and opportunity"}
+      width={760}
+    >
+      <Form
+        className="pt-4"
+        form={form}
+        layout="vertical"
+        onFinish={handleFinish}
+        onValuesChange={(_, allValues) =>
+          writeSessionDraft(draftKey, allValues satisfies Partial<ClientFormValues>)
+        }
+      >
+        <div className="grid gap-5 md:grid-cols-2">
+          <Form.Item
+            label="Client name"
+            name="name"
+            rules={[{ message: "Please enter the client name", required: true }]}
+          >
+            <Input placeholder="e.g., Northwind Foods" />
+          </Form.Item>
+
+          <Form.Item
+            label="Industry"
+            name="industry"
+            rules={[{ message: "Please enter the industry", required: true }]}
+          >
+            <Input placeholder="e.g., Manufacturing" />
+          </Form.Item>
+
+          <Form.Item label="Segment" name="segment">
+            <Select
+              options={[
+                { label: "Enterprise", value: "Enterprise" },
+                { label: "Growth", value: "Growth" },
+                { label: "SMB", value: "SMB" },
+              ]}
+              placeholder="Choose segment"
+            />
+          </Form.Item>
+
+          <Form.Item label="Primary contact role" name="contactPosition">
+            <Input placeholder="e.g., Operations Director" />
+          </Form.Item>
+
+          <Form.Item label="Primary contact first name" name="contactFirstName">
+            <Input placeholder="First name" />
+          </Form.Item>
+
+          <Form.Item label="Primary contact last name" name="contactLastName">
+            <Input placeholder="Last name" />
+          </Form.Item>
+
+          <Form.Item
+            label="Primary contact email"
+            name="contactEmail"
+            rules={[{ type: "email" }]}
+          >
+            <Input placeholder="contact@company.com" />
+          </Form.Item>
+
+          <Form.Item label="Primary contact phone" name="contactPhoneNumber">
+            <Input placeholder="+27 11 000 0000" />
+          </Form.Item>
+        </div>
+
+        {!editingClient ? (
+          <>
+            <div className="mt-2 grid gap-5 md:grid-cols-2">
+              <Form.Item
+                label="Opportunity title"
+                name="opportunityTitle"
+                rules={[{ message: "Please enter the opportunity title", required: true }]}
+              >
+                <Input placeholder="e.g., National reporting rollout" />
+              </Form.Item>
+
+              <Form.Item
+                label="Pipeline stage"
+                name="opportunityStage"
+                initialValue={OpportunityStage.New}
+              >
+                <Select
+                  options={[
+                    { label: "New", value: OpportunityStage.New },
+                    { label: "Qualified", value: OpportunityStage.Qualified },
+                    { label: "Proposal Sent", value: OpportunityStage.ProposalSent },
+                    { label: "Negotiating", value: OpportunityStage.Negotiating },
+                  ]}
+                />
+              </Form.Item>
+
+              <Form.Item
+                label="Opportunity value"
+                name="opportunityValue"
+                rules={[{ message: "Please enter the opportunity value", required: true }]}
+              >
+                <InputNumber className="!w-full" min={0} prefix="R" />
+              </Form.Item>
+
+              <Form.Item
+                label="Expected close date"
+                name="expectedCloseDate"
+                rules={[{ message: "Please enter the close date", required: true }]}
+              >
+                <Input type="date" />
+              </Form.Item>
+            </div>
+
+            <Form.Item label="Opportunity notes" name="opportunityDescription">
+              <Input.TextArea
+                placeholder="What is being sold and why is it important?"
+                rows={4}
+              />
+            </Form.Item>
+          </>
+        ) : null}
+      </Form>
+    </Modal>
+  );
+}

--- a/components/dashboard/clients-panel.tsx
+++ b/components/dashboard/clients-panel.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { Button, Tag, Typography } from "antd";
+import { PlusOutlined, DeleteOutlined, EditOutlined } from "@ant-design/icons";
+import { useState } from "react";
+
+import { useClientActions, useClientState } from "@/providers/clientProvider";
+import { useContactState } from "@/providers/contactProvider";
+import { useDashboardActions } from "@/providers/dashboardProvider";
+import type { IClient } from "@/providers/salesTypes";
+import { AnimatedDashboardTable } from "./animated-dashboard-table";
+import { ClientForm } from "./client-form";
+
+export function ClientsPanel() {
+  const { clients } = useClientState();
+  const { contacts } = useContactState();
+  const { addClientBundle } = useDashboardActions();
+  const { deleteClient, updateClient } = useClientActions();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingClient, setEditingClient] = useState<IClient | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const statusColors: Record<string, string> = {
+    Active: "green",
+    Inactive: "red",
+  };
+
+  const columns = [
+    {
+      title: "Client Name",
+      dataIndex: "name",
+      key: "name",
+    },
+    {
+      title: "Email",
+      key: "email",
+      render: (_: unknown, record: IClient) =>
+        contacts.find((contact) => contact.clientId === record.id && contact.isPrimaryContact)
+          ?.email ?? "No primary contact",
+    },
+    {
+      title: "Phone",
+      key: "phone",
+      render: (_: unknown, record: IClient) =>
+        contacts.find((contact) => contact.clientId === record.id && contact.isPrimaryContact)
+          ?.phoneNumber ?? "Not set",
+    },
+    {
+      title: "Industry",
+      dataIndex: "industry",
+      key: "industry",
+    },
+    {
+      title: "Status",
+      key: "status",
+      render: (_: unknown, record: IClient) => (
+        <Tag color={statusColors[record.isActive ? "Active" : "Inactive"]}>
+          {record.isActive ? "Active" : "Inactive"}
+        </Tag>
+      ),
+    },
+    {
+      title: "Actions",
+      key: "actions",
+      render: (_: unknown, record: IClient) => (
+        <div className="space-x-2">
+          <Button type="text" icon={<EditOutlined />} onClick={() => setEditingClient(record)} size="small" />
+          <Button type="text" danger icon={<DeleteOutlined />} onClick={() => deleteClient(record.id)} size="small" />
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <Typography.Title level={4} className="!m-0">
+          Clients ({clients.length})
+        </Typography.Title>
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => setIsModalOpen(true)}>
+          Add Client
+        </Button>
+      </div>
+
+      <AnimatedDashboardTable
+        columns={columns}
+        dataSource={clients}
+        emptyDescription="No clients yet"
+        isBusy={isSubmitting}
+        rowKey="id"
+      />
+
+      <ClientForm
+        editingClient={editingClient}
+        isOpen={isModalOpen || editingClient !== null}
+        isSubmitting={isSubmitting}
+        onClose={() => {
+          setIsModalOpen(false);
+          setEditingClient(null);
+        }}
+        onSave={async (values) => {
+          setIsSubmitting(true);
+
+          try {
+            if (editingClient) {
+              await updateClient(editingClient.id, {
+                industry: values.industry,
+                name: values.name,
+                segment: values.segment,
+              });
+            } else {
+              await addClientBundle({
+                client: {
+                  industry: values.industry,
+                  name: values.name,
+                  segment: values.segment,
+                },
+                contact:
+                  values.contactFirstName && values.contactLastName && values.contactEmail
+                    ? {
+                        email: values.contactEmail,
+                        firstName: values.contactFirstName,
+                        lastName: values.contactLastName,
+                        phoneNumber: values.contactPhoneNumber,
+                        position: values.contactPosition,
+                      }
+                    : undefined,
+                opportunity: {
+                  description: values.opportunityDescription,
+                  expectedCloseDate: values.expectedCloseDate ?? new Date().toISOString().split("T")[0],
+                  stage: values.opportunityStage,
+                  title: values.opportunityTitle ?? `${values.name} opportunity`,
+                  value: values.opportunityValue ?? 0,
+                },
+              });
+            }
+
+            setIsModalOpen(false);
+            setEditingClient(null);
+          } finally {
+            setIsSubmitting(false);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/components/dashboard/contact-form.tsx
+++ b/components/dashboard/contact-form.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Form, Input, Modal, Select } from "antd";
+import { useEffect } from "react";
+
+import { type IContact } from "@/providers/salesTypes";
+import { useClientState } from "@/providers/clientProvider";
+
+interface ContactFormProps {
+  editingContact: IContact | null;
+  isOpen: boolean;
+  isSubmitting?: boolean;
+  onClose: () => void;
+  onSave: (contact: Partial<IContact>) => Promise<void> | void;
+}
+
+export function ContactForm({
+  editingContact,
+  isOpen,
+  isSubmitting = false,
+  onClose,
+  onSave,
+}: ContactFormProps) {
+  const [form] = Form.useForm();
+  const { clients } = useClientState();
+
+  useEffect(() => {
+    if (editingContact) {
+      form.setFieldsValue(editingContact);
+    } else {
+      form.resetFields();
+    }
+  }, [editingContact, form, isOpen]);
+
+  return (
+    <Modal
+      onCancel={onClose}
+      onOk={() => form.submit()}
+      okButtonProps={{ loading: isSubmitting }}
+      open={isOpen}
+      title={editingContact ? "Edit contact" : "Add contact"}
+    >
+      <Form
+        className="pt-4"
+        form={form}
+        layout="vertical"
+        onFinish={onSave}
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <Form.Item
+            label="First name"
+            name="firstName"
+            rules={[{ required: true }]}
+          >
+            <Input placeholder="First name" />
+          </Form.Item>
+          <Form.Item
+            label="Last name"
+            name="lastName"
+            rules={[{ required: true }]}
+          >
+            <Input placeholder="Last name" />
+          </Form.Item>
+        </div>
+
+        <Form.Item label="Email" name="email" rules={[{ required: true, type: "email" }]}>
+          <Input type="email" />
+        </Form.Item>
+
+        <Form.Item label="Phone" name="phoneNumber">
+          <Input placeholder="+27 ..." />
+        </Form.Item>
+
+        <Form.Item label="Role" name="position" rules={[{ required: true }]}>
+          <Select
+            options={[
+              { label: "Decision maker", value: "Decision maker" },
+              { label: "Technical lead", value: "Technical lead" },
+              { label: "Finance reviewer", value: "Finance reviewer" },
+            ]}
+          />
+        </Form.Item>
+
+        <Form.Item label="Client" name="clientId" rules={[{ required: true }]}>
+          <Select
+            options={clients.map((client) => ({
+              label: client.name,
+              value: client.id,
+            }))}
+          />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/components/dashboard/contacts-panel.tsx
+++ b/components/dashboard/contacts-panel.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { Button, Space, Tag, Typography } from "antd";
+import { PlusOutlined, DeleteOutlined, EditOutlined, MailOutlined, PhoneOutlined } from "@ant-design/icons";
+import { useState } from "react";
+
+import { useContactActions, useContactState } from "@/providers/contactProvider";
+import type { IContact } from "@/providers/salesTypes";
+import { AnimatedDashboardTable } from "./animated-dashboard-table";
+import { ContactForm } from "./contact-form";
+
+export function ContactsPanel() {
+  const { contacts } = useContactState();
+  const { addContact, deleteContact, updateContact } = useContactActions();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingContact, setEditingContact] = useState<IContact | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const columns = [
+    {
+      title: "Name",
+      key: "name",
+      render: (_: unknown, record: IContact) => `${record.firstName} ${record.lastName}`.trim(),
+    },
+    { title: "Email", dataIndex: "email", key: "email", render: (email: string) => <a href={`mailto:${email}`}><MailOutlined /> {email}</a> },
+    { title: "Phone", dataIndex: "phoneNumber", key: "phoneNumber", render: (phone: string) => phone ? <a href={`tel:${phone}`}><PhoneOutlined /> {phone}</a> : "Not set" },
+    { title: "Role", dataIndex: "position", key: "position", render: (role: string) => <Tag>{role}</Tag> },
+    {
+      title: "Actions",
+      key: "actions",
+      render: (_: unknown, record: IContact) => (
+        <Space>
+          <Button type="text" icon={<EditOutlined />} onClick={() => setEditingContact(record)} size="small" />
+          <Button type="text" danger icon={<DeleteOutlined />} onClick={() => deleteContact(record.id)} size="small" />
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <Typography.Title level={4} className="!m-0">Contacts ({contacts.length})</Typography.Title>
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => setIsModalOpen(true)}>Add Contact</Button>
+      </div>
+      <AnimatedDashboardTable
+        columns={columns}
+        dataSource={contacts}
+        emptyDescription="No contacts yet"
+        isBusy={isSubmitting}
+        rowKey="id"
+      />
+      <ContactForm
+        editingContact={editingContact}
+        isOpen={isModalOpen || editingContact !== null}
+        isSubmitting={isSubmitting}
+        onClose={() => {
+          setIsModalOpen(false);
+          setEditingContact(null);
+        }}
+        onSave={async (contact) => {
+          setIsSubmitting(true);
+
+          try {
+            if (editingContact) {
+              await updateContact(editingContact.id, contact);
+            } else {
+              await addContact({
+                clientId: contact.clientId ?? "",
+                createdAt: new Date().toISOString(),
+                email: contact.email ?? "",
+                firstName: contact.firstName ?? "",
+                id: crypto.randomUUID(),
+                isPrimaryContact: Boolean(contact.isPrimaryContact),
+                lastName: contact.lastName ?? "",
+                phoneNumber: contact.phoneNumber,
+                position: contact.position ?? "",
+              });
+            }
+
+            setIsModalOpen(false);
+            setEditingContact(null);
+          } finally {
+            setIsSubmitting(false);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/components/dashboard/dashboard-frame.tsx
+++ b/components/dashboard/dashboard-frame.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { LogoutOutlined, MenuFoldOutlined, MenuUnfoldOutlined } from "@ant-design/icons";
+import { Button, Layout, Menu, Space, Tag, Typography } from "antd";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+import { getSessionToken } from "@/lib/client/backend-api";
+import { getPrimaryUserRole, getUserRoleLabel, isManagerRole } from "@/lib/auth/roles";
+import { dashboardNavItems } from "@/constants/dashboard-nav";
+import { canAccessDashboardPath, DASHBOARD_HOME_PATH } from "@/lib/auth/dashboard-access";
+import { useAuthActions, useAuthState } from "@/providers/authProvider";
+import { type UserRole } from "@/providers/salesTypes";
+import { BoxfusionLogo } from "./boxfusion-logo";
+
+const { Content, Header } = Layout;
+
+type DashboardFrameProps = Readonly<{
+  children: React.ReactNode;
+}>;
+
+export function DashboardFrame({ children }: DashboardFrameProps) {
+  const [collapsed, setCollapsed] = useState(false);
+  const pathname = usePathname();
+  const router = useRouter();
+  const { logout } = useAuthActions();
+  const { isAuthenticated, isPending, user } = useAuthState();
+  const activeRole: UserRole = getPrimaryUserRole(user?.roles);
+  const activeNavItem = dashboardNavItems.find((item) => item.key === pathname);
+  const headerTitle = activeNavItem?.headerTitle ?? "Sales command center";
+  const headerDescription =
+    activeNavItem?.description ??
+    "Track pipeline movement, workload, and the next actions that need attention.";
+
+  const menuItems = useMemo(
+    () =>
+      dashboardNavItems
+        .filter((item) => item.access.includes(activeRole))
+        .map((item) => ({
+          icon: <item.icon />,
+          key: item.key,
+          label: <Link href={item.href}>{item.label}</Link>,
+        })),
+    [activeRole],
+  );
+
+  useEffect(() => {
+    if (isPending) {
+      return;
+    }
+
+    if (!isAuthenticated && !getSessionToken()) {
+      router.replace("/login");
+      return;
+    }
+
+    if (isAuthenticated && !canAccessDashboardPath(pathname, activeRole)) {
+      router.replace(DASHBOARD_HOME_PATH);
+    }
+  }, [activeRole, isAuthenticated, isPending, pathname, router]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (window.innerWidth < 1024) {
+      const timer = window.setTimeout(() => {
+        setCollapsed(true);
+      }, 0);
+
+      return () => window.clearTimeout(timer);
+    }
+  }, [pathname]);
+
+  return (
+    <div className="dashboard-shell">
+      <div
+        aria-hidden={collapsed}
+        className={`dashboard-sidebar ${collapsed ? "dashboard-sidebar--collapsed" : ""}`}
+      >
+        <div className="flex h-screen flex-col overflow-hidden bg-[#1f365c]">
+          <div className="flex items-center gap-3 border-b border-white/10 px-6 py-5">
+            <BoxfusionLogo size={38} />
+            <div className="min-w-0">
+              <Typography.Title className="!mb-0 !text-lg !text-white" level={4}>
+                AutoSales
+              </Typography.Title>
+              <Typography.Text className="!text-slate-300">
+                Sales workflow hub
+              </Typography.Text>
+            </div>
+          </div>
+
+          <Menu
+            className="min-h-0 flex-1 overflow-y-auto border-0 bg-transparent px-3 py-4"
+            items={menuItems}
+            mode="inline"
+            selectedKeys={[pathname]}
+            theme="dark"
+          />
+
+          <div className="shrink-0 space-y-3 border-t border-white/10 px-5 py-5">
+            <div className="space-y-1">
+              <Typography.Text className="block font-medium !text-white">
+                {user?.firstName ?? "Team member"} {user?.lastName ?? ""}
+              </Typography.Text>
+              <Typography.Text className="block !text-slate-300">
+                {user?.email ?? "No active session"}
+              </Typography.Text>
+              <Tag color={isManagerRole(activeRole) ? "#f28c28" : "#4f7cac"}>
+                {getUserRoleLabel(activeRole)}
+              </Tag>
+            </div>
+            <Button block icon={<LogoutOutlined />} onClick={() => void logout()}>
+              Sign out
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <button
+        aria-hidden={collapsed}
+        aria-label="Close sidebar"
+        className={`dashboard-sidebar-backdrop ${collapsed ? "dashboard-sidebar-backdrop--hidden" : ""}`}
+        onClick={() => setCollapsed(true)}
+        type="button"
+      />
+
+      <Layout className={`dashboard-main ${collapsed ? "dashboard-main--expanded" : ""}`}>
+        <Header className="sticky top-0 z-30 flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 bg-[#1f365c] px-4 py-3 md:px-6">
+          <Space align="center" className="min-w-0">
+            <Button
+              className="!text-white hover:!text-[#f7b267]"
+              icon={collapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
+              onClick={() => setCollapsed((value) => !value)}
+              type="text"
+            />
+            <div className="min-w-0">
+              <Typography.Title
+                className="!mb-0 truncate !text-base !text-white"
+                level={5}
+              >
+                {headerTitle}
+              </Typography.Title>
+              <Typography.Text className="block max-w-full truncate !text-slate-300">
+                {headerDescription}
+              </Typography.Text>
+            </div>
+          </Space>
+          <Tag color="#f28c28">{activeNavItem?.label ?? "Overview"}</Tag>
+        </Header>
+
+        <Content className="p-4 md:p-6">{children}</Content>
+      </Layout>
+    </div>
+  );
+}

--- a/components/dashboard/dashboard-metrics.tsx
+++ b/components/dashboard/dashboard-metrics.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { Card, Col, Row, Statistic, Tag, Typography } from "antd";
+
+import { getOpenPipelineValue, getOpportunityInsights } from "@/providers/salesSelectors";
+import { useDashboardState } from "@/providers/dashboardProvider";
+import { OpportunityPriorityQueue } from "./opportunity-priority-queue";
+import { PriorityAdvisor } from "./priority-advisor";
+import { ReassignmentSimulator } from "./reassignment-simulator";
+import { TeamCapacityPanel } from "./team-capacity-panel";
+
+export const DashboardMetrics = () => {
+  const { salesData, automationFeed } = useDashboardState();
+  const insights = getOpportunityInsights(salesData);
+  const topDeal = insights[0];
+  const submittedProposals = salesData.proposals.filter(
+    (proposal) => String(proposal.status) === "Submitted",
+  ).length;
+  const draftProposals = salesData.proposals.filter(
+    (proposal) => String(proposal.status) === "Draft",
+  ).length;
+  const activeFollowUps = salesData.activities.filter(
+    (activity) => !activity.completed && String(activity.status) !== "Completed",
+  ).length;
+  const pipelineValue = getOpenPipelineValue(salesData);
+
+  return (
+    <div className="space-y-6">
+      <Row gutter={[16, 16]}>
+        <Col xs={24} sm={12} xl={6}>
+          <Card className="h-full border-slate-200">
+            <Statistic
+              prefix="R "
+              precision={0}
+              title="Pipeline value"
+              value={pipelineValue}
+            />
+            <Typography.Text className="!text-slate-500">
+              All live opportunities in one total.
+            </Typography.Text>
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} xl={6}>
+          <Card className="h-full border-slate-200">
+            <Statistic title="Open opportunities" value={insights.length} />
+            <Typography.Text className="!text-slate-500">
+              Plain-language pipeline from New to Won.
+            </Typography.Text>
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} xl={6}>
+          <Card className="h-full border-slate-200">
+            <Statistic title="Proposal workload" value={submittedProposals} />
+            <div className="mt-2 flex flex-wrap gap-2">
+              <Tag color="#eab308">{draftProposals} draft</Tag>
+              <Tag color="#2563eb">{submittedProposals} submitted</Tag>
+            </div>
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} xl={6}>
+          <Card className="h-full border-slate-200">
+            <Statistic title="Follow-ups due" value={activeFollowUps} />
+            <Typography.Text className="!text-slate-500">
+              Generated and tracked against each deal.
+            </Typography.Text>
+          </Card>
+        </Col>
+      </Row>
+
+      {topDeal ? (
+        <Card className="border-slate-200 bg-[linear-gradient(135deg,_#eef3f8,_#fff7ed)]">
+          <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+            <div className="min-w-0 space-y-2">
+              <Tag color="#f97316">Top priority</Tag>
+              <Typography.Title className="!mb-0" level={3}>
+                {topDeal.opportunity.title}
+              </Typography.Title>
+              <Typography.Paragraph className="!mb-0 !text-slate-600">
+                {topDeal.summary} Owner: {topDeal.owner?.name ?? "Auto-pick pending"}.
+              </Typography.Paragraph>
+            </div>
+            <div className="grid w-full gap-3 sm:grid-cols-2 2xl:grid-cols-3 xl:max-w-2xl">
+              <div className="rounded-2xl bg-white px-4 py-3">
+                <Typography.Text className="!text-slate-500">Money weight</Typography.Text>
+                <Typography.Title className="!mb-0" level={4}>
+                  {topDeal.moneyWeight}
+                </Typography.Title>
+              </div>
+              <div className="rounded-2xl bg-white px-4 py-3">
+                <Typography.Text className="!text-slate-500">Deadline weight</Typography.Text>
+                <Typography.Title className="!mb-0" level={4}>
+                  {topDeal.deadlineWeight}
+                </Typography.Title>
+              </div>
+              <div className="rounded-2xl bg-white px-4 py-3">
+                <Typography.Text className="!text-slate-500">Priority score</Typography.Text>
+                <Typography.Title className="!mb-0" level={4}>
+                  {topDeal.score}
+                </Typography.Title>
+              </div>
+            </div>
+          </div>
+        </Card>
+      ) : null}
+
+      <Row gutter={[16, 16]}>
+        <Col className="min-w-0" xs={24} xxl={14}>
+          <OpportunityPriorityQueue />
+        </Col>
+        <Col className="min-w-0" xs={24} xxl={10}>
+          <PriorityAdvisor />
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col className="min-w-0" xs={24} xxl={14}>
+          <TeamCapacityPanel />
+        </Col>
+        <Col className="min-w-0" xs={24} xxl={10}>
+          <ReassignmentSimulator />
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col className="min-w-0" xs={24}>
+          <Card className="h-full" title="Automation feed">
+            <div className="space-y-4">
+              {automationFeed.map((event) => (
+                <div
+                  className="min-w-0 rounded-2xl border border-slate-200 bg-slate-50 p-4"
+                  key={event.id}
+                >
+                  <Typography.Text className="break-words" strong>
+                    {event.title}
+                  </Typography.Text>
+                  <Typography.Paragraph className="!mb-0 !mt-1 !text-slate-500">
+                    {event.description}
+                  </Typography.Paragraph>
+                </div>
+              ))}
+            </div>
+          </Card>
+        </Col>
+      </Row>
+    </div>
+  );
+};

--- a/components/dashboard/documents-panel.tsx
+++ b/components/dashboard/documents-panel.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Button, Empty, Form, Input, Modal, Space, Table, Tag, Typography } from "antd";
+import { DeleteOutlined, DownloadOutlined, PlusOutlined } from "@ant-design/icons";
+import { useState } from "react";
+
+import { type IDocumentItem } from "@/providers/domainSeeds";
+import { useDocumentActions, useDocumentState } from "@/providers/documentProvider";
+
+type DocumentFormValues = {
+  fileName: string;
+  fileType: string;
+};
+
+export function DocumentsPanel() {
+  const { documents } = useDocumentState();
+  const { addDocument, deleteDocument } = useDocumentActions();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [form] = Form.useForm<DocumentFormValues>();
+
+  const handleUpload = (values: DocumentFormValues) => {
+    addDocument({
+      id: Date.now().toString(),
+      name: values.fileName,
+      size: "1.0 MB",
+      type: values.fileType,
+      uploadedDate: new Date().toISOString().split("T")[0],
+    });
+    setIsModalOpen(false);
+    form.resetFields();
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <Typography.Title className="!m-0" level={4}>
+          Documents ({documents.length})
+        </Typography.Title>
+        <Button icon={<PlusOutlined />} onClick={() => setIsModalOpen(true)} type="primary">
+          Upload document
+        </Button>
+      </div>
+      {documents.length === 0 ? (
+        <Empty description="No documents yet" />
+      ) : (
+        <Table
+          columns={[
+            { dataIndex: "name", key: "name", title: "File name" },
+            {
+              dataIndex: "type",
+              key: "type",
+              render: (type: string) => <Tag color="#355c7d">{type}</Tag>,
+              title: "Type",
+            },
+            { dataIndex: "uploadedDate", key: "uploadedDate", title: "Uploaded" },
+            { dataIndex: "size", key: "size", title: "Size" },
+            {
+              key: "actions",
+              render: (_: unknown, record: IDocumentItem) => (
+                <Space>
+                  <Button icon={<DownloadOutlined />} size="small" type="text" />
+                  <Button
+                    danger
+                    icon={<DeleteOutlined />}
+                    onClick={() => deleteDocument(record.id)}
+                    size="small"
+                    type="text"
+                  />
+                </Space>
+              ),
+              title: "Actions",
+            },
+          ]}
+          dataSource={documents}
+          pagination={false}
+          rowKey="id"
+        />
+      )}
+      <Modal
+        onCancel={() => setIsModalOpen(false)}
+        onOk={() => form.submit()}
+        open={isModalOpen}
+        title="Upload document"
+      >
+        <Form className="pt-4" form={form} layout="vertical" onFinish={handleUpload}>
+          <Form.Item label="File name" name="fileName" rules={[{ required: true }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item label="File type" name="fileType" rules={[{ required: true }]}>
+            <Input placeholder="e.g., PDF, DOCX, XLSX" />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  );
+}

--- a/components/dashboard/draft-storage.ts
+++ b/components/dashboard/draft-storage.ts
@@ -1,0 +1,18 @@
+export const ASSISTANT_PANEL_DRAFT_KEY = "autosales:draft:assistant-panel";
+export const ASSISTANT_PANEL_MESSAGES_KEY = "autosales:draft:assistant-panel:messages";
+export const PRIORITY_ADVISOR_DRAFT_KEY = "autosales:draft:priority-advisor";
+
+export const getClientFormDraftKey = (clientId?: string | null) =>
+  clientId
+    ? `autosales:draft:client-form:edit:${clientId}`
+    : "autosales:draft:client-form:new";
+
+export const getOpportunityFormDraftKey = (opportunityId?: string | null) =>
+  opportunityId
+    ? `autosales:draft:opportunity-form:edit:${opportunityId}`
+    : "autosales:draft:opportunity-form:new";
+
+export const getProposalFormDraftKey = (proposalId?: string | null) =>
+  proposalId
+    ? `autosales:draft:proposal-form:edit:${proposalId}`
+    : "autosales:draft:proposal-form:new";

--- a/components/dashboard/kanban-board.tsx
+++ b/components/dashboard/kanban-board.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { Button, Card, Space, Typography } from "antd";
+import { DeleteOutlined, EditOutlined } from "@ant-design/icons";
+import { useMemo, useState } from "react";
+
+interface KanbanItem {
+  id: string;
+  metadata?: Record<string, string>;
+  stage: string;
+  title: string;
+  value?: number;
+}
+
+interface KanbanBoardProps {
+  items: KanbanItem[];
+  stages: readonly string[] | string[];
+  stageColors: Record<string, string>;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
+  onStageChange?: (itemId: string, newStage: string) => void;
+  title?: string;
+}
+
+export function KanbanBoard({
+  items,
+  stages,
+  stageColors,
+  onEdit,
+  onDelete,
+  onStageChange,
+  title = "Kanban Board",
+}: KanbanBoardProps) {
+  const [draggedItem, setDraggedItem] = useState<KanbanItem | null>(null);
+  const [dragOverStage, setDragOverStage] = useState<string | null>(null);
+
+  const groupedItems = useMemo(() => {
+    const grouped: Record<string, KanbanItem[]> = {};
+    stages.forEach((stage) => {
+      grouped[stage] = items.filter((item) => item.stage === stage);
+    });
+    return grouped;
+  }, [items, stages]);
+
+  return (
+    <Card
+      className="dashboard-table-card dashboard-kanban-card border-slate-200"
+      styles={{ body: { padding: 20 } }}
+      title={title}
+      extra={
+        <Typography.Text className="!text-slate-500">
+          Drag cards to update the automated pipeline.
+        </Typography.Text>
+      }
+    >
+      <div className="dashboard-kanban-scroll">
+        {stages.map((stage) => (
+          <div
+            className="dashboard-kanban-lane"
+            key={stage}
+            onDragLeave={() => setDragOverStage(null)}
+            onDragOver={(event) => {
+              event.preventDefault();
+              setDragOverStage(stage);
+            }}
+            onDrop={() => {
+              if (draggedItem && draggedItem.stage !== stage) {
+                onStageChange?.(draggedItem.id, stage);
+              }
+              setDraggedItem(null);
+              setDragOverStage(null);
+            }}
+          >
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <span
+                  className="h-3 w-3 rounded-full"
+                  style={{ backgroundColor: stageColors[stage] ?? "#94a3b8" }}
+                />
+                <Typography.Text strong>{stage}</Typography.Text>
+              </div>
+              <span className="rounded-full bg-slate-200 px-2.5 py-1 text-xs font-semibold text-slate-600">
+                {groupedItems[stage]?.length ?? 0}
+              </span>
+            </div>
+
+            <div
+              className={`dashboard-kanban-lane-body transition ${
+                dragOverStage === stage
+                  ? "dashboard-kanban-lane-body--active"
+                  : ""
+              }`}
+            >
+              <div className="space-y-3">
+                {(groupedItems[stage] ?? []).map((item) => (
+                  <div
+                    className="dashboard-kanban-card-item cursor-grab"
+                    draggable
+                    key={item.id}
+                    onDragEnd={() => setDraggedItem(null)}
+                    onDragStart={() => setDraggedItem(item)}
+                  >
+                    <div
+                      className="mb-3 h-1.5 rounded-full"
+                      style={{ backgroundColor: stageColors[stage] ?? "#94a3b8" }}
+                    />
+                    <Typography.Title className="!mb-1 !text-sm !leading-5" level={5}>
+                      {item.title}
+                    </Typography.Title>
+                    {item.value ? (
+                      <Typography.Text className="!text-sm !font-semibold !text-orange-500">
+                        R {item.value.toLocaleString()}
+                      </Typography.Text>
+                    ) : null}
+                    {item.metadata ? (
+                      <div className="mt-3 space-y-1.5">
+                        {Object.entries(item.metadata).map(([key, value]) => (
+                          <div className="flex items-start justify-between gap-3" key={key}>
+                            <Typography.Text className="min-w-0 !text-[11px] !font-semibold !uppercase !tracking-[0.08em] !text-slate-400">
+                              {key}
+                            </Typography.Text>
+                            <Typography.Text className="min-w-0 flex-1 break-words text-right !text-xs !text-slate-600">
+                              {value}
+                            </Typography.Text>
+                          </div>
+                        ))}
+                      </div>
+                    ) : null}
+                    <Space className="!mt-4 w-full justify-between">
+                      <Button
+                        icon={<EditOutlined />}
+                        onClick={() => onEdit(item.id)}
+                        size="small"
+                        type="text"
+                      />
+                      <Button
+                        danger
+                        icon={<DeleteOutlined />}
+                        onClick={() => onDelete(item.id)}
+                        size="small"
+                        type="text"
+                      />
+                    </Space>
+                  </div>
+                ))}
+
+                {!groupedItems[stage]?.length ? (
+                  <div className="dashboard-kanban-empty-state">
+                    <span>Drop cards here</span>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/components/dashboard/module-placeholder.tsx
+++ b/components/dashboard/module-placeholder.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Card, Col, Empty, Row, Tag, Typography } from "antd";
+
+type ModulePlaceholderProps = {
+  description: string;
+  title: string;
+};
+
+export function ModulePlaceholder({
+  description,
+  title,
+}: ModulePlaceholderProps) {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Tag color="blue">AutoSales Module</Tag>
+        <Typography.Title className="!mb-0" level={2}>
+          {title}
+        </Typography.Title>
+        <Typography.Paragraph className="!mb-0 max-w-3xl !text-slate-500">
+          {description}
+        </Typography.Paragraph>
+      </div>
+
+      <Row gutter={[16, 16]}>
+        <Col span={24} xl={16}>
+          <Card>
+            <Empty
+              description={`${title} is ready for its dedicated workflows, filters, and day-to-day actions.`}
+            />
+          </Card>
+        </Col>
+        <Col span={24} xl={8}>
+          <Card title="Coming next">
+            <Typography.Paragraph className="!mb-0 !text-slate-500">
+              This area is set up for a fuller working view with the right tools and records for this part of the sales cycle.
+            </Typography.Paragraph>
+          </Card>
+        </Col>
+      </Row>
+    </div>
+  );
+}

--- a/components/dashboard/notes-panel.tsx
+++ b/components/dashboard/notes-panel.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { Button, Empty, Form, Input, Modal, Space, Table, Tag, Typography } from "antd";
+import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
+import { useEffect, useState } from "react";
+
+import { type INoteItem } from "@/providers/domainSeeds";
+import { useNoteActions, useNoteState } from "@/providers/noteProvider";
+
+type NoteFormValues = {
+  category: string;
+  content: string;
+  title: string;
+};
+
+export function NotesPanel() {
+  const { notes } = useNoteState();
+  const { addNote, deleteNote, updateNote } = useNoteActions();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form] = Form.useForm<NoteFormValues>();
+
+  useEffect(() => {
+    if (!editingId) {
+      form.resetFields();
+      return;
+    }
+
+    const note = notes.find((item) => item.id === editingId);
+    if (note) {
+      form.setFieldsValue({
+        category: note.category,
+        content: note.content,
+        title: note.title,
+      });
+    }
+  }, [editingId, form, notes]);
+
+  const handleSave = (values: NoteFormValues) => {
+    if (editingId) {
+      updateNote(editingId, values);
+    } else {
+      addNote({
+        ...values,
+        createdDate: new Date().toISOString().split("T")[0],
+        id: Date.now().toString(),
+      });
+    }
+
+    setIsModalOpen(false);
+    setEditingId(null);
+    form.resetFields();
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <Typography.Title className="!m-0" level={4}>
+          Notes ({notes.length})
+        </Typography.Title>
+        <Button icon={<PlusOutlined />} onClick={() => setIsModalOpen(true)} type="primary">
+          Add note
+        </Button>
+      </div>
+      {notes.length === 0 ? (
+        <Empty description="No notes yet" />
+      ) : (
+        <Table
+          columns={[
+            { dataIndex: "title", key: "title", title: "Title" },
+            { dataIndex: "content", key: "content", title: "Content" },
+            {
+              dataIndex: "category",
+              key: "category",
+              render: (category: string) => <Tag color="#355c7d">{category}</Tag>,
+              title: "Category",
+            },
+            { dataIndex: "createdDate", key: "createdDate", title: "Date" },
+            {
+              key: "actions",
+              render: (_: unknown, record: INoteItem) => (
+                <Space>
+                  <Button
+                    icon={<EditOutlined />}
+                    onClick={() => {
+                      setEditingId(record.id);
+                      setIsModalOpen(true);
+                    }}
+                    size="small"
+                    type="text"
+                  />
+                  <Button
+                    danger
+                    icon={<DeleteOutlined />}
+                    onClick={() => deleteNote(record.id)}
+                    size="small"
+                    type="text"
+                  />
+                </Space>
+              ),
+              title: "Actions",
+            },
+          ]}
+          dataSource={notes}
+          pagination={false}
+          rowKey="id"
+        />
+      )}
+      <Modal
+        onCancel={() => {
+          setIsModalOpen(false);
+          setEditingId(null);
+        }}
+        onOk={() => form.submit()}
+        open={isModalOpen}
+        title={editingId ? "Edit note" : "Add note"}
+      >
+        <Form className="pt-4" form={form} layout="vertical" onFinish={handleSave}>
+          <Form.Item label="Title" name="title" rules={[{ required: true }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item label="Content" name="content" rules={[{ required: true }]}>
+            <Input.TextArea rows={4} />
+          </Form.Item>
+          <Form.Item label="Category" name="category" rules={[{ required: true }]}>
+            <Input />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  );
+}

--- a/components/dashboard/opportunities-panel.tsx
+++ b/components/dashboard/opportunities-panel.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { Button, Card, Col, Row, Statistic, Tag, Typography } from "antd";
+import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
+import { useState } from "react";
+
+import { formatCurrency, getOpenPipelineValue, getOpportunityInsights } from "@/providers/salesSelectors";
+import { OPPORTUNITY_STAGE_COLORS, OPPORTUNITY_STAGE_ORDER, type IOpportunity } from "@/providers/salesTypes";
+import { useClientState } from "@/providers/clientProvider";
+import { useDashboardState } from "@/providers/dashboardProvider";
+import { useOpportunityActions, useOpportunityState } from "@/providers/opportunityProvider";
+import { AnimatedDashboardTable } from "./animated-dashboard-table";
+import { KanbanBoard } from "./kanban-board";
+import { OpportunityForm } from "./opportunity-form";
+import { OpportunityPriorityQueue } from "./opportunity-priority-queue";
+
+export function OpportunitiesPanel() {
+  const { opportunities } = useOpportunityState();
+  const { deleteOpportunity, updateOpportunity } = useOpportunityActions();
+  const { clients } = useClientState();
+  const { salesData, teamMembers } = useDashboardState();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const insights = getOpportunityInsights(salesData);
+  const pipelineValue = getOpenPipelineValue(salesData);
+
+  const columns = [
+    {
+      dataIndex: "name",
+      key: "name",
+      title: "Opportunity",
+    },
+    {
+      key: "client",
+      render: (_: unknown, record: IOpportunity) =>
+        clients.find((client) => client.id === record.clientId)?.name ?? "Client pending",
+      title: "Client",
+    },
+    {
+      dataIndex: "value",
+      key: "value",
+      render: (value: number, record: IOpportunity) =>
+        formatCurrency(value ?? record.estimatedValue),
+      title: "Value",
+    },
+    {
+      dataIndex: "stage",
+      key: "stage",
+      render: (stage: string) => <Tag color={OPPORTUNITY_STAGE_COLORS[stage]}>{stage}</Tag>,
+      title: "Pipeline stage",
+    },
+    {
+      dataIndex: "probability",
+      key: "probability",
+      render: (probability: number) => `${probability}%`,
+      title: "Confidence",
+    },
+    {
+      dataIndex: "expectedCloseDate",
+      key: "expectedCloseDate",
+      title: "Target close",
+    },
+    {
+      key: "owner",
+      render: (_: unknown, record: IOpportunity) =>
+        teamMembers.find((member) => member.id === record.ownerId)?.name ??
+        "Auto-pick pending",
+      title: "Owner",
+    },
+    {
+      key: "actions",
+      render: (_: unknown, record: IOpportunity) => (
+        <div className="space-x-2">
+          <Button
+            icon={<EditOutlined />}
+            onClick={() => setEditingId(record.id)}
+            size="small"
+            type="text"
+          />
+          <Button
+            danger
+            icon={<DeleteOutlined />}
+            onClick={() => deleteOpportunity(record.id)}
+            size="small"
+            type="text"
+          />
+        </div>
+      ),
+      title: "Actions",
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="space-y-1">
+          <Typography.Title className="!m-0" level={4}>
+            Opportunities ({opportunities.length})
+          </Typography.Title>
+          <Typography.Text className="!text-slate-500">
+            New, Qualified, Proposal Sent, Negotiating, Won, and Lost are written for non-technical users.
+          </Typography.Text>
+        </div>
+        <Button icon={<PlusOutlined />} onClick={() => setIsModalOpen(true)} type="primary">
+          Add opportunity
+        </Button>
+      </div>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} md={12} xxl={6}>
+          <Card className="h-full border-slate-200">
+            <Statistic title="Live pipeline value" value={pipelineValue} prefix="R " precision={0} />
+            <Typography.Text className="!text-slate-500">
+              Updates as soon as a live opportunity is added or edited.
+            </Typography.Text>
+          </Card>
+        </Col>
+        <Col xs={24} md={12} xxl={6}>
+          <Card className="h-full border-slate-200">
+            <Statistic title="Live opportunities" value={insights.length} />
+            <Typography.Text className="!text-slate-500">
+              Won and lost deals are excluded from the active pipeline.
+            </Typography.Text>
+          </Card>
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col className="min-w-0" xs={24} xxl={10}>
+          <OpportunityPriorityQueue limit={6} />
+        </Col>
+        <Col className="min-w-0" xs={24} xxl={14}>
+          <div className="grid gap-3 md:grid-cols-2 2xl:grid-cols-3">
+            {insights.slice(0, 3).map((insight) => (
+              <div
+                className="min-w-0 rounded-3xl border border-slate-200 bg-white p-5 shadow-sm"
+                key={insight.opportunity.id}
+              >
+                <Tag color={OPPORTUNITY_STAGE_COLORS[String(insight.opportunity.stage)]}>
+                  {insight.priorityBand}
+                </Tag>
+                <Typography.Title className="!mb-1 !mt-3 break-words" level={5}>
+                  {insight.opportunity.title}
+                </Typography.Title>
+                <Typography.Paragraph className="!mb-3 !text-slate-500">
+                  {insight.summary}
+                </Typography.Paragraph>
+                <Typography.Text className="break-words !text-slate-600">
+                  Owner: {insight.owner?.name ?? "Auto-pick pending"}
+                </Typography.Text>
+              </div>
+            ))}
+          </div>
+        </Col>
+      </Row>
+
+      <KanbanBoard
+        items={opportunities.map((opportunity) => ({
+          id: opportunity.id,
+          metadata: {
+            client: clients.find((client) => client.id === opportunity.clientId)?.name ?? "Client pending",
+            owner:
+              teamMembers.find((member) => member.id === opportunity.ownerId)?.name ??
+              "Unassigned",
+          },
+          stage: String(opportunity.stage),
+          title: opportunity.name || opportunity.title,
+          value: opportunity.value || opportunity.estimatedValue,
+        }))}
+        onDelete={deleteOpportunity}
+        onEdit={(id) => setEditingId(id)}
+        onStageChange={(id, newStage) => updateOpportunity(id, { stage: newStage })}
+        stageColors={OPPORTUNITY_STAGE_COLORS}
+        stages={OPPORTUNITY_STAGE_ORDER}
+        title="Automated pipeline"
+      />
+
+      <AnimatedDashboardTable
+        columns={columns}
+        dataSource={opportunities}
+        emptyDescription="No opportunities yet"
+        isBusy={isSubmitting}
+        rowKey="id"
+      />
+
+      <OpportunityForm
+        editingId={editingId}
+        isOpen={isModalOpen || editingId !== null}
+        isSubmitting={isSubmitting}
+        onClose={() => {
+          setIsModalOpen(false);
+          setEditingId(null);
+        }}
+        onSubmitEnd={() => setIsSubmitting(false)}
+        onSubmitStart={() => setIsSubmitting(true)}
+      />
+    </div>
+  );
+}

--- a/components/dashboard/opportunity-form.tsx
+++ b/components/dashboard/opportunity-form.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { DatePicker, Form, Input, InputNumber, Modal, Select } from "antd";
+import dayjs from "dayjs";
+import { useEffect } from "react";
+
+import { clearSessionDraft, readSessionDraft, writeSessionDraft } from "@/lib/client/session-drafts";
+import { OPPORTUNITY_STAGE_ORDER, type IOpportunity } from "@/providers/salesTypes";
+import { useClientState } from "@/providers/clientProvider";
+import { useDashboardState } from "@/providers/dashboardProvider";
+import { useOpportunityActions, useOpportunityState } from "@/providers/opportunityProvider";
+import { getOpportunityFormDraftKey } from "./draft-storage";
+
+type OpportunityFormValues = {
+  clientId: string;
+  expectedCloseDate: dayjs.Dayjs;
+  ownerId?: string;
+  probability: number;
+  stage: string;
+  title: string;
+  value: number;
+};
+
+type PersistedOpportunityFormValues = Omit<Partial<OpportunityFormValues>, "expectedCloseDate"> & {
+  expectedCloseDate?: string;
+};
+
+interface OpportunityFormProps {
+  isOpen: boolean;
+  isSubmitting?: boolean;
+  editingId: string | null;
+  onClose: () => void;
+  onSubmitStart?: () => void;
+  onSubmitEnd?: () => void;
+}
+
+export function OpportunityForm({
+  isOpen,
+  isSubmitting = false,
+  editingId,
+  onClose,
+  onSubmitStart,
+  onSubmitEnd,
+}: OpportunityFormProps) {
+  const [form] = Form.useForm<OpportunityFormValues>();
+  const { clients } = useClientState();
+  const { teamMembers } = useDashboardState();
+  const { opportunities } = useOpportunityState();
+  const { addOpportunity, updateOpportunity } = useOpportunityActions();
+  const draftKey = getOpportunityFormDraftKey(editingId);
+
+  useEffect(() => {
+    const savedDraft = readSessionDraft<PersistedOpportunityFormValues>(draftKey);
+
+    if (editingId) {
+      const opportunity = opportunities.find((item) => item.id === editingId);
+      if (opportunity) {
+        form.setFieldsValue({
+          ...opportunity,
+          expectedCloseDate: dayjs(opportunity.expectedCloseDate),
+          value: opportunity.value ?? opportunity.estimatedValue,
+        });
+      }
+    } else {
+      form.resetFields();
+    }
+
+    if (savedDraft) {
+      form.setFieldsValue({
+        ...savedDraft,
+        expectedCloseDate: savedDraft.expectedCloseDate
+          ? dayjs(savedDraft.expectedCloseDate)
+          : undefined,
+      });
+    }
+  }, [draftKey, editingId, form, isOpen, opportunities]);
+
+  const handleSubmit = async (values: OpportunityFormValues) => {
+    onSubmitStart?.();
+
+    const data: IOpportunity = {
+      clientId: values.clientId,
+      createdDate:
+        editingId
+          ? opportunities.find((item) => item.id === editingId)?.createdDate ??
+            new Date().toISOString().split("T")[0]
+          : new Date().toISOString().split("T")[0],
+      currency: "ZAR",
+      estimatedValue: values.value,
+      expectedCloseDate: values.expectedCloseDate.format("YYYY-MM-DD"),
+      id: editingId || Date.now().toString(),
+      name: values.title,
+      ownerId: values.ownerId,
+      probability: values.probability,
+      source: 1,
+      stage: values.stage,
+      title: values.title,
+      value: values.value,
+    };
+
+    try {
+      if (editingId) {
+        await updateOpportunity(editingId, data);
+      } else {
+        await addOpportunity(data);
+      }
+
+      clearSessionDraft(draftKey);
+      onClose();
+      form.resetFields();
+    } finally {
+      onSubmitEnd?.();
+    }
+  };
+
+  return (
+    <Modal
+      onCancel={onClose}
+      onOk={() => form.submit()}
+      okButtonProps={{ loading: isSubmitting }}
+      open={isOpen}
+      title={editingId ? "Edit opportunity" : "Add opportunity"}
+    >
+      <Form
+        className="pt-4"
+        form={form}
+        layout="vertical"
+        onFinish={handleSubmit}
+        onValuesChange={(_, allValues: Partial<OpportunityFormValues>) =>
+          writeSessionDraft(draftKey, {
+            ...allValues,
+            expectedCloseDate: allValues.expectedCloseDate
+              ? allValues.expectedCloseDate.format("YYYY-MM-DD")
+              : undefined,
+          } satisfies PersistedOpportunityFormValues)
+        }
+      >
+        <Form.Item
+          label="Opportunity name"
+          name="title"
+          rules={[{ message: "Please enter opportunity name", required: true }]}
+        >
+          <Input placeholder="e.g., Enterprise software rollout" />
+        </Form.Item>
+
+        <Form.Item
+          label="Client"
+          name="clientId"
+          rules={[{ message: "Please choose a client", required: true }]}
+        >
+          <Select
+            options={clients.map((client) => ({
+              label: client.name,
+              value: client.id,
+            }))}
+            placeholder="Select client"
+          />
+        </Form.Item>
+
+        <Form.Item
+          label="Value (R)"
+          name="value"
+          rules={[{ message: "Please enter value", required: true }]}
+        >
+          <InputNumber className="!w-full" min={0} prefix="R" />
+        </Form.Item>
+
+        <Form.Item
+          label="Pipeline stage"
+          name="stage"
+          rules={[{ message: "Please select stage", required: true }]}
+        >
+          <Select
+            options={OPPORTUNITY_STAGE_ORDER.map((stage) => ({
+              label: stage,
+              value: stage,
+            }))}
+          />
+        </Form.Item>
+
+        <Form.Item label="Owner" name="ownerId">
+          <Select
+            options={teamMembers.map((member) => ({
+              label: `${member.name} (${member.availabilityPercent}% free)`,
+              value: member.id,
+            }))}
+            placeholder="Select owner"
+          />
+        </Form.Item>
+
+        <Form.Item
+          label="Confidence (%)"
+          name="probability"
+          rules={[{ message: "Please enter probability", required: true }]}
+        >
+          <InputNumber className="!w-full" max={100} min={0} />
+        </Form.Item>
+
+        <Form.Item
+          label="Expected close date"
+          name="expectedCloseDate"
+          rules={[{ message: "Please select close date", required: true }]}
+        >
+          <DatePicker className="!w-full" />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/components/dashboard/opportunity-priority-queue.tsx
+++ b/components/dashboard/opportunity-priority-queue.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Card, Table, Tag, Typography } from "antd";
+
+import { PRIORITY_BAND_COLORS, type PriorityBand } from "@/providers/salesTypes";
+import { formatCurrency, getOpportunityInsights } from "@/providers/salesSelectors";
+import { useDashboardState } from "@/providers/dashboardProvider";
+
+type OpportunityPriorityQueueProps = {
+  limit?: number;
+};
+
+export function OpportunityPriorityQueue({
+  limit = 5,
+}: OpportunityPriorityQueueProps) {
+  const { salesData } = useDashboardState();
+  const insights = getOpportunityInsights(salesData).slice(0, limit);
+
+  return (
+    <Card
+      className="dashboard-table-card h-full"
+      title="Priority queue"
+      extra={
+        <Typography.Text className="block max-w-full !text-slate-500">
+          Ranked by money and deadline pressure
+        </Typography.Text>
+      }
+    >
+      <Table
+        className="dashboard-responsive-table"
+        columns={[
+          {
+            dataIndex: ["opportunity", "title"],
+            key: "opportunity",
+            title: "Opportunity",
+            width: 220,
+          },
+          {
+            key: "client",
+            render: (record) => record.client?.name ?? "Unassigned client",
+            title: "Client",
+            width: 180,
+          },
+          {
+            key: "priorityBand",
+            render: (priorityBand: PriorityBand) => (
+              <Tag color={PRIORITY_BAND_COLORS[priorityBand]}>{priorityBand}</Tag>
+            ),
+            title: "Priority",
+            dataIndex: "priorityBand",
+            width: 120,
+          },
+          {
+            key: "score",
+            title: "Score",
+            dataIndex: "score",
+            width: 90,
+          },
+          {
+            key: "value",
+            render: (_, record) =>
+              formatCurrency(
+                record.opportunity.value ?? record.opportunity.estimatedValue,
+              ),
+            title: "Value",
+            width: 130,
+          },
+          {
+            key: "daysToClose",
+            render: (daysToClose: number) =>
+              daysToClose <= 0 ? "Past due" : `${daysToClose} days`,
+            title: "Deadline",
+            dataIndex: "daysToClose",
+            width: 120,
+          },
+          {
+            key: "owner",
+            render: (_, record) => record.owner?.name ?? "Auto-pick pending",
+            title: "Owner",
+            width: 170,
+          },
+        ]}
+        dataSource={insights}
+        pagination={false}
+        rowKey={(record) => record.opportunity.id}
+        scroll={{ x: 1030 }}
+        size="small"
+        tableLayout="fixed"
+      />
+    </Card>
+  );
+}

--- a/components/dashboard/overview-panels.tsx
+++ b/components/dashboard/overview-panels.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Card, Tabs, Tag, Typography } from "antd";
+import { DashboardMetrics } from "./dashboard-metrics";
+import { OpportunitiesPanel } from "./opportunities-panel";
+import { ProposalsPanel } from "./proposals-panel";
+import { RenewalsPanel } from "./renewals-panel";
+import { ActivitiesPanel } from "./activities-panel";
+
+export function OverviewPanels() {
+  const tabs = [
+    {
+      key: "overview",
+      label: "Overview",
+      children: <DashboardMetrics />,
+    },
+    {
+      key: "opportunities",
+      label: "Opportunities",
+      children: <OpportunitiesPanel />,
+    },
+    {
+      key: "proposals",
+      label: "Proposals",
+      children: <ProposalsPanel />,
+    },
+    {
+      key: "renewals",
+      label: "Renewals",
+      children: <RenewalsPanel />,
+    },
+    {
+      key: "activities",
+      label: "Activities",
+      children: <ActivitiesPanel />,
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Tag color="geekblue">Dashboard</Tag>
+        <Typography.Title className="!mb-0" level={2}>
+          Sales automation overview
+        </Typography.Title>
+        <Typography.Paragraph className="!mb-0 max-w-3xl !text-slate-500">
+          Track pipeline movement, proposal throughput, renewals, and activities from one operational view.
+        </Typography.Paragraph>
+      </div>
+
+      <Card>
+        <Tabs defaultActiveKey="overview" items={tabs} />
+      </Card>
+    </div>
+  );
+}

--- a/components/dashboard/page-intro.tsx
+++ b/components/dashboard/page-intro.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Typography } from "antd";
+
+import { usePageModule } from "@/providers/pageProviders";
+
+export function PageIntro() {
+  const page = usePageModule();
+
+  return (
+    <div className="space-y-2">
+      <Typography.Title className="!mb-0 !text-slate-900" level={2}>
+        {page.title}
+      </Typography.Title>
+      <Typography.Paragraph className="!mb-0 max-w-3xl !text-slate-500">
+        {page.description}
+      </Typography.Paragraph>
+    </div>
+  );
+}

--- a/components/dashboard/pricing-requests-panel.tsx
+++ b/components/dashboard/pricing-requests-panel.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { Alert, Button, Form, Input, Modal, Select, Space, Tag, Typography, message } from "antd";
+import { CheckOutlined, DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
+import { useEffect, useState } from "react";
+
+import {
+  PRICING_REQUEST_STATUS_COLORS,
+  type IPricingRequest,
+} from "@/providers/salesTypes";
+import { useDashboardState } from "@/providers/dashboardProvider";
+import { useOpportunityState } from "@/providers/opportunityProvider";
+import {
+  usePricingRequestActions,
+  usePricingRequestState,
+} from "@/providers/pricingRequestProvider";
+import { AnimatedDashboardTable } from "./animated-dashboard-table";
+
+type PricingRequestFormValues = {
+  assignedToId?: string;
+  description?: string;
+  opportunityId: string;
+  priority: number;
+  requiredByDate?: string;
+  title: string;
+};
+
+const PRIORITY_OPTIONS = [
+  { label: "Critical", value: 1 },
+  { label: "High", value: 2 },
+  { label: "Medium", value: 3 },
+  { label: "Low", value: 4 },
+];
+
+const formatDate = (value?: string) => value || "Not set";
+
+export function PricingRequestsPanel() {
+  const { pricingRequests } = usePricingRequestState();
+  const { teamMembers } = useDashboardState();
+  const { opportunities } = useOpportunityState();
+  const {
+    addPricingRequest,
+    completePricingRequest,
+    deletePricingRequest,
+    updatePricingRequest,
+  } = usePricingRequestActions();
+  const [messageApi, contextHolder] = message.useMessage();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [form] = Form.useForm<PricingRequestFormValues>();
+
+  useEffect(() => {
+    if (!editingId) {
+      form.resetFields();
+      return;
+    }
+
+    const request = pricingRequests.find((item) => item.id === editingId);
+
+    if (request) {
+      form.setFieldsValue({
+        assignedToId: request.assignedToId,
+        description: request.description,
+        opportunityId: request.opportunityId,
+        priority: request.priority,
+        requiredByDate: request.requiredByDate,
+        title: request.title,
+      });
+    }
+  }, [editingId, form, pricingRequests]);
+
+  const handleSave = async (values: PricingRequestFormValues) => {
+    setFormError(null);
+    setIsSaving(true);
+
+    try {
+      const existingRequest = pricingRequests.find((item) => item.id === editingId);
+      const opportunity = opportunities.find((item) => item.id === values.opportunityId);
+      const request: IPricingRequest = {
+        assignedToId: values.assignedToId,
+        assignedToName: teamMembers.find((member) => member.id === values.assignedToId)?.name,
+        createdAt: existingRequest?.createdAt ?? new Date().toISOString(),
+        description: values.description?.trim() || undefined,
+        id: editingId ?? Date.now().toString(),
+        opportunityId: values.opportunityId,
+        opportunityTitle: opportunity?.name || opportunity?.title,
+        priority: values.priority,
+        requiredByDate: values.requiredByDate,
+        status: existingRequest?.status ?? "Pending",
+        title: values.title.trim(),
+      };
+
+      if (editingId) {
+        await updatePricingRequest(editingId, request);
+        messageApi.success("Pricing request updated.");
+      } else {
+        await addPricingRequest(request);
+        messageApi.success("Pricing request created.");
+      }
+
+      setIsModalOpen(false);
+      setEditingId(null);
+      form.resetFields();
+    } catch (error) {
+      console.error(error);
+      setFormError(
+        error instanceof Error ? error.message : "Could not save the pricing request.",
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deletePricingRequest(id);
+      messageApi.success("Pricing request deleted.");
+    } catch (error) {
+      console.error(error);
+      messageApi.error(
+        error instanceof Error ? error.message : "Could not delete the pricing request.",
+      );
+    }
+  };
+
+  const handleComplete = async (id: string) => {
+    try {
+      await completePricingRequest(id);
+      messageApi.success("Pricing request marked complete.");
+    } catch (error) {
+      console.error(error);
+      messageApi.error(
+        error instanceof Error ? error.message : "Could not complete the pricing request.",
+      );
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {contextHolder}
+
+      <div className="flex items-center justify-between">
+        <div className="space-y-1">
+          <Typography.Title className="!m-0" level={4}>
+            Pricing requests ({pricingRequests.length})
+          </Typography.Title>
+          <Typography.Text className="!text-slate-500">
+            Track deal-desk coordination, assignees, deadlines, and completion before proposals go out.
+          </Typography.Text>
+        </div>
+        <Button icon={<PlusOutlined />} onClick={() => setIsModalOpen(true)} type="primary">
+          New request
+        </Button>
+      </div>
+
+      <AnimatedDashboardTable
+        columns={[
+          { dataIndex: "title", key: "title", title: "Request" },
+          {
+            key: "opportunity",
+            render: (_: unknown, record: IPricingRequest) =>
+              record.opportunityTitle ??
+              opportunities.find((opportunity) => opportunity.id === record.opportunityId)?.title ??
+              "Opportunity pending",
+            title: "Opportunity",
+          },
+          {
+            key: "owner",
+            render: (_: unknown, record: IPricingRequest) =>
+              record.assignedToName ?? "Unassigned",
+            title: "Assigned to",
+          },
+          {
+            key: "priority",
+            render: (_: unknown, record: IPricingRequest) =>
+              record.priorityLabel ??
+              PRIORITY_OPTIONS.find((option) => option.value === record.priority)?.label ??
+              "Priority",
+            title: "Priority",
+          },
+          {
+            dataIndex: "status",
+            key: "status",
+            render: (status: string) => (
+              <Tag color={PRICING_REQUEST_STATUS_COLORS[status] ?? "#94a3b8"}>{status}</Tag>
+            ),
+            title: "Status",
+          },
+          {
+            key: "requiredByDate",
+            render: (_: unknown, record: IPricingRequest) => formatDate(record.requiredByDate),
+            title: "Required by",
+          },
+          {
+            key: "createdAt",
+            render: (_: unknown, record: IPricingRequest) =>
+              formatDate(record.createdAt.split("T")[0]),
+            title: "Created",
+          },
+          {
+            key: "actions",
+            render: (_: unknown, record: IPricingRequest) => (
+              <Space wrap>
+                <Button
+                  icon={<EditOutlined />}
+                  onClick={() => {
+                    setEditingId(record.id);
+                    setIsModalOpen(true);
+                  }}
+                  size="small"
+                  type="text"
+                />
+                {record.status !== "Completed" ? (
+                  <Button
+                    icon={<CheckOutlined />}
+                    onClick={() => void handleComplete(record.id)}
+                    size="small"
+                  >
+                    Complete
+                  </Button>
+                ) : null}
+                <Button
+                  danger
+                  icon={<DeleteOutlined />}
+                  onClick={() => void handleDelete(record.id)}
+                  size="small"
+                  type="text"
+                />
+              </Space>
+            ),
+            title: "Actions",
+          },
+        ]}
+        dataSource={pricingRequests}
+        emptyDescription="No pricing requests"
+        isBusy={isSaving}
+        rowKey="id"
+      />
+
+      <Modal
+        onCancel={() => {
+          setFormError(null);
+          setIsModalOpen(false);
+          setEditingId(null);
+        }}
+        onOk={() => form.submit()}
+        okButtonProps={{ loading: isSaving }}
+        open={isModalOpen}
+        title={editingId ? "Edit pricing request" : "New pricing request"}
+      >
+        <Form className="pt-4" form={form} layout="vertical" onFinish={handleSave}>
+          <Form.Item
+            label="Opportunity"
+            name="opportunityId"
+            rules={[{ message: "Please select an opportunity", required: true }]}
+          >
+            <Select
+              options={opportunities.map((opportunity) => ({
+                label: opportunity.name || opportunity.title,
+                value: opportunity.id,
+              }))}
+              placeholder="Select the related opportunity"
+            />
+          </Form.Item>
+
+          <Form.Item
+            label="Request title"
+            name="title"
+            rules={[{ message: "Please enter a title", required: true }]}
+          >
+            <Input placeholder="e.g., Discount approval for enterprise scope" />
+          </Form.Item>
+
+          <Form.Item label="Commercial context" name="description">
+            <Input.TextArea
+              placeholder="What pricing review or exception is needed?"
+              rows={4}
+            />
+          </Form.Item>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <Form.Item
+              label="Priority"
+              name="priority"
+              rules={[{ message: "Please select a priority", required: true }]}
+            >
+              <Select options={PRIORITY_OPTIONS} />
+            </Form.Item>
+
+            <Form.Item label="Required by" name="requiredByDate">
+              <Input type="date" />
+            </Form.Item>
+
+            <Form.Item label="Assign to" name="assignedToId">
+              <Select
+                allowClear
+                options={teamMembers.map((member) => ({
+                  label: member.name,
+                  value: member.id,
+                }))}
+                placeholder="Choose a deal-desk owner"
+              />
+            </Form.Item>
+          </div>
+
+          {formError ? <Alert message={formError} type="error" /> : null}
+        </Form>
+      </Modal>
+    </div>
+  );
+}

--- a/components/dashboard/priority-advisor.tsx
+++ b/components/dashboard/priority-advisor.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Button, Card, Input, Typography } from "antd";
+import { useEffect, useMemo, useState } from "react";
+
+import { clearSessionDraft, readSessionDraft, writeSessionDraft } from "@/lib/client/session-drafts";
+import { getAdvisorResponse } from "@/providers/salesSelectors";
+import { useDashboardState } from "@/providers/dashboardProvider";
+import { PRIORITY_ADVISOR_DRAFT_KEY } from "./draft-storage";
+
+export function PriorityAdvisor() {
+  const { salesData } = useDashboardState();
+  const defaultResponse = useMemo(() => getAdvisorResponse(salesData), [salesData]);
+  const [prompt, setPrompt] = useState(() => readSessionDraft<string>(PRIORITY_ADVISOR_DRAFT_KEY) ?? "");
+  const [response, setResponse] = useState(defaultResponse);
+
+  useEffect(() => {
+    if (prompt) {
+      writeSessionDraft(PRIORITY_ADVISOR_DRAFT_KEY, prompt);
+      return;
+    }
+
+    clearSessionDraft(PRIORITY_ADVISOR_DRAFT_KEY);
+  }, [prompt]);
+
+  return (
+    <Card title="Sales advisor">
+      <div className="space-y-4">
+        <div className="rounded-2xl bg-slate-50 p-4">
+          <Typography.Text strong>Advisor</Typography.Text>
+          <Typography.Paragraph className="!mb-0 !mt-2 !text-slate-600">
+            {response}
+          </Typography.Paragraph>
+        </div>
+
+        <Input.TextArea
+          onChange={(event) => setPrompt(event.target.value)}
+          placeholder="Ask which sale to prioritize, who should own it, or what follow-up to do next."
+          rows={3}
+          value={prompt}
+        />
+
+        <div className="flex flex-wrap gap-3">
+          <Button onClick={() => setResponse(getAdvisorResponse(salesData, prompt))} type="primary">
+            Ask advisor
+          </Button>
+          <Button onClick={() => setResponse(getAdvisorResponse(salesData, "follow up"))}>
+            Best follow-up
+          </Button>
+          <Button onClick={() => setResponse(getAdvisorResponse(salesData, "assign owner"))}>
+            Best owner
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/components/dashboard/profile-panel.tsx
+++ b/components/dashboard/profile-panel.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Card, Descriptions, Tag, Typography } from "antd";
+
+import { getUserRoleLabel, isManagerRole, normalizeUserRole } from "@/lib/auth/roles";
+import { useProfileState } from "@/providers/profileProvider";
+
+export function ProfilePanel() {
+  const profile = useProfileState();
+  const role = normalizeUserRole(profile.role);
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <Typography.Title className="!m-0" level={4}>
+          Account profile
+        </Typography.Title>
+        <Typography.Text className="!text-slate-500">
+          View your account details and workspace access.
+        </Typography.Text>
+      </div>
+
+      <Card>
+        <Descriptions bordered column={1}>
+          <Descriptions.Item label="First name">
+            {profile.firstName}
+          </Descriptions.Item>
+          <Descriptions.Item label="Last name">
+            {profile.lastName}
+          </Descriptions.Item>
+          <Descriptions.Item label="Email">{profile.email}</Descriptions.Item>
+          <Descriptions.Item label="Role">
+            <Tag color={isManagerRole(role) ? "#f97316" : "#4f7cac"}>
+              {getUserRoleLabel(role)}
+            </Tag>
+          </Descriptions.Item>
+          <Descriptions.Item label="Organization">
+            {profile.workspace}
+          </Descriptions.Item>
+        </Descriptions>
+      </Card>
+    </div>
+  );
+}

--- a/components/dashboard/proposal-form.tsx
+++ b/components/dashboard/proposal-form.tsx
@@ -1,0 +1,379 @@
+"use client";
+
+import { Alert, Button, Form, Input, InputNumber, Modal, Select, Space, Spin, Tag, Typography } from "antd";
+import { MinusCircleOutlined, PlusOutlined } from "@ant-design/icons";
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  type BackendProposalDto,
+  backendRequest,
+  mapBackendProposal,
+} from "@/lib/client/backend-api";
+import { clearSessionDraft, readSessionDraft, writeSessionDraft } from "@/lib/client/session-drafts";
+import { PROPOSAL_STATUS_COLORS, ProposalStatus, type ILineItem, type IProposal } from "@/providers/salesTypes";
+import { useOpportunityState } from "@/providers/opportunityProvider";
+import { useProposalActions, useProposalState } from "@/providers/proposalProvider";
+import { getProposalFormDraftKey } from "./draft-storage";
+
+interface ProposalFormProps {
+  isOpen: boolean;
+  editingId: string | null;
+  onClose: () => void;
+}
+
+type ProposalFormValues = {
+  description?: string;
+  lineItems: Array<ILineItem>;
+  opportunityId: string;
+  title: string;
+  validUntil: string;
+};
+
+const createEmptyLineItem = (): ILineItem => ({
+  description: "",
+  discount: 0,
+  productServiceName: "",
+  quantity: 1,
+  taxRate: 15,
+  unitPrice: 0,
+});
+
+const getLineItemTotal = (item?: Partial<ILineItem>) => {
+  const quantity = Number(item?.quantity ?? 0);
+  const unitPrice = Number(item?.unitPrice ?? 0);
+  const discount = Number(item?.discount ?? 0);
+  const taxRate = Number(item?.taxRate ?? 0);
+  const discountedSubtotal = quantity * unitPrice * (1 - discount / 100);
+
+  return discountedSubtotal * (1 + taxRate / 100);
+};
+
+export function ProposalForm({ isOpen, editingId, onClose }: ProposalFormProps) {
+  const [form] = Form.useForm<ProposalFormValues>();
+  const { proposals } = useProposalState();
+  const { opportunities } = useOpportunityState();
+  const { addProposal, updateProposal } = useProposalActions();
+  const [isSaving, setIsSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const draftKey = getProposalFormDraftKey(editingId);
+
+  const watchedLineItems = Form.useWatch("lineItems", form);
+  const watchedTitle = Form.useWatch("title", form);
+  const editingProposal = proposals.find((item) => item.id === editingId) ?? null;
+  const proposalStatus = editingProposal ? String(editingProposal.status) : ProposalStatus.Draft;
+  const isLoadingProposal = Boolean(
+    editingId && !editingProposal?.lineItems?.length && !watchedTitle,
+  );
+
+  const proposalTotal = useMemo(
+    () =>
+      (watchedLineItems ?? []).reduce(
+        (sum, item) => sum + getLineItemTotal(item),
+        0,
+      ),
+    [watchedLineItems],
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    if (!editingId) {
+      const savedDraft = readSessionDraft<Partial<ProposalFormValues>>(draftKey);
+
+      form.resetFields();
+      form.setFieldsValue({
+        lineItems: savedDraft?.lineItems?.length
+          ? savedDraft.lineItems
+          : [createEmptyLineItem()],
+        ...savedDraft,
+      });
+      return;
+    }
+
+    let isActive = true;
+
+    const loadProposal = async () => {
+      const sourceProposal =
+        editingProposal?.lineItems && editingProposal.lineItems.length > 0
+          ? editingProposal
+          : mapBackendProposal(
+              await backendRequest<BackendProposalDto>(`/api/Proposals/${editingId}`),
+            );
+
+      if (!isActive) {
+        return;
+      }
+
+      const baseValues: ProposalFormValues = {
+        description: sourceProposal.description,
+        lineItems:
+          sourceProposal.lineItems && sourceProposal.lineItems.length > 0
+            ? sourceProposal.lineItems
+            : [createEmptyLineItem()],
+        opportunityId: sourceProposal.opportunityId,
+        title: sourceProposal.title,
+        validUntil: sourceProposal.validUntil,
+      };
+      const savedDraft = readSessionDraft<Partial<ProposalFormValues>>(draftKey);
+
+      form.setFieldsValue(savedDraft ? { ...baseValues, ...savedDraft } : baseValues);
+    };
+
+    void loadProposal().catch((error) => {
+      console.error(error);
+
+      if (!isActive) {
+        return;
+      }
+
+      setFormError(error instanceof Error ? error.message : "Could not load proposal details.");
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, [draftKey, editingId, editingProposal, form, isOpen]);
+
+  const handleSubmit = async (values: ProposalFormValues) => {
+    setIsSaving(true);
+    setFormError(null);
+
+    try {
+      const opportunity = opportunities.find((item) => item.id === values.opportunityId);
+      const lineItems = (values.lineItems ?? []).filter(
+        (item) => item.productServiceName.trim().length > 0,
+      );
+
+      if (lineItems.length === 0) {
+        throw new Error("Add at least one line item before saving the proposal.");
+      }
+
+      const data: IProposal = {
+        clientId: opportunity?.clientId ?? editingProposal?.clientId ?? "",
+        currency: editingProposal?.currency ?? "ZAR",
+        description: values.description?.trim() || undefined,
+        id: editingId || Date.now().toString(),
+        lineItems,
+        opportunityId: values.opportunityId,
+        status: editingProposal?.status ?? ProposalStatus.Draft,
+        title: values.title.trim(),
+        validUntil: values.validUntil,
+        value: proposalTotal,
+      };
+
+      if (editingId) {
+        await updateProposal(editingId, data);
+      } else {
+        await addProposal(data);
+      }
+
+      clearSessionDraft(draftKey);
+      onClose();
+      form.resetFields();
+    } catch (error) {
+      console.error(error);
+      setFormError(error instanceof Error ? error.message : "Could not save the proposal.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      onCancel={() => {
+        setFormError(null);
+        onClose();
+      }}
+      onOk={() => form.submit()}
+      okButtonProps={{ loading: isSaving }}
+      open={isOpen}
+      title={editingId ? "Edit proposal" : "Create proposal"}
+      width={920}
+    >
+      {isLoadingProposal ? (
+        <div className="flex items-center justify-center py-16">
+          <Spin />
+        </div>
+      ) : (
+        <Form
+          className="pt-4"
+          form={form}
+          layout="vertical"
+          onFinish={handleSubmit}
+          onValuesChange={(_, allValues) =>
+            writeSessionDraft(draftKey, allValues satisfies Partial<ProposalFormValues>)
+          }
+        >
+          <div className="grid gap-5 md:grid-cols-2">
+            <Form.Item
+              label="Opportunity"
+              name="opportunityId"
+              rules={[{ message: "Please select an opportunity", required: true }]}
+            >
+              <Select
+                disabled={Boolean(editingId)}
+                options={opportunities.map((opportunity) => ({
+                  label: opportunity.name || opportunity.title,
+                  value: opportunity.id,
+                }))}
+                placeholder="Select an opportunity"
+              />
+            </Form.Item>
+
+            <Form.Item
+              label="Valid until"
+              name="validUntil"
+              rules={[{ message: "Please enter the proposal validity date", required: true }]}
+            >
+              <Input type="date" />
+            </Form.Item>
+
+            <Form.Item
+              label="Proposal title"
+              name="title"
+              rules={[{ message: "Please enter a proposal title", required: true }]}
+            >
+              <Input placeholder="e.g., Enterprise commercial proposal" />
+            </Form.Item>
+
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+              <Typography.Text className="block !text-slate-500">
+                Current workflow status
+              </Typography.Text>
+              <div className="mt-2 flex items-center gap-2">
+                <Tag color={PROPOSAL_STATUS_COLORS[proposalStatus] ?? "#94a3b8"}>
+                  {proposalStatus}
+                </Tag>
+                <Typography.Text className="!text-slate-500">
+                  Use the workflow actions on the proposal board to submit, approve, or reject.
+                </Typography.Text>
+              </div>
+            </div>
+          </div>
+
+          <Form.Item label="Commercial context" name="description">
+            <Input.TextArea
+              placeholder="Summarize scope, assumptions, and commercial notes."
+              rows={4}
+            />
+          </Form.Item>
+
+          <div className="rounded-3xl border border-slate-200 bg-slate-50 p-4">
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <div>
+                <Typography.Title className="!mb-0" level={5}>
+                  Line items
+                </Typography.Title>
+                <Typography.Text className="!text-slate-500">
+                  Quantities, discounts, and tax roll into the proposal total automatically.
+                </Typography.Text>
+              </div>
+            </div>
+
+            <Form.List name="lineItems">
+              {(fields, { add, remove }) => (
+                <div className="space-y-4">
+                  {fields.map((field) => (
+                    <div
+                      className="rounded-2xl border border-slate-200 bg-white p-4"
+                      key={field.key}
+                    >
+                      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-6">
+                        <Form.Item
+                          hidden
+                          name={[field.name, "id"]}
+                        >
+                          <Input />
+                        </Form.Item>
+
+                        <Form.Item
+                          className="xl:col-span-2"
+                          label="Product or service"
+                          name={[field.name, "productServiceName"]}
+                          rules={[{ message: "Please enter a line item name", required: true }]}
+                        >
+                          <Input placeholder="e.g., Managed analytics" />
+                        </Form.Item>
+
+                        <Form.Item
+                          label="Qty"
+                          name={[field.name, "quantity"]}
+                          rules={[{ message: "Quantity is required", required: true }]}
+                        >
+                          <InputNumber className="!w-full" min={1} />
+                        </Form.Item>
+
+                        <Form.Item
+                          label="Unit price"
+                          name={[field.name, "unitPrice"]}
+                          rules={[{ message: "Unit price is required", required: true }]}
+                        >
+                          <InputNumber className="!w-full" min={0} prefix="R" />
+                        </Form.Item>
+
+                        <Form.Item label="Discount %" name={[field.name, "discount"]}>
+                          <InputNumber className="!w-full" max={100} min={0} />
+                        </Form.Item>
+
+                        <Form.Item label="Tax %" name={[field.name, "taxRate"]}>
+                          <InputNumber className="!w-full" max={100} min={0} />
+                        </Form.Item>
+                      </div>
+
+                      <div className="grid gap-4 md:grid-cols-[1fr_auto] md:items-end">
+                        <Form.Item
+                          className="!mb-0"
+                          label="Description"
+                          name={[field.name, "description"]}
+                        >
+                          <Input.TextArea
+                            placeholder="Optional notes for this line item"
+                            rows={2}
+                          />
+                        </Form.Item>
+
+                        <Space className="justify-between md:justify-end">
+                          <Typography.Text className="!text-slate-500">
+                            Total: R {getLineItemTotal(watchedLineItems?.[field.name]).toLocaleString()}
+                          </Typography.Text>
+                          <Button
+                            danger
+                            icon={<MinusCircleOutlined />}
+                            onClick={() => remove(field.name)}
+                          >
+                            Remove
+                          </Button>
+                        </Space>
+                      </div>
+                    </div>
+                  ))}
+
+                  <Button
+                    icon={<PlusOutlined />}
+                    onClick={() => add(createEmptyLineItem())}
+                    type="dashed"
+                  >
+                    Add line item
+                  </Button>
+                </div>
+              )}
+            </Form.List>
+          </div>
+
+          <div className="mt-5 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-orange-100 bg-orange-50 px-4 py-3">
+            <Typography.Text strong>Proposal total</Typography.Text>
+            <Typography.Text className="!text-lg !text-orange-600">
+              R {proposalTotal.toLocaleString()}
+            </Typography.Text>
+          </div>
+
+          {formError ? (
+            <Alert className="mt-4" message={formError} type="error" />
+          ) : null}
+        </Form>
+      )}
+    </Modal>
+  );
+}

--- a/components/dashboard/proposal-status-chart.tsx
+++ b/components/dashboard/proposal-status-chart.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { Card } from "antd";
+import { useMemo, useState } from "react";
+
+interface ProposalStatusChartProps {
+  proposals: Array<{ id: string; status: string; value: number }>;
+  statusColors: Record<string, string>;
+}
+
+export function ProposalStatusChart({ proposals, statusColors }: ProposalStatusChartProps) {
+  const [hoveredStatus, setHoveredStatus] = useState<string | null>(null);
+  const statusBreakdown = useMemo(() => {
+    const breakdown: Record<string, { count: number; value: number }> = {};
+    proposals.forEach((p) => {
+      if (!breakdown[p.status]) {
+        breakdown[p.status] = { count: 0, value: 0 };
+      }
+      breakdown[p.status].count++;
+      breakdown[p.status].value += p.value;
+    });
+    return breakdown;
+  }, [proposals]);
+
+  const total = proposals.length;
+  const totalValue = proposals.reduce((sum, p) => sum + p.value, 0);
+
+  // Simple SVG pie chart
+  const generatePieChart = () => {
+    const statuses = Object.keys(statusBreakdown);
+    if (statuses.length === 0) return null;
+
+    let currentAngle = -90; // Start from top
+    const cx = 150,
+      cy = 150,
+      r = 105;
+    const paths: Array<
+      | { color: string; path: string; status: string; type: "path" }
+      | { color: string; status: string; type: "circle" }
+    > = [];
+
+    statuses.forEach((status) => {
+      const slicePercent = statusBreakdown[status].count / total;
+      const sliceAngle = slicePercent * 360;
+      const color = statusColors[status] || "#94a3b8";
+
+      if (sliceAngle >= 359.999) {
+        paths.push({
+          color,
+          status,
+          type: "circle",
+        });
+        currentAngle += sliceAngle;
+        return;
+      }
+
+      const startAngle = currentAngle * (Math.PI / 180);
+      const endAngle = (currentAngle + sliceAngle) * (Math.PI / 180);
+
+      const x1 = cx + r * Math.cos(startAngle);
+      const y1 = cy + r * Math.sin(startAngle);
+      const x2 = cx + r * Math.cos(endAngle);
+      const y2 = cy + r * Math.sin(endAngle);
+
+      const largeArc = sliceAngle > 180 ? 1 : 0;
+
+      const path = `M ${cx} ${cy} L ${x1} ${y1} A ${r} ${r} 0 ${largeArc} 1 ${x2} ${y2} Z`;
+      paths.push({
+        path,
+        color,
+        status,
+        type: "path",
+      });
+
+      currentAngle += sliceAngle;
+    });
+
+    return (
+      <svg width="100%" height="300" viewBox="0 0 300 300" className="mx-auto">
+        {paths.map((p, i) => (
+          p.type === "circle" ? (
+            <circle
+              key={i}
+              cx={cx}
+              cy={cy}
+              r={r}
+              fill={p.color}
+              stroke="white"
+              strokeWidth="2"
+              opacity={hoveredStatus === null || hoveredStatus === p.status ? "0.8" : "0.3"}
+              onMouseEnter={() => setHoveredStatus(p.status)}
+              onMouseLeave={() => setHoveredStatus(null)}
+              className="cursor-pointer transition-opacity duration-200"
+            />
+          ) : (
+            <path
+              key={i}
+              d={p.path}
+              fill={p.color}
+              stroke="white"
+              strokeWidth="2"
+              opacity={hoveredStatus === null || hoveredStatus === p.status ? "0.8" : "0.3"}
+              onMouseEnter={() => setHoveredStatus(p.status)}
+              onMouseLeave={() => setHoveredStatus(null)}
+              className="cursor-pointer transition-opacity duration-200"
+            />
+          )
+        ))}
+        <circle cx={cx} cy={cy} r="58" fill="white" />
+        <text
+          x={cx}
+          y={cy}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          className="text-lg font-bold"
+        >
+          {total}
+        </text>
+      </svg>
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card title="Proposal Status Breakdown">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>{generatePieChart()}</div>
+
+          <div className="space-y-3">
+            <div className="space-y-2">
+              {Object.entries(statusBreakdown).map(([status, data]) => (
+                <div
+                  key={status}
+                  className="flex justify-between items-center px-3 py-2 rounded transition-all duration-200 cursor-pointer"
+                  style={{
+                    backgroundColor:
+                      hoveredStatus === null || hoveredStatus === status ? "transparent" : "#f5f5f5",
+                    opacity: hoveredStatus === null || hoveredStatus === status ? 1 : 0.4,
+                  }}
+                  onMouseEnter={() => setHoveredStatus(status)}
+                  onMouseLeave={() => setHoveredStatus(null)}
+                >
+                  <div className="flex items-center gap-2">
+                    <div
+                      className="w-3 h-3 rounded-full transition-all duration-200"
+                      style={{
+                        backgroundColor: statusColors[status] || "#94a3b8",
+                        boxShadow:
+                          hoveredStatus === status
+                            ? `0 0 8px ${statusColors[status] || "#94a3b8"}`
+                            : "none",
+                      }}
+                    />
+                    <span
+                      className="font-medium transition-colors duration-200"
+                      style={{
+                        fontWeight: hoveredStatus === status ? 700 : 500,
+                        color: hoveredStatus === status ? "#000" : "#666",
+                      }}
+                    >
+                      {status}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-4">
+                    <span className="text-sm font-medium">{data.count}</span>
+                    <span className="text-xs text-gray-500">
+                      ({((data.count / total) * 100).toFixed(0)}%)
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="border-t pt-3 mt-3">
+              <div className="flex justify-between">
+                <span>Total Value:</span>
+                <span className="font-semibold">R {totalValue.toLocaleString()}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/components/dashboard/proposals-panel.tsx
+++ b/components/dashboard/proposals-panel.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { Button, Input, Modal, Space, Tag, Typography, message } from "antd";
+import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
+import { useMemo, useState } from "react";
+
+import { OpportunityStage, PROPOSAL_STATUS_COLORS, ProposalStatus, type IProposal } from "@/providers/salesTypes";
+import { formatCurrency } from "@/providers/salesSelectors";
+import { useClientState } from "@/providers/clientProvider";
+import { useOpportunityActions } from "@/providers/opportunityProvider";
+import {
+  useProposalActions,
+  useProposalState,
+} from "@/providers/proposalProvider";
+import { AnimatedDashboardTable } from "./animated-dashboard-table";
+import { KanbanBoard } from "./kanban-board";
+import { ProposalForm } from "./proposal-form";
+import { ProposalStatusChart } from "./proposal-status-chart";
+
+const getOpportunityStageForProposal = (status: string) => {
+  if (status === ProposalStatus.Submitted) {
+    return OpportunityStage.ProposalSent;
+  }
+
+  if (status === ProposalStatus.Approved) {
+    return OpportunityStage.Won;
+  }
+
+  if (status === ProposalStatus.Rejected) {
+    return OpportunityStage.Lost;
+  }
+
+  return undefined;
+};
+
+export function ProposalsPanel() {
+  const { clients } = useClientState();
+  const { proposals } = useProposalState();
+  const { updateOpportunity } = useOpportunityActions();
+  const { deleteProposal, transitionProposal } = useProposalActions();
+  const [messageApi, contextHolder] = message.useMessage();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [rejectingProposalId, setRejectingProposalId] = useState<string | null>(null);
+  const [rejectReason, setRejectReason] = useState("");
+
+  const proposalById = useMemo(
+    () => new Map(proposals.map((proposal) => [proposal.id, proposal])),
+    [proposals],
+  );
+
+  const syncOpportunityStage = async (proposal: IProposal, status: string) => {
+    const nextStage = getOpportunityStageForProposal(status);
+
+    if (nextStage) {
+      await updateOpportunity(proposal.opportunityId, { stage: nextStage });
+    }
+  };
+
+  const handleTransition = async (
+    proposalId: string,
+    status: ProposalStatus | string,
+    decisionNote?: string,
+  ) => {
+    const proposal = proposalById.get(proposalId);
+
+    if (!proposal) {
+      return;
+    }
+
+    try {
+      const nextProposal = await transitionProposal(proposalId, status, decisionNote);
+
+      if (nextProposal) {
+        await syncOpportunityStage(nextProposal, String(nextProposal.status));
+      }
+
+      messageApi.success(`Proposal moved to ${status}.`);
+    } catch (error) {
+      console.error(error);
+      messageApi.error(
+        error instanceof Error ? error.message : "Could not update the proposal workflow.",
+      );
+    }
+  };
+
+  const handleDelete = async (proposalId: string) => {
+    try {
+      await deleteProposal(proposalId);
+      messageApi.success("Proposal deleted.");
+    } catch (error) {
+      console.error(error);
+      messageApi.error(
+        error instanceof Error ? error.message : "Could not delete the proposal.",
+      );
+    }
+  };
+
+  const handleStageChange = (proposalId: string, newStatus: string) => {
+    if (newStatus === ProposalStatus.Draft) {
+      messageApi.info("Draft is the starting state. Use Edit if you need to update the proposal content.");
+      return;
+    }
+
+    if (newStatus === ProposalStatus.Rejected) {
+      setRejectingProposalId(proposalId);
+      return;
+    }
+
+    void handleTransition(proposalId, newStatus);
+  };
+
+  const columns = [
+    {
+      dataIndex: "title",
+      key: "title",
+      title: "Proposal",
+    },
+    {
+      dataIndex: "status",
+      key: "status",
+      render: (status: string) => (
+        <Tag color={PROPOSAL_STATUS_COLORS[status] ?? "#94a3b8"}>{status}</Tag>
+      ),
+      title: "Status",
+    },
+    {
+      dataIndex: "value",
+      key: "value",
+      render: (value: number) => formatCurrency(value),
+      title: "Value",
+    },
+    {
+      key: "items",
+      render: (_: unknown, record: IProposal) =>
+        record.lineItemsCount ?? record.lineItems?.length ?? 0,
+      title: "Items",
+    },
+    {
+      dataIndex: "validUntil",
+      key: "validUntil",
+      title: "Valid until",
+    },
+    {
+      key: "workflow",
+      render: (_: unknown, record: IProposal) => {
+        const status = String(record.status);
+
+        return (
+          <Space wrap>
+            {status === ProposalStatus.Draft ? (
+              <Button onClick={() => void handleTransition(record.id, ProposalStatus.Submitted)}>
+                Submit
+              </Button>
+            ) : null}
+            {status === ProposalStatus.Submitted ? (
+              <>
+                <Button
+                  onClick={() => void handleTransition(record.id, ProposalStatus.Approved)}
+                  type="primary"
+                >
+                  Approve
+                </Button>
+                <Button danger onClick={() => setRejectingProposalId(record.id)}>
+                  Reject
+                </Button>
+              </>
+            ) : null}
+          </Space>
+        );
+      },
+      title: "Workflow",
+    },
+    {
+      key: "actions",
+      render: (_: unknown, record: IProposal) => (
+        <Space>
+          <Button
+            icon={<EditOutlined />}
+            onClick={() => setEditingId(record.id)}
+            size="small"
+            type="text"
+          />
+          <Button
+            danger
+            icon={<DeleteOutlined />}
+            onClick={() => void handleDelete(record.id)}
+            size="small"
+            type="text"
+          />
+        </Space>
+      ),
+      title: "Actions",
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      {contextHolder}
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="space-y-1">
+          <Typography.Title className="!m-0" level={4}>
+            Proposals ({proposals.length})
+          </Typography.Title>
+          <Typography.Text className="!text-slate-500">
+            Build structured commercials, then move them through draft, submission, approval, and rejection.
+          </Typography.Text>
+        </div>
+        <Button icon={<PlusOutlined />} onClick={() => setIsModalOpen(true)} type="primary">
+          Create proposal
+        </Button>
+      </div>
+
+      <ProposalStatusChart
+        proposals={proposals.map((proposal) => ({
+          id: proposal.id,
+          status: String(proposal.status),
+          value: proposal.value || 0,
+        }))}
+        statusColors={PROPOSAL_STATUS_COLORS}
+      />
+
+      <KanbanBoard
+        items={proposals.map((proposal) => ({
+          id: proposal.id,
+          metadata: {
+            client:
+              clients.find((client) => client.id === proposal.clientId)?.name ?? "Client pending",
+            items: String(proposal.lineItemsCount ?? proposal.lineItems?.length ?? 0),
+          },
+          stage: String(proposal.status),
+          title: proposal.title,
+          value: proposal.value || 0,
+        }))}
+        onDelete={(id) => void handleDelete(id)}
+        onEdit={(id) => setEditingId(id)}
+        onStageChange={handleStageChange}
+        stageColors={PROPOSAL_STATUS_COLORS}
+        stages={[
+          ProposalStatus.Draft,
+          ProposalStatus.Submitted,
+          ProposalStatus.Approved,
+          ProposalStatus.Rejected,
+        ]}
+        title="Proposal workflow"
+      />
+
+      <AnimatedDashboardTable
+        columns={columns}
+        dataSource={proposals}
+        emptyDescription="No proposals yet"
+        rowKey="id"
+      />
+
+      <ProposalForm
+        editingId={editingId}
+        isOpen={isModalOpen || editingId !== null}
+        onClose={() => {
+          setIsModalOpen(false);
+          setEditingId(null);
+        }}
+      />
+
+      <Modal
+        onCancel={() => {
+          setRejectReason("");
+          setRejectingProposalId(null);
+        }}
+        onOk={() => {
+          if (!rejectingProposalId) {
+            return;
+          }
+
+          void handleTransition(rejectingProposalId, ProposalStatus.Rejected, rejectReason).finally(
+            () => {
+              setRejectReason("");
+              setRejectingProposalId(null);
+            },
+          );
+        }}
+        okButtonProps={{ danger: true }}
+        okText="Reject proposal"
+        open={Boolean(rejectingProposalId)}
+        title="Reject proposal"
+      >
+        <div className="space-y-3 pt-2">
+          <Typography.Text className="!text-slate-500">
+            Capture a reason so the rejection is visible in the proposal history.
+          </Typography.Text>
+          <Input.TextArea
+            onChange={(event) => setRejectReason(event.target.value)}
+            placeholder="Why was this proposal rejected?"
+            rows={4}
+            value={rejectReason}
+          />
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/components/dashboard/reassignment-simulator.tsx
+++ b/components/dashboard/reassignment-simulator.tsx
@@ -1,0 +1,477 @@
+"use client";
+
+import { Alert, Button, Card, Checkbox, Select, Space, Spin, Statistic, Table, Tag, Typography } from "antd";
+import type { DefaultOptionType } from "antd/es/select";
+import { useMemo, useState } from "react";
+
+import { getPrimaryUserRole, isManagerRole } from "@/lib/auth/roles";
+import { useActivityActions, useActivityState } from "@/providers/activityProvider";
+import { useAuthState } from "@/providers/authProvider";
+import { useClientState } from "@/providers/clientProvider";
+import { useDashboardActions, useDashboardState } from "@/providers/dashboardProvider";
+import { useOpportunityActions } from "@/providers/opportunityProvider";
+import { formatCurrency, getDaysUntil } from "@/providers/salesSelectors";
+import { PRIORITY_BAND_COLORS } from "@/providers/salesTypes";
+import type {
+  IReassignmentSimulationResponse,
+} from "@/types/reassignment";
+
+const MAX_SELECTED_DEALS = 3;
+
+const createId = (prefix: string) =>
+  `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+export function ReassignmentSimulator() {
+  const { user } = useAuthState();
+  const { salesData, teamMembers } = useDashboardState();
+  const { clients } = useClientState();
+  const { activities } = useActivityState();
+  const { updateOpportunity } = useOpportunityActions();
+  const { updateActivity } = useActivityActions();
+  const { addAutomationEvent } = useDashboardActions();
+  const [selectedOpportunityIds, setSelectedOpportunityIds] = useState<string[]>([]);
+  const [targetOwnerId, setTargetOwnerId] = useState<string>();
+  const [moveFollowUps, setMoveFollowUps] = useState(true);
+  const [result, setResult] = useState<IReassignmentSimulationResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isApplying, setIsApplying] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const isAdmin = isManagerRole(getPrimaryUserRole(user?.roles));
+  const openOpportunities = useMemo(
+    () =>
+      salesData.opportunities.filter(
+        (opportunity) => !["Won", "Lost"].includes(String(opportunity.stage)),
+      ),
+    [salesData.opportunities],
+  );
+
+  const opportunityOptions = useMemo(
+    () =>
+      openOpportunities.map((opportunity) => {
+        const clientName =
+          clients.find((client) => client.id === opportunity.clientId)?.name ?? "Client pending";
+        const daysToClose = getDaysUntil(opportunity.expectedCloseDate);
+        const deadlineLabel = daysToClose <= 0 ? "Past due" : `${daysToClose} days to close`;
+        const value = opportunity.value ?? opportunity.estimatedValue;
+
+        return {
+          clientName,
+          deadlineLabel,
+          label: `${opportunity.title} - ${clientName} - ${deadlineLabel}`,
+          opportunityTitle: opportunity.title,
+          valueLabel: formatCurrency(value),
+          value: opportunity.id,
+        };
+      }),
+    [clients, openOpportunities],
+  );
+
+  const ownerOptions = useMemo(
+    () =>
+      teamMembers.map((member) => ({
+        label: `${member.name} - ${member.role}`,
+        value: member.id,
+      })),
+    [teamMembers],
+  );
+
+  const renderOpportunityOption = (option: DefaultOptionType) => {
+    const opportunityTitle =
+      typeof option.opportunityTitle === "string" ? option.opportunityTitle : "";
+    const clientName = typeof option.clientName === "string" ? option.clientName : "";
+    const deadlineLabel = typeof option.deadlineLabel === "string" ? option.deadlineLabel : "";
+    const valueLabel = typeof option.valueLabel === "string" ? option.valueLabel : "";
+
+    return (
+      <div className="dashboard-reassignment-option">
+        <Typography.Text className="block !font-semibold !text-slate-900">
+          {opportunityTitle}
+        </Typography.Text>
+        <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-500">
+          <span>{clientName}</span>
+          <span>{deadlineLabel}</span>
+          <span>{valueLabel}</span>
+        </div>
+      </div>
+    );
+  };
+
+  const runSimulation = async () => {
+    if (!targetOwnerId || selectedOpportunityIds.length === 0) {
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    setSuccessMessage(null);
+
+    try {
+      const response = await fetch("/api/reassignment-simulator", {
+        body: JSON.stringify({
+          opportunityIds: selectedOpportunityIds,
+          salesData,
+          targetOwnerId,
+        }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      });
+
+      const payload = (await response.json()) as
+        | IReassignmentSimulationResponse
+        | { message?: string };
+
+      if (!response.ok) {
+        throw new Error("message" in payload ? payload.message : "Simulation failed.");
+      }
+
+      setResult(payload as IReassignmentSimulationResponse);
+    } catch (requestError) {
+      setError(
+        requestError instanceof Error
+          ? requestError.message
+          : "The reassignment simulator could not process this request.",
+      );
+      setResult(null);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const applyScenario = () => {
+    if (!result || !targetOwnerId) {
+      return;
+    }
+
+    const targetOwner = teamMembers.find((member) => member.id === targetOwnerId);
+
+    if (!targetOwner) {
+      setError("The selected target owner could not be found.");
+      return;
+    }
+
+    setIsApplying(true);
+    setError(null);
+
+    try {
+      selectedOpportunityIds.forEach((opportunityId) => {
+        updateOpportunity(opportunityId, { ownerId: targetOwnerId });
+      });
+
+      if (moveFollowUps) {
+        activities
+          .filter(
+            (activity) =>
+              selectedOpportunityIds.includes(activity.relatedToId) &&
+              !activity.completed &&
+              String(activity.status) !== "Completed",
+          )
+          .forEach((activity) => {
+            updateActivity(activity.id, {
+              assignedToId: targetOwner.id,
+              assignedToName: targetOwner.name,
+            });
+          });
+      }
+
+      addAutomationEvent({
+        createdAt: new Date().toISOString(),
+        description: `${result.movedDealCount} deal${
+          result.movedDealCount === 1 ? "" : "s"
+        } were reassigned to ${targetOwner.name}. ${
+          moveFollowUps
+            ? `${result.followUpsToReassign} open follow-up${
+                result.followUpsToReassign === 1 ? "" : "s"
+              } moved with the deals.`
+            : "Related follow-ups stayed with their current assignees."
+        }`,
+        id: createId("auto"),
+        title: `Reassignment applied to ${targetOwner.name}`,
+      });
+
+      setSuccessMessage(`Reassignment applied to ${targetOwner.name}.`);
+      setResult(null);
+      setSelectedOpportunityIds([]);
+      setTargetOwnerId(undefined);
+    } finally {
+      setIsApplying(false);
+    }
+  };
+
+  if (!isAdmin) {
+    return (
+      <Card title="Reassignment simulator">
+        <Alert
+          description="Only admins and sales managers can test and apply deal reassignments."
+          showIcon
+          type="info"
+        />
+      </Card>
+    );
+  }
+
+  return (
+    <Card
+      className="h-full"
+      title="Reassignment simulator"
+      extra={
+        <Typography.Text className="!text-slate-500">
+          Move up to three deals and test the impact first
+        </Typography.Text>
+      }
+    >
+      <div className="space-y-4">
+        <div className="grid gap-3 xl:grid-cols-[minmax(0,1.65fr)_minmax(260px,0.9fr)]">
+          <Select
+            className="dashboard-reassignment-deals-select w-full"
+            disabled={Boolean(result) || isApplying || isLoading}
+            mode="multiple"
+            maxCount={MAX_SELECTED_DEALS}
+            maxTagCount={1}
+            optionRender={(option) => renderOpportunityOption(option.data)}
+            onChange={(value) => setSelectedOpportunityIds(value)}
+            options={opportunityOptions}
+            placeholder="Select up to 3 live deals"
+            popupMatchSelectWidth={false}
+            showSearch
+            size="large"
+            tagRender={(tagProps) => {
+              const selectedCount = selectedOpportunityIds.length;
+
+              if (selectedCount === 0) {
+                return <span className="hidden" />;
+              }
+
+              const isFirstTag = tagProps.value === selectedOpportunityIds[0];
+
+              if (!isFirstTag) {
+                return <span className="hidden" />;
+              }
+
+              return (
+                <span className="dashboard-reassignment-deals-tag">
+                  {selectedCount} deal{selectedCount === 1 ? "" : "s"} selected
+                </span>
+              );
+            }}
+            value={selectedOpportunityIds}
+          />
+
+          <Select
+            className="w-full"
+            disabled={Boolean(result) || isApplying || isLoading}
+            onChange={(value) => setTargetOwnerId(value)}
+            options={ownerOptions}
+            placeholder="Select the target owner"
+            showSearch
+            value={targetOwnerId}
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <Checkbox
+            checked={moveFollowUps}
+            disabled={Boolean(result) || isApplying || isLoading}
+            onChange={(event) => setMoveFollowUps(event.target.checked)}
+          >
+            Move open follow-ups when applying
+          </Checkbox>
+          <Space wrap>
+            <Button
+              disabled={
+                !targetOwnerId ||
+                selectedOpportunityIds.length === 0 ||
+                isLoading ||
+                isApplying ||
+                Boolean(result)
+              }
+              onClick={() => void runSimulation()}
+              type="primary"
+            >
+              Run simulation
+            </Button>
+            <Button
+              disabled={selectedOpportunityIds.length === 0 && !result}
+              onClick={() => {
+                setError(null);
+                setResult(null);
+                setSelectedOpportunityIds([]);
+                setTargetOwnerId(undefined);
+                setSuccessMessage(null);
+              }}
+            >
+              Reset
+            </Button>
+          </Space>
+        </div>
+
+        {error ? <Alert description={error} showIcon type="error" /> : null}
+        {successMessage ? <Alert description={successMessage} showIcon type="success" /> : null}
+
+        {isLoading ? (
+          <div className="flex items-center gap-3 rounded-2xl bg-slate-50 p-4 text-slate-500">
+            <Spin size="small" />
+            <span>Running reassignment analysis...</span>
+          </div>
+        ) : null}
+
+        {result ? (
+          <div className="space-y-4">
+            <Alert
+              description={result.summary}
+              message={`${result.recommendation} - ${result.scenarioRisk} risk`}
+              showIcon
+              type={
+                result.recommendation === "Hold"
+                  ? "error"
+                  : result.recommendation === "Proceed with support"
+                    ? "warning"
+                    : "success"
+              }
+            />
+
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <Card size="small">
+                <Statistic title="Moved value" value={result.totalValue} prefix="R " precision={0} />
+              </Card>
+              <Card size="small">
+                <Statistic title="Urgent deals" value={result.urgentDealCount} />
+              </Card>
+              <Card size="small">
+                <Statistic title="Open follow-ups" value={result.followUpsToReassign} />
+              </Card>
+              <Card size="small">
+                <Statistic title="Deals moved" value={result.movedDealCount} />
+              </Card>
+            </div>
+
+            {result.warnings.length > 0 ? (
+              <Card size="small" title="Watch-outs">
+                <div className="space-y-2">
+                  {result.warnings.map((warning) => (
+                    <Typography.Paragraph className="!mb-0 !text-slate-600" key={warning}>
+                      {warning}
+                    </Typography.Paragraph>
+                  ))}
+                </div>
+              </Card>
+            ) : null}
+
+            <Table
+              columns={[
+                {
+                  dataIndex: "title",
+                  key: "title",
+                  title: "Deal",
+                  width: 220,
+                },
+                {
+                  dataIndex: "clientName",
+                  key: "clientName",
+                  title: "Client",
+                  width: 150,
+                },
+                {
+                  dataIndex: "priorityBand",
+                  key: "priorityBand",
+                  render: (priorityBand: string) => (
+                    <Tag color={PRIORITY_BAND_COLORS[priorityBand as keyof typeof PRIORITY_BAND_COLORS]}>
+                      {priorityBand}
+                    </Tag>
+                  ),
+                  title: "Priority",
+                  width: 110,
+                },
+                {
+                  dataIndex: "daysToClose",
+                  key: "daysToClose",
+                  render: (daysToClose: number) =>
+                    daysToClose <= 0 ? "Past due" : `${daysToClose} days`,
+                  title: "Deadline",
+                  width: 110,
+                },
+                {
+                  dataIndex: "currentOwnerName",
+                  key: "currentOwnerName",
+                  title: "Current owner",
+                  width: 160,
+                },
+                {
+                  dataIndex: "targetOwnerName",
+                  key: "targetOwnerName",
+                  title: "Target owner",
+                  width: 160,
+                },
+                {
+                  dataIndex: "openFollowUps",
+                  key: "openFollowUps",
+                  title: "Open follow-ups",
+                  width: 130,
+                },
+                {
+                  dataIndex: "value",
+                  key: "value",
+                  render: (value: number) => formatCurrency(value),
+                  title: "Value",
+                  width: 130,
+                },
+              ]}
+              dataSource={result.deals}
+              pagination={false}
+              rowKey="opportunityId"
+              scroll={{ x: 1170 }}
+              size="small"
+            />
+
+            <Table
+              columns={[
+                {
+                  dataIndex: "memberName",
+                  key: "memberName",
+                  title: "Team member",
+                  width: 170,
+                },
+                {
+                  dataIndex: "role",
+                  key: "role",
+                  title: "Role",
+                  width: 150,
+                },
+                {
+                  key: "liveDeals",
+                  render: (_, record) => `${record.beforeAssignments} -> ${record.afterAssignments}`,
+                  title: "Live deals",
+                  width: 110,
+                },
+                {
+                  key: "urgentDeals",
+                  render: (_, record) => `${record.beforeUrgentDeals} -> ${record.afterUrgentDeals}`,
+                  title: "Urgent deals",
+                  width: 110,
+                },
+                {
+                  key: "capacity",
+                  render: (_, record) =>
+                    `${record.beforeAvailableCapacity}% -> ${record.afterAvailableCapacity}%`,
+                  title: "Capacity",
+                  width: 140,
+                },
+              ]}
+              dataSource={result.ownerImpacts}
+              pagination={false}
+              rowKey="memberId"
+              size="small"
+            />
+
+            <div className="flex justify-end">
+              <Button loading={isApplying} onClick={applyScenario} type="primary">
+                Apply reassignment
+              </Button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/components/dashboard/renewal-form.tsx
+++ b/components/dashboard/renewal-form.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Form, Input, Modal, InputNumber } from "antd";
+import { useEffect } from "react";
+import { useContractActions, useContractState } from "@/providers/contractProvider";
+import { type IRenewal } from "@/providers/salesTypes";
+
+interface RenewalFormProps {
+  isOpen: boolean;
+  editingId: string | null;
+  onClose: () => void;
+}
+
+interface RenewalFormValues {
+  clientName: string;
+  contractId: string;
+  renewalDate: string;
+  value: number;
+}
+
+export function RenewalForm({ isOpen, editingId, onClose }: RenewalFormProps) {
+  const [form] = Form.useForm();
+  const { renewals } = useContractState();
+  const { addRenewal, updateRenewal } = useContractActions();
+
+  useEffect(() => {
+    if (editingId) {
+      const renewal = renewals.find((r) => r.id === editingId);
+      if (renewal) {
+        form.setFieldsValue(renewal);
+      }
+    } else {
+      form.resetFields();
+    }
+  }, [editingId, form, isOpen, renewals]);
+
+  const calculateDaysUntil = (renewalDate: string) => {
+    const today = new Date();
+    const renewal = new Date(renewalDate);
+    const diffTime = renewal.getTime() - today.getTime();
+    return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  };
+
+  const handleSubmit = async (values: RenewalFormValues) => {
+    const data: IRenewal = {
+      id: editingId || Date.now().toString(),
+      contractId: values.contractId,
+      clientName: values.clientName,
+      renewalDate: values.renewalDate,
+      value: values.value,
+      status: calculateDaysUntil(values.renewalDate) <= 30 ? 0 : 1,
+     daysUntilRenewal: calculateDaysUntil(values.renewalDate),
+    };
+
+    if (editingId) {
+      updateRenewal(editingId, data);
+    } else {
+      addRenewal(data);
+    }
+
+    onClose();
+    form.resetFields();
+  };
+
+  return (
+    <Modal
+      title={editingId ? "Edit Renewal" : "Add Renewal"}
+      open={isOpen}
+      onCancel={onClose}
+      onOk={() => form.submit()}
+    >
+      <Form form={form} layout="vertical" onFinish={handleSubmit} className="pt-4">
+        <Form.Item
+          label="Contract ID"
+          name="contractId"
+          rules={[{ required: true, message: "Please enter contract ID" }]}
+        >
+          <Input placeholder="e.g., C001" />
+        </Form.Item>
+
+        <Form.Item
+          label="Client Name"
+          name="clientName"
+          rules={[{ required: true, message: "Please enter client name" }]}
+        >
+          <Input placeholder="e.g., Acme Corp" />
+        </Form.Item>
+
+        <Form.Item
+          label="Renewal Date (YYYY-MM-DD)"
+          name="renewalDate"
+          rules={[{ required: true, message: "Please enter renewal date" }]}
+        >
+          <Input type="date" />
+        </Form.Item>
+
+        <Form.Item
+          label="Value (R)"
+          name="value"
+          rules={[{ required: true, message: "Please enter value" }]}
+        >
+          <InputNumber min={0} />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/components/dashboard/renewals-panel.tsx
+++ b/components/dashboard/renewals-panel.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Button, Empty, Table, Tag, Typography } from "antd";
+import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
+import { useState } from "react";
+
+import { type IRenewal } from "@/providers/salesTypes";
+import { useContractActions, useContractState } from "@/providers/contractProvider";
+import { RenewalForm } from "./renewal-form";
+
+export function RenewalsPanel() {
+  const { renewals } = useContractState();
+  const { deleteRenewal } = useContractActions();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const getUrgencyColor = (daysUntilRenewal: number) => {
+    if (daysUntilRenewal <= 7) return "#f97316";
+    if (daysUntilRenewal <= 21) return "#f59e0b";
+    return "#355c7d";
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="space-y-1">
+          <Typography.Title className="!m-0" level={4}>
+            Renewals ({renewals.length})
+          </Typography.Title>
+          <Typography.Text className="!text-slate-500">
+            Watch contract risk and upcoming dates before revenue slips.
+          </Typography.Text>
+        </div>
+        <Button icon={<PlusOutlined />} onClick={() => setIsModalOpen(true)} type="primary">
+          Add renewal
+        </Button>
+      </div>
+
+      {renewals.length === 0 ? (
+        <Empty description="No renewals" />
+      ) : (
+        <Table
+          columns={[
+            { dataIndex: "clientName", key: "clientName", title: "Client" },
+            {
+              dataIndex: "value",
+              key: "value",
+              render: (value: number) => `R ${value.toLocaleString()}`,
+              title: "Value",
+            },
+            { dataIndex: "renewalDate", key: "renewalDate", title: "Renewal date" },
+            {
+              dataIndex: "daysUntilRenewal",
+              key: "daysUntilRenewal",
+              render: (daysUntilRenewal: number) => (
+                <Tag color={getUrgencyColor(daysUntilRenewal)}>
+                  {daysUntilRenewal} days
+                </Tag>
+              ),
+              title: "Days until",
+            },
+            {
+              key: "actions",
+              render: (_: unknown, record: IRenewal) => (
+                <div className="space-x-2">
+                  <Button
+                    icon={<EditOutlined />}
+                    onClick={() => setEditingId(record.id)}
+                    size="small"
+                    type="text"
+                  />
+                  <Button
+                    danger
+                    icon={<DeleteOutlined />}
+                    onClick={() => deleteRenewal(record.id)}
+                    size="small"
+                    type="text"
+                  />
+                </div>
+              ),
+              title: "Actions",
+            },
+          ]}
+          dataSource={renewals}
+          pagination={false}
+          rowKey="id"
+        />
+      )}
+
+      <RenewalForm
+        editingId={editingId}
+        isOpen={isModalOpen || editingId !== null}
+        onClose={() => {
+          setIsModalOpen(false);
+          setEditingId(null);
+        }}
+      />
+    </div>
+  );
+}

--- a/components/dashboard/reports-panel.tsx
+++ b/components/dashboard/reports-panel.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Card, Col, Row, Statistic, Table, Tag, Typography } from "antd";
+
+import { OPPORTUNITY_STAGE_COLORS, PROPOSAL_STATUS_COLORS } from "@/providers/salesTypes";
+import { formatCurrency } from "@/providers/salesSelectors";
+import { useReportState } from "@/providers/reportProvider";
+import { useDashboardState } from "@/providers/dashboardProvider";
+
+export function ReportsPanel() {
+  const { opportunityInsights, totalPipelineValue, averageDealValue } = useReportState();
+  const { salesData } = useDashboardState();
+
+  return (
+    <div className="space-y-4">
+      <Row gutter={[16, 16]}>
+        <Col span={24} md={8}>
+          <Card>
+            <Statistic title="Pipeline total" value={totalPipelineValue} prefix="R" precision={0} />
+          </Card>
+        </Col>
+        <Col span={24} md={8}>
+          <Card>
+            <Statistic title="Ranked opportunities" value={opportunityInsights.length} />
+          </Card>
+        </Col>
+        <Col span={24} md={8}>
+          <Card>
+            <Statistic title="Average deal size" value={averageDealValue} prefix="R" precision={0} />
+          </Card>
+        </Col>
+      </Row>
+
+      <Card title="Priority report">
+        <Table
+          columns={[
+            {
+              key: "opportunity",
+              render: (_, record) => record.opportunity.title,
+              title: "Opportunity",
+            },
+            {
+              key: "stage",
+              render: (_, record) => (
+                <Tag color={OPPORTUNITY_STAGE_COLORS[String(record.opportunity.stage)]}>
+                  {record.opportunity.stage}
+                </Tag>
+              ),
+              title: "Stage",
+            },
+            {
+              key: "priorityBand",
+              render: (_, record) => <Tag color="#f97316">{record.priorityBand}</Tag>,
+              title: "Priority",
+            },
+            {
+              key: "score",
+              title: "Score",
+              dataIndex: "score",
+            },
+            {
+              key: "owner",
+              render: (_, record) => record.owner?.name ?? "Auto-pick pending",
+              title: "Owner",
+            },
+            {
+              key: "value",
+              render: (_, record) =>
+                formatCurrency(
+                  record.opportunity.value ?? record.opportunity.estimatedValue,
+                ),
+              title: "Value",
+            },
+          ]}
+          dataSource={opportunityInsights}
+          pagination={false}
+          rowKey={(record) => record.opportunity.id}
+        />
+      </Card>
+
+      <Card title="Proposal status summary">
+        <div className="flex flex-wrap gap-3">
+          {Object.entries(
+            salesData.proposals.reduce<Record<string, number>>((accumulator, proposal) => {
+              const status = String(proposal.status);
+              accumulator[status] = (accumulator[status] ?? 0) + 1;
+              return accumulator;
+            }, {}),
+          ).map(([status, count]) => (
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3" key={status}>
+              <Tag color={PROPOSAL_STATUS_COLORS[status]}>{status}</Tag>
+              <Typography.Paragraph className="!mb-0 !mt-2 !text-slate-500">
+                {count} proposal{count === 1 ? "" : "s"}
+              </Typography.Paragraph>
+            </div>
+          ))}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/components/dashboard/team-capacity-panel.tsx
+++ b/components/dashboard/team-capacity-panel.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Card, Progress, Table, Tag } from "antd";
+
+import { getTeamCapacity } from "@/providers/salesSelectors";
+import { useDashboardState } from "@/providers/dashboardProvider";
+
+export function TeamCapacityPanel() {
+  const { salesData } = useDashboardState();
+  const rows = getTeamCapacity(salesData).slice(0, 8);
+
+  return (
+    <Card className="dashboard-table-card h-full" title="Available team capacity">
+      <Table
+        className="dashboard-responsive-table"
+        columns={[
+          {
+            key: "member",
+            render: (_, record) => record.member.name,
+            title: "Team member",
+            width: 180,
+          },
+          {
+            key: "role",
+            render: (_, record) => record.member.role,
+            title: "Role",
+            width: 140,
+          },
+          {
+            key: "assignments",
+            render: (assignments: number) => <Tag color="#355c7d">{assignments}</Tag>,
+            title: "Live deals",
+            dataIndex: "assignments",
+            width: 110,
+          },
+          {
+            key: "availableCapacity",
+            render: (availableCapacity: number) => (
+              <Progress
+                percent={Math.max(0, Math.min(100, availableCapacity))}
+                showInfo
+                strokeColor="#f97316"
+              />
+            ),
+            title: "Availability",
+            dataIndex: "availableCapacity",
+            width: 220,
+          },
+        ]}
+        dataSource={rows}
+        pagination={false}
+        rowKey={(record) => record.member.id}
+        scroll={{ x: 650 }}
+        size="small"
+        tableLayout="fixed"
+      />
+    </Card>
+  );
+}

--- a/constants/dashboard-nav.ts
+++ b/constants/dashboard-nav.ts
@@ -1,0 +1,147 @@
+import {
+  BarChartOutlined,
+  ClockCircleOutlined,
+  CommentOutlined,
+  ContactsOutlined,
+  FileTextOutlined,
+  FolderOpenOutlined,
+  HomeOutlined,
+  IdcardOutlined,
+  NotificationOutlined,
+  ProfileOutlined,
+  ScheduleOutlined,
+  SolutionOutlined,
+  TeamOutlined,
+} from "@ant-design/icons";
+
+import { type UserRole } from "@/providers/salesTypes";
+
+type DashboardNavItem = {
+  access: UserRole[];
+  description: string;
+  href: string;
+  headerTitle?: string;
+  icon: typeof HomeOutlined;
+  key: string;
+  label: string;
+};
+
+export const dashboardNavItems: DashboardNavItem[] = [
+  {
+    access: ["Admin", "BusinessDevelopmentManager", "SalesManager", "SalesRep"],
+    description: "Track pipeline movement, workload, and the next actions that need attention.",
+    href: "/dashboard",
+    headerTitle: "Sales command center",
+    icon: HomeOutlined,
+    key: "/dashboard",
+    label: "Command Center",
+  },
+  {
+    access: ["Admin", "BusinessDevelopmentManager", "SalesManager", "SalesRep"],
+    description: "Ask for account updates, pipeline guidance, renewal risk, and the next best action.",
+    href: "/dashboard/assistant",
+    headerTitle: "Secure sales assistant",
+    icon: CommentOutlined,
+    key: "/dashboard/assistant",
+    label: "Assistant",
+  },
+  {
+    access: ["Admin", "BusinessDevelopmentManager", "SalesManager", "SalesRep"],
+    description: "Track live opportunities, owners, deadlines, and priority across the pipeline.",
+    href: "/dashboard/opportunities",
+    headerTitle: "Opportunity pipeline",
+    icon: SolutionOutlined,
+    key: "/dashboard/opportunities",
+    label: "Opportunities",
+  },
+  {
+    access: ["Admin", "BusinessDevelopmentManager", "SalesManager", "SalesRep"],
+    description: "Manage calls, tasks, meetings, and the follow-ups that keep deals moving.",
+    href: "/dashboard/activities",
+    headerTitle: "Follow-ups",
+    icon: ClockCircleOutlined,
+    key: "/dashboard/activities",
+    label: "Follow-ups",
+  },
+  {
+    access: ["Admin", "BusinessDevelopmentManager", "SalesManager"],
+    description: "Manage accounts, ownership, and the commercial work tied to each client.",
+    href: "/dashboard/clients",
+    headerTitle: "Clients",
+    icon: TeamOutlined,
+    key: "/dashboard/clients",
+    label: "Clients",
+  },
+  {
+    access: ["Admin", "BusinessDevelopmentManager", "SalesManager"],
+    description: "Keep decision-makers, champions, and key stakeholders attached to the right account.",
+    href: "/dashboard/contacts",
+    headerTitle: "Contacts",
+    icon: ContactsOutlined,
+    key: "/dashboard/contacts",
+    label: "Contacts",
+  },
+  {
+    access: ["Admin", "BusinessDevelopmentManager", "SalesManager", "SalesRep"],
+    description: "Keep commercial responses, approvals, and proposal progress visible in one place.",
+    href: "/dashboard/proposals",
+    headerTitle: "Proposals",
+    icon: FileTextOutlined,
+    key: "/dashboard/proposals",
+    label: "Proposals",
+  },
+  {
+    access: ["Admin", "BusinessDevelopmentManager", "SalesManager", "SalesRep"],
+    description: "Coordinate pricing requests before final commercials go out to the client.",
+    href: "/dashboard/pricing-requests",
+    headerTitle: "Pricing requests",
+    icon: ScheduleOutlined,
+    key: "/dashboard/pricing-requests",
+    label: "Pricing Requests",
+  },
+  {
+    access: ["Admin", "BusinessDevelopmentManager", "SalesManager"],
+    description: "Monitor renewals, contract health, and upcoming deadlines before they become risks.",
+    href: "/dashboard/contracts",
+    headerTitle: "Contracts and renewals",
+    icon: ProfileOutlined,
+    key: "/dashboard/contracts",
+    label: "Contracts",
+  },
+  {
+    access: ["Admin", "BusinessDevelopmentManager", "SalesManager", "SalesRep"],
+    description: "Keep commercial files organized against the right client and deal records.",
+    href: "/dashboard/documents",
+    headerTitle: "Documents",
+    icon: FolderOpenOutlined,
+    key: "/dashboard/documents",
+    label: "Documents",
+  },
+  {
+    access: ["Admin", "BusinessDevelopmentManager", "SalesManager", "SalesRep"],
+    description: "Capture context, handover notes, and deal history without losing the thread.",
+    href: "/dashboard/notes",
+    headerTitle: "Notes",
+    icon: NotificationOutlined,
+    key: "/dashboard/notes",
+    label: "Notes",
+  },
+  {
+    access: ["Admin", "SalesManager"],
+    description: "Review pipeline health, priority shifts, and team workload at a glance.",
+    href: "/dashboard/reports",
+    headerTitle: "Reports",
+    icon: BarChartOutlined,
+    key: "/dashboard/reports",
+    label: "Reports",
+  },
+  {
+    access: ["Admin", "BusinessDevelopmentManager", "SalesManager", "SalesRep"],
+    description: "View your account details, role, and workspace information.",
+    href: "/dashboard/profile",
+    headerTitle: "Profile",
+    icon: IdcardOutlined,
+    key: "/dashboard/profile",
+    label: "Profile",
+  },
+] as const;

--- a/lib/auth/dashboard-access.ts
+++ b/lib/auth/dashboard-access.ts
@@ -1,0 +1,12 @@
+import { dashboardNavItems } from "@/constants/dashboard-nav";
+import type { UserRole } from "@/providers/salesTypes";
+
+export const DASHBOARD_HOME_PATH = "/dashboard";
+
+const getNavItemForPath = (pathname: string) =>
+  [...dashboardNavItems]
+    .sort((left, right) => right.href.length - left.href.length)
+    .find((item) => pathname === item.href || pathname.startsWith(`${item.href}/`));
+
+export const canAccessDashboardPath = (pathname: string, role: UserRole) =>
+  getNavItemForPath(pathname)?.access.includes(role) ?? true;

--- a/lib/client/session-drafts.ts
+++ b/lib/client/session-drafts.ts
@@ -1,0 +1,43 @@
+"use client";
+
+export const readSessionDraft = <T,>(key: string): T | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const rawValue = window.sessionStorage.getItem(key);
+
+    if (!rawValue) {
+      return null;
+    }
+
+    return JSON.parse(rawValue) as T;
+  } catch {
+    return null;
+  }
+};
+
+export const writeSessionDraft = (key: string, value: unknown) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Ignore storage failures so drafts do not break the UI.
+  }
+};
+
+export const clearSessionDraft = (key: string) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.removeItem(key);
+  } catch {
+    // Ignore storage failures so cleanup does not break the UI.
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend-project",
       "version": "0.1.0",
       "dependencies": {
+        "@ant-design/icons": "^6.1.1",
         "antd": "^6.3.6",
         "next": "16.2.4",
         "react": "19.2.4",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@ant-design/icons": "^6.1.1",
     "antd": "^6.3.6",
     "next": "16.2.4",
     "react": "19.2.4",

--- a/providers/pageProviders.tsx
+++ b/providers/pageProviders.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+type PageModuleKey =
+  | "activity"
+  | "assistant"
+  | "pricing-request"
+  | "dashboard"
+  | "opportunity"
+  | "proposal"
+  | "client"
+  | "contact"
+  | "contract"
+  | "document"
+  | "note"
+  | "report"
+  | "profile";
+
+interface IPageModuleValue {
+  description: string;
+  key: PageModuleKey;
+  title: string;
+}
+
+const PageModuleContext = createContext<IPageModuleValue | null>(null);
+
+const createModuleProvider = (value: IPageModuleValue) => {
+  return function ModuleProvider({
+    children,
+  }: Readonly<{ children: React.ReactNode }>) {
+    return (
+      <PageModuleContext.Provider value={value}>
+        {children}
+      </PageModuleContext.Provider>
+    );
+  };
+};
+
+export const DashboardProvider = createModuleProvider({
+  description: "Track pipeline movement, workload, and the next actions that need attention.",
+  key: "dashboard",
+  title: "Sales command center",
+});
+
+export const ActivityProviderPage = createModuleProvider({
+  description: "Manage calls, tasks, meetings, and the follow-ups that keep deals moving.",
+  key: "activity",
+  title: "Follow-ups",
+});
+
+export const AssistantProvider = createModuleProvider({
+  description:
+    "Ask for account updates, pipeline guidance, renewal risk, and the next best action.",
+  key: "assistant",
+  title: "Secure sales assistant",
+});
+
+export const OpportunityProvider = createModuleProvider({
+  description: "Track live opportunities, owners, deadlines, and priority across the pipeline.",
+  key: "opportunity",
+  title: "Opportunity pipeline",
+});
+
+export const ProposalProvider = createModuleProvider({
+  description: "Keep commercial responses, approvals, and proposal progress visible in one place.",
+  key: "proposal",
+  title: "Proposals",
+});
+
+export const PricingRequestProvider = createModuleProvider({
+  description: "Coordinate pricing requests before final commercials go out to the client.",
+  key: "pricing-request",
+  title: "Pricing requests",
+});
+
+export const ClientProvider = createModuleProvider({
+  description: "Manage accounts, ownership, and the commercial work tied to each client.",
+  key: "client",
+  title: "Clients",
+});
+
+export const ContactProvider = createModuleProvider({
+  description: "Keep decision-makers, champions, and key stakeholders attached to the right account.",
+  key: "contact",
+  title: "Contacts",
+});
+
+export const ContractProvider = createModuleProvider({
+  description: "Monitor renewals, contract health, and upcoming deadlines before they become risks.",
+  key: "contract",
+  title: "Contracts and renewals",
+});
+
+export const DocumentProvider = createModuleProvider({
+  description: "Keep commercial files organized against the right client and deal records.",
+  key: "document",
+  title: "Documents",
+});
+
+export const NoteProvider = createModuleProvider({
+  description: "Capture context, handover notes, and deal history without losing the thread.",
+  key: "note",
+  title: "Notes",
+});
+
+export const ReportProvider = createModuleProvider({
+  description: "Review pipeline health, priority shifts, and team workload at a glance.",
+  key: "report",
+  title: "Reports",
+});
+
+export const ProfileProvider = createModuleProvider({
+  description: "View your account details, role, and workspace information.",
+  key: "profile",
+  title: "Profile",
+});
+
+export const usePageModule = () => {
+  const context = useContext(PageModuleContext);
+
+  if (!context) {
+    throw new Error("usePageModule must be used within a page provider.");
+  }
+
+  return context;
+};

--- a/types/reassignment.ts
+++ b/types/reassignment.ts
@@ -1,0 +1,50 @@
+import type { ISalesData, PriorityBand } from "@/providers/salesTypes";
+
+export type ReassignmentRecommendation = "Hold" | "Proceed" | "Proceed with support";
+export type ReassignmentRiskLevel = "High" | "Low" | "Medium";
+
+export interface IReassignmentSimulationRequest {
+  opportunityIds: string[];
+  salesData: ISalesData;
+  targetOwnerId: string;
+}
+
+export interface IReassignmentDealImpact {
+  clientName: string;
+  currentOwnerName: string;
+  daysToClose: number;
+  openFollowUps: number;
+  opportunityId: string;
+  priorityBand: PriorityBand;
+  targetOwnerName: string;
+  title: string;
+  value: number;
+}
+
+export interface IReassignmentOwnerImpact {
+  afterAssignments: number;
+  afterAvailableCapacity: number;
+  afterUrgentDeals: number;
+  beforeAssignments: number;
+  beforeAvailableCapacity: number;
+  beforeUrgentDeals: number;
+  deltaAssignments: number;
+  deltaUrgentDeals: number;
+  memberId: string;
+  memberName: string;
+  role: string;
+}
+
+export interface IReassignmentSimulationResponse {
+  deals: IReassignmentDealImpact[];
+  followUpsToReassign: number;
+  movedDealCount: number;
+  ownerImpacts: IReassignmentOwnerImpact[];
+  recommendation: ReassignmentRecommendation;
+  scenarioRisk: ReassignmentRiskLevel;
+  summary: string;
+  targetOwnerName: string;
+  totalValue: number;
+  urgentDealCount: number;
+  warnings: string[];
+}


### PR DESCRIPTION
## Summary
Adds the dashboard shell, route pages, navigation, and dashboard UI panels.

## Included
- dashboard route structure
- dashboard shell and navigation
- route page providers
- dashboard panels and forms
- session draft helpers
- dashboard styling updates
- reassignment simulator UI types

## Validation
- `npm ci`
- `npm run lint`
- `npm run build`

## Notes
This branch depends on the shared sales state foundation being merged first.
