### PR TITLE
feat: add client detail page

### DIFF
--- a/app/dashboard/(routes)/clients/[clientId]/page.tsx
+++ b/app/dashboard/(routes)/clients/[clientId]/page.tsx
@@ -1,0 +1,14 @@
+import { ClientDetailView } from "@/components/dashboard/client-detail-view";
+import { ClientProvider } from "@/providers/pageProviders";
+
+export default async function ClientDetailPage(
+  props: PageProps<"/dashboard/clients/[clientId]">,
+) {
+  const { clientId } = await props.params;
+
+  return (
+    <ClientProvider>
+      <ClientDetailView clientId={clientId} />
+    </ClientProvider>
+  );
+}

--- a/components/dashboard/client-detail-view.tsx
+++ b/components/dashboard/client-detail-view.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { ArrowLeftOutlined } from "@ant-design/icons";
+import { Card, Col, Descriptions, Empty, Row, Skeleton, Space, Tag, Typography } from "antd";
+import Link from "next/link";
+
+import { useClientState } from "@/providers/clientProvider";
+import { useContactState } from "@/providers/contactProvider";
+import { useContractState } from "@/providers/contractProvider";
+import { useDashboardState } from "@/providers/dashboardProvider";
+import { useOpportunityState } from "@/providers/opportunityProvider";
+import { useProposalState } from "@/providers/proposalProvider";
+import {
+  formatCurrency,
+  getDaysUntil,
+  getOpportunityInsights,
+} from "@/providers/salesSelectors";
+import {
+  OPPORTUNITY_STAGE_COLORS,
+  PROPOSAL_STATUS_COLORS,
+  type IOpportunity,
+  type IProposal,
+} from "@/providers/salesTypes";
+import { AnimatedDashboardTable } from "./animated-dashboard-table";
+
+type ClientDetailViewProps = Readonly<{
+  clientId: string;
+}>;
+
+export function ClientDetailView({ clientId }: ClientDetailViewProps) {
+  const { clients } = useClientState();
+  const { contacts } = useContactState();
+  const { proposals } = useProposalState();
+  const { opportunities } = useOpportunityState();
+  const { contracts } = useContractState();
+  const { salesData, teamMembers } = useDashboardState();
+
+  const client = clients.find((item) => item.id === clientId);
+  const clientContacts = contacts.filter((contact) => contact.clientId === clientId);
+  const primaryContact =
+    clientContacts.find((contact) => contact.isPrimaryContact) ?? clientContacts[0];
+  const clientOpportunities = opportunities.filter((opportunity) => opportunity.clientId === clientId);
+  const clientProposals = proposals.filter((proposal) => proposal.clientId === clientId);
+  const clientContracts = contracts.filter((contract) => contract.clientId === clientId);
+  const opportunityInsights = getOpportunityInsights(salesData).filter(
+    (insight) => insight.opportunity.clientId === clientId,
+  );
+  const insightByOpportunityId = new Map(
+    opportunityInsights.map((insight) => [insight.opportunity.id, insight]),
+  );
+  const topPriority = opportunityInsights[0];
+  const openPipelineValue = clientOpportunities
+    .filter((opportunity) => !["Won", "Lost"].includes(String(opportunity.stage)))
+    .reduce(
+      (sum, opportunity) => sum + (opportunity.value ?? opportunity.estimatedValue),
+      0,
+    );
+
+  if (!client && clients.length === 0) {
+    return (
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <Skeleton.Button active block className="!h-6 !w-40" />
+          <Skeleton active paragraph={{ rows: 1 }} title={{ width: "40%" }} />
+        </div>
+        <Card className="border-slate-200 shadow-sm">
+          <Skeleton active paragraph={{ rows: 10 }} />
+        </Card>
+      </div>
+    );
+  }
+
+  if (!client) {
+    return (
+      <div className="space-y-6">
+        <Link
+          className="inline-flex items-center gap-2 font-medium text-[#355c7d] transition-colors hover:text-[#f28c28]"
+          href="/dashboard/clients"
+        >
+          <ArrowLeftOutlined />
+          Back to clients
+        </Link>
+        <Card className="border-slate-200 shadow-sm">
+          <Empty
+            description="This client record could not be found."
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+          />
+        </Card>
+      </div>
+    );
+  }
+
+  const opportunityColumns = [
+    {
+      dataIndex: "title",
+      key: "title",
+      title: "Opportunity",
+    },
+    {
+      key: "priority",
+      render: (_: unknown, record: IOpportunity) => {
+        const insight = insightByOpportunityId.get(record.id);
+
+        return insight ? <Tag color="#1f365c">{insight.priorityBand}</Tag> : <Tag>Unranked</Tag>;
+      },
+      title: "Priority",
+    },
+    {
+      dataIndex: "stage",
+      key: "stage",
+      render: (stage: string) => <Tag color={OPPORTUNITY_STAGE_COLORS[stage] ?? "#94a3b8"}>{stage}</Tag>,
+      title: "Stage",
+    },
+    {
+      key: "value",
+      render: (_: unknown, record: IOpportunity) =>
+        formatCurrency(record.value ?? record.estimatedValue),
+      title: "Value",
+    },
+    {
+      dataIndex: "expectedCloseDate",
+      key: "expectedCloseDate",
+      title: "Target close",
+    },
+    {
+      key: "owner",
+      render: (_: unknown, record: IOpportunity) =>
+        teamMembers.find((member) => member.id === record.ownerId)?.name ?? "Unassigned",
+      title: "Owner",
+    },
+  ];
+
+  const proposalColumns = [
+    {
+      dataIndex: "title",
+      key: "title",
+      title: "Proposal",
+    },
+    {
+      dataIndex: "status",
+      key: "status",
+      render: (status: string) => (
+        <Tag color={PROPOSAL_STATUS_COLORS[status] ?? "#94a3b8"}>{status}</Tag>
+      ),
+      title: "Status",
+    },
+    {
+      key: "value",
+      render: (_: unknown, record: IProposal) => formatCurrency(record.value ?? 0),
+      title: "Value",
+    },
+    {
+      dataIndex: "validUntil",
+      key: "validUntil",
+      title: "Valid until",
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <Space direction="vertical" size={8}>
+        <Link
+          className="inline-flex items-center gap-2 font-medium text-[#355c7d] transition-colors hover:text-[#f28c28]"
+          href="/dashboard/clients"
+        >
+          <ArrowLeftOutlined />
+          Back to clients
+        </Link>
+        <div className="space-y-2">
+          <Typography.Title className="!mb-0 !text-slate-900" level={2}>
+            {client.name}
+          </Typography.Title>
+          <Typography.Paragraph className="!mb-0 max-w-3xl !text-slate-500">
+            {client.industry} account in the {client.segment ?? "Unassigned"} segment with{" "}
+            {client.isActive ? "active" : "inactive"} commercial tracking.
+          </Typography.Paragraph>
+        </div>
+      </Space>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} md={12} xl={6}>
+          <Card className="h-full border-slate-200 shadow-sm">
+            <Typography.Text className="!text-slate-500">Open pipeline</Typography.Text>
+            <Typography.Title className="!mb-1 !mt-2" level={3}>
+              {formatCurrency(openPipelineValue)}
+            </Typography.Title>
+            <Typography.Text className="!text-slate-500">
+              {clientOpportunities.length} opportunity{clientOpportunities.length === 1 ? "" : "ies"} linked to this client.
+            </Typography.Text>
+          </Card>
+        </Col>
+        <Col xs={24} md={12} xl={6}>
+          <Card className="h-full border-slate-200 shadow-sm">
+            <Typography.Text className="!text-slate-500">Highest priority</Typography.Text>
+            <Typography.Title className="!mb-1 !mt-2" level={3}>
+              {topPriority?.priorityBand ?? "None"}
+            </Typography.Title>
+            <Typography.Text className="!text-slate-500">
+              {topPriority
+                ? `${Math.max(getDaysUntil(topPriority.opportunity.expectedCloseDate), 0)} day${Math.abs(getDaysUntil(topPriority.opportunity.expectedCloseDate)) === 1 ? "" : "s"} to close ${topPriority.opportunity.title}.`
+                : "No active opportunities to rank yet."}
+            </Typography.Text>
+          </Card>
+        </Col>
+        <Col xs={24} md={12} xl={6}>
+          <Card className="h-full border-slate-200 shadow-sm">
+            <Typography.Text className="!text-slate-500">Proposals</Typography.Text>
+            <Typography.Title className="!mb-1 !mt-2" level={3}>
+              {clientProposals.length}
+            </Typography.Title>
+            <Typography.Text className="!text-slate-500">
+              {clientProposals.filter((proposal) => proposal.status === "Submitted").length} awaiting client or internal decision.
+            </Typography.Text>
+          </Card>
+        </Col>
+        <Col xs={24} md={12} xl={6}>
+          <Card className="h-full border-slate-200 shadow-sm">
+            <Typography.Text className="!text-slate-500">Contracts</Typography.Text>
+            <Typography.Title className="!mb-1 !mt-2" level={3}>
+              {clientContracts.length}
+            </Typography.Title>
+            <Typography.Text className="!text-slate-500">
+              {clientContracts.filter((contract) => contract.status === "Active").length} active contract{clientContracts.filter((contract) => contract.status === "Active").length === 1 ? "" : "s"} on record.
+            </Typography.Text>
+          </Card>
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} xl={12}>
+          <Card className="h-full border-slate-200 shadow-sm" title="Client details">
+            <Descriptions column={1} size="small">
+              <Descriptions.Item label="Industry">{client.industry}</Descriptions.Item>
+              <Descriptions.Item label="Segment">{client.segment ?? "Not set"}</Descriptions.Item>
+              <Descriptions.Item label="Status">
+                <Tag color={client.isActive ? "green" : "red"}>
+                  {client.isActive ? "Active" : "Inactive"}
+                </Tag>
+              </Descriptions.Item>
+              <Descriptions.Item label="Website">{client.website ?? "Not set"}</Descriptions.Item>
+              <Descriptions.Item label="Company size">
+                {client.companySize ?? "Not set"}
+              </Descriptions.Item>
+              <Descriptions.Item label="Tax number">{client.taxNumber ?? "Not set"}</Descriptions.Item>
+            </Descriptions>
+          </Card>
+        </Col>
+        <Col xs={24} xl={12}>
+          <Card className="h-full border-slate-200 shadow-sm" title="Primary contact">
+            {primaryContact ? (
+              <Descriptions column={1} size="small">
+                <Descriptions.Item label="Name">
+                  {`${primaryContact.firstName} ${primaryContact.lastName}`.trim()}
+                </Descriptions.Item>
+                <Descriptions.Item label="Role">{primaryContact.position}</Descriptions.Item>
+                <Descriptions.Item label="Email">
+                  <a href={`mailto:${primaryContact.email}`}>{primaryContact.email}</a>
+                </Descriptions.Item>
+                <Descriptions.Item label="Phone">
+                  {primaryContact.phoneNumber ? (
+                    <a href={`tel:${primaryContact.phoneNumber}`}>{primaryContact.phoneNumber}</a>
+                  ) : (
+                    "Not set"
+                  )}
+                </Descriptions.Item>
+              </Descriptions>
+            ) : (
+              <Empty
+                description="No contact has been linked to this client yet."
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+              />
+            )}
+          </Card>
+        </Col>
+      </Row>
+
+      <Card
+        className="border-slate-200 shadow-sm"
+        title={`Priority pipeline (${clientOpportunities.length})`}
+      >
+        <AnimatedDashboardTable
+          columns={opportunityColumns}
+          dataSource={clientOpportunities}
+          emptyDescription="No opportunities linked to this client yet"
+          rowKey="id"
+        />
+      </Card>
+
+      <Card
+        className="border-slate-200 shadow-sm"
+        title={`Proposals (${clientProposals.length})`}
+      >
+        <AnimatedDashboardTable
+          columns={proposalColumns}
+          dataSource={clientProposals}
+          emptyDescription="No proposals linked to this client yet"
+          rowKey="id"
+        />
+      </Card>
+    </div>
+  );
+}

--- a/components/dashboard/clients-panel.tsx
+++ b/components/dashboard/clients-panel.tsx
@@ -2,6 +2,7 @@
 
 import { Button, Tag, Typography } from "antd";
 import { PlusOutlined, DeleteOutlined, EditOutlined } from "@ant-design/icons";
+import Link from "next/link";
 import { useState } from "react";
 
 import { useClientActions, useClientState } from "@/providers/clientProvider";
@@ -27,9 +28,16 @@ export function ClientsPanel() {
 
   const columns = [
     {
-      title: "Client Name",
-      dataIndex: "name",
       key: "name",
+      render: (_: unknown, record: IClient) => (
+        <Link
+          className="font-medium text-[#1f365c] transition-colors hover:text-[#f28c28]"
+          href={`/dashboard/clients/${record.id}`}
+        >
+          {record.name}
+        </Link>
+      ),
+      title: "Client Name",
     },
     {
       title: "Email",

--- a/components/dashboard/dashboard-frame.tsx
+++ b/components/dashboard/dashboard-frame.tsx
@@ -27,7 +27,9 @@ export function DashboardFrame({ children }: DashboardFrameProps) {
   const { logout } = useAuthActions();
   const { isAuthenticated, isPending, user } = useAuthState();
   const activeRole: UserRole = getPrimaryUserRole(user?.roles);
-  const activeNavItem = dashboardNavItems.find((item) => item.key === pathname);
+  const activeNavItem = dashboardNavItems.find(
+    (item) => pathname === item.key || pathname.startsWith(`${item.key}/`),
+  );
   const headerTitle = activeNavItem?.headerTitle ?? "Sales command center";
   const headerDescription =
     activeNavItem?.description ??
@@ -97,7 +99,7 @@ export function DashboardFrame({ children }: DashboardFrameProps) {
             className="min-h-0 flex-1 overflow-y-auto border-0 bg-transparent px-3 py-4"
             items={menuItems}
             mode="inline"
-            selectedKeys={[pathname]}
+            selectedKeys={[activeNavItem?.key ?? pathname]}
             theme="dark"
           />
 


### PR DESCRIPTION
## Summary

Add a dedicated client detail page so client records can be opened from the clients table and reviewed in context.

## Related Work

- Issue:
- Azure DevOps Work Item:

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Refactor
- [ ] Documentation
- [ ] Test-only change

## Validation

- [ ] `npm run lint`
- [x] `npm run build`
- [x] Manual verification completed

Describe the validation performed:

- Ran `npm run build`
- Verified the new `/dashboard/clients/[clientId]` route is present in the build output
- Verified the change set is limited to the client detail page flow

## Checklist

- [x] Branch name follows the repository standard
- [x] Change is limited to one logical unit of work
- [x] No unrelated files are included
- [ ] Documentation updated where required
- [ ] Screenshots attached for UI changes where relevant
- [ ] Breaking changes documented

## Screenshots

- Not attached in this PR

## Notes for Reviewers

- Client names in the clients table now link to a dedicated client page
- The client detail page is read-only in this PR and surfaces client details, primary contact, priority pipeline, and proposals
- `dashboard-frame` was adjusted so nested client routes still highlight the correct dashboard navigation item