### PR TITLE
fix: force render modal forms

### DIFF
--- a/components/dashboard/activity-form.tsx
+++ b/components/dashboard/activity-form.tsx
@@ -90,6 +90,7 @@ export default function ActivityForm({
 
   return (
     <Modal
+      forceRender
       onCancel={onClose}
       onOk={() => form.submit()}
       okButtonProps={{ loading: isSubmitting }}

--- a/components/dashboard/contact-form.tsx
+++ b/components/dashboard/contact-form.tsx
@@ -34,6 +34,7 @@ export function ContactForm({
 
   return (
     <Modal
+      forceRender
       onCancel={onClose}
       onOk={() => form.submit()}
       okButtonProps={{ loading: isSubmitting }}

--- a/components/dashboard/renewal-form.tsx
+++ b/components/dashboard/renewal-form.tsx
@@ -64,6 +64,7 @@ export function RenewalForm({ isOpen, editingId, onClose }: RenewalFormProps) {
 
   return (
     <Modal
+      forceRender
       title={editingId ? "Edit Renewal" : "Add Renewal"}
       open={isOpen}
       onCancel={onClose}


### PR DESCRIPTION
## Summary

This PR fixes the Ant Design form instance warning that appears when opening modal-based dashboard forms.

## Changes

- add `forceRender` to the modal wrappers used by the activity, contact, and renewal forms
- ensure each `Form.useForm()` instance is connected to a mounted `Form` before form methods run

## Issue

- refs #20

## Validation

- npm run build
