### PR TITLE
fix: replace deprecated antd alert prop

### DIFF
--- a/components/dashboard/reassignment-simulator.tsx
+++ b/components/dashboard/reassignment-simulator.tsx
@@ -320,7 +320,7 @@ export function ReassignmentSimulator() {
           <div className="space-y-4">
             <Alert
               description={result.summary}
-              message={`${result.recommendation} - ${result.scenarioRisk} risk`}
+              title={`${result.recommendation} - ${result.scenarioRisk} risk`}
               showIcon
               type={
                 result.recommendation === "Hold"


### PR DESCRIPTION
## Summary
Replace the deprecated Ant Design Alert message prop with title in the reassignment simulator to remove the console deprecation warning.

## Related Work
- Issue: #8
- Azure DevOps Work Item:

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix
- [ ] Refactor
- [ ] Documentation
- [ ] Test-only change

## Validation
- [ ] npm run lint
- [x] npm run build
- [ ] Manual verification completed

Describe the validation performed:
- Ran npm run build successfully.

## Checklist
- [x] Branch name follows the repository standard
- [x] Change is limited to one logical unit of work
- [x] No unrelated files are included
- [ ] Documentation updated where required
- [ ] Screenshots attached for UI changes where relevant
- [ ] Breaking changes documented

## Screenshots
None.

## Notes for Reviewers
Single-file change in the reassignment simulator Alert usage.