### PR TITLE
fix: match the most specific sidebar route

### DIFF
--- a/components/dashboard/dashboard-frame.tsx
+++ b/components/dashboard/dashboard-frame.tsx
@@ -9,7 +9,11 @@ import { useEffect, useMemo, useState } from "react";
 import { getSessionToken } from "@/lib/client/backend-api";
 import { getPrimaryUserRole, getUserRoleLabel, isManagerRole } from "@/lib/auth/roles";
 import { dashboardNavItems } from "@/constants/dashboard-nav";
-import { canAccessDashboardPath, DASHBOARD_HOME_PATH } from "@/lib/auth/dashboard-access";
+import {
+  canAccessDashboardPath,
+  DASHBOARD_HOME_PATH,
+  getDashboardNavItemForPath,
+} from "@/lib/auth/dashboard-access";
 import { useAuthActions, useAuthState } from "@/providers/authProvider";
 import { type UserRole } from "@/providers/salesTypes";
 import { BoxfusionLogo } from "./boxfusion-logo";
@@ -27,9 +31,7 @@ export function DashboardFrame({ children }: DashboardFrameProps) {
   const { logout } = useAuthActions();
   const { isAuthenticated, isPending, user } = useAuthState();
   const activeRole: UserRole = getPrimaryUserRole(user?.roles);
-  const activeNavItem = dashboardNavItems.find(
-    (item) => pathname === item.key || pathname.startsWith(`${item.key}/`),
-  );
+  const activeNavItem = getDashboardNavItemForPath(pathname);
   const headerTitle = activeNavItem?.headerTitle ?? "Sales command center";
   const headerDescription =
     activeNavItem?.description ??

--- a/lib/auth/dashboard-access.ts
+++ b/lib/auth/dashboard-access.ts
@@ -3,10 +3,10 @@ import type { UserRole } from "@/providers/salesTypes";
 
 export const DASHBOARD_HOME_PATH = "/dashboard";
 
-const getNavItemForPath = (pathname: string) =>
+export const getDashboardNavItemForPath = (pathname: string) =>
   [...dashboardNavItems]
     .sort((left, right) => right.href.length - left.href.length)
     .find((item) => pathname === item.href || pathname.startsWith(`${item.href}/`));
 
 export const canAccessDashboardPath = (pathname: string, role: UserRole) =>
-  getNavItemForPath(pathname)?.access.includes(role) ?? true;
+  getDashboardNavItemForPath(pathname)?.access.includes(role) ?? true;


### PR DESCRIPTION
## Summary

This PR fixes dashboard sidebar route selection so the active item matches the most specific current route instead of falling back to `/dashboard`.

## Changes

- export the shared dashboard route matcher from the dashboard access helper
- reuse that matcher in the dashboard frame for sidebar active-state selection
- remove the separate unsorted sidebar route lookup

## Issue

- refs #27

## Validation

- npm run build
