### PR TITLE
fix: declare dayjs dependency for vercel build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@ant-design/nextjs-registry": "^1.3.0",
         "antd": "^6.3.6",
         "axios": "^1.15.2",
+        "dayjs": "^1.11.19",
         "next": "16.2.4",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -2402,6 +2403,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@ant-design/nextjs-registry": "^1.3.0",
     "antd": "^6.3.6",
     "axios": "^1.15.2",
+    "dayjs": "^1.11.19",
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       axios:
         specifier: ^1.15.2
         version: 1.15.2
+      dayjs:
+        specifier: ^1.11.19
+        version: 1.11.20
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary
Add the missing dayjs dependency and ignore local Vercel metadata so production builds succeed consistently on clean installs.

## Related Work
- Issue:
- Azure DevOps Work Item:

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix
- [ ] Refactor
- [ ] Documentation
- [ ] Test-only change

## Validation
- [ ] npm run lint
- [x] npm run build
- [ ] Manual verification completed

Describe the validation performed:
- Ran npm run build successfully after declaring dayjs.
- Confirmed the Vercel production deployment completed successfully with these changes.

## Checklist
- [x] Branch name follows the repository standard
- [x] Change is limited to one logical unit of work
- [x] No unrelated files are included
- [ ] Documentation updated where required
- [ ] Screenshots attached for UI changes where relevant
- [ ] Breaking changes documented

## Screenshots
None.

## Notes for Reviewers
This PR includes package.json, package-lock.json, pnpm-lock.yaml, and .gitignore only.