### PR TITLE
feat: sanitize cookie-backed auth responses refs #54

### DIFF
--- a/app/api/Auth/login/route.ts
+++ b/app/api/Auth/login/route.ts
@@ -1,50 +1,41 @@
 import { NextRequest, NextResponse } from "next/server";
-
+import type { AuthLoginRequestDto } from "@/lib/auth/auth-contract";
 import { findUserByEmail, toAuthPayload } from "../mock-users";
-import { AUTH_COOKIE_NAME, AUTH_COOKIE_OPTIONS } from "../session-cookie";
+import { AUTH_COOKIE_NAME, AUTH_COOKIE_OPTIONS, sanitizeAuthPayload } from "../session-cookie";
 import { createBackendUrl } from "@/lib/server/backend-url";
-
 const readJsonBody = async (response: Response) => {
-  const text = await response.text();
-
-  if (!text.trim()) {
-    return {} as Record<string, unknown>;
-  }
-
-  return JSON.parse(text) as Record<string, unknown>;
+    const text = await response.text();
+    if (!text.trim()) {
+        return {} as Record<string, unknown>;
+    }
+    return JSON.parse(text) as Record<string, unknown>;
 };
-
-export async function POST(request: NextRequest) {
-  const rawBody = await request.text();
-  const credentials = JSON.parse(rawBody) as { email?: string; password?: string };
-  const email = credentials.email?.trim().toLowerCase() ?? "";
-  const mockUser = email ? findUserByEmail(email) : undefined;
-
-  if (mockUser && credentials.password === mockUser.password) {
-    const payload = toAuthPayload(mockUser);
-    const response = NextResponse.json(payload, { status: 200 });
-
-    response.cookies.set(AUTH_COOKIE_NAME, payload.token, AUTH_COOKIE_OPTIONS);
-
+export const POST = async (request: NextRequest) => {
+    const rawBody = await request.text();
+    const credentials = JSON.parse(rawBody) as AuthLoginRequestDto;
+    const email = credentials.email?.trim().toLowerCase() ?? "";
+    const mockUser = email ? findUserByEmail(email) : undefined;
+    if (mockUser && credentials.password === mockUser.password) {
+        const payload = toAuthPayload(mockUser);
+        const response = NextResponse.json(sanitizeAuthPayload(payload), { status: 200 });
+        if (payload.token) {
+            response.cookies.set(AUTH_COOKIE_NAME, payload.token, AUTH_COOKIE_OPTIONS);
+        }
+        return response;
+    }
+    const upstream = await fetch(createBackendUrl("/api/Auth/login"), {
+        body: rawBody,
+        headers: {
+            "Content-Type": "application/json",
+        },
+        method: "POST",
+        redirect: "manual",
+    });
+    const payload = await readJsonBody(upstream);
+    const token = typeof payload.token === "string" ? payload.token : "";
+    const response = NextResponse.json(sanitizeAuthPayload(payload), { status: upstream.status });
+    if (upstream.ok && token) {
+        response.cookies.set(AUTH_COOKIE_NAME, token, AUTH_COOKIE_OPTIONS);
+    }
     return response;
-  }
-
-  const upstream = await fetch(createBackendUrl("/api/Auth/login"), {
-    body: rawBody,
-    headers: {
-      "Content-Type": "application/json",
-    },
-    method: "POST",
-    redirect: "manual",
-  });
-  const payload = await readJsonBody(upstream);
-  const response = NextResponse.json(payload, { status: upstream.status });
-
-  const token = typeof payload.token === "string" ? payload.token : "";
-
-  if (upstream.ok && token) {
-    response.cookies.set(AUTH_COOKIE_NAME, token, AUTH_COOKIE_OPTIONS);
-  }
-
-  return response;
-}
+};

--- a/app/api/Auth/logout/route.ts
+++ b/app/api/Auth/logout/route.ts
@@ -1,14 +1,10 @@
 import { NextResponse } from "next/server";
-
 import { AUTH_COOKIE_NAME, AUTH_COOKIE_OPTIONS } from "../session-cookie";
-
-export async function POST() {
-  const response = NextResponse.json({ success: true });
-
-  response.cookies.set(AUTH_COOKIE_NAME, "", {
-    ...AUTH_COOKIE_OPTIONS,
-    maxAge: 0,
-  });
-
-  return response;
-}
+export const POST = async () => {
+    const response = NextResponse.json({ success: true });
+    response.cookies.set(AUTH_COOKIE_NAME, "", {
+        ...AUTH_COOKIE_OPTIONS,
+        maxAge: 0,
+    });
+    return response;
+};

--- a/app/api/Auth/me/route.ts
+++ b/app/api/Auth/me/route.ts
@@ -1,42 +1,36 @@
 import { NextRequest, NextResponse } from "next/server";
-
+import type { AuthSessionUser } from "@/lib/auth/auth-contract";
 import { toAuthPayload } from "../mock-users";
-import { AUTH_COOKIE_NAME, AUTH_COOKIE_OPTIONS } from "../session-cookie";
+import { AUTH_COOKIE_NAME, AUTH_COOKIE_OPTIONS, sanitizeAuthPayload } from "../session-cookie";
 import { createBackendUrl } from "@/lib/server/backend-url";
 import { getUserFromSessionToken } from "@/lib/auth/session-user";
-
-export async function GET(request: NextRequest) {
-  const authHeader = request.headers.get("authorization");
-  const cookieToken = request.cookies.get(AUTH_COOKIE_NAME)?.value;
-  const token = authHeader?.replace(/^Bearer\s+/i, "").trim() || cookieToken || "";
-  const mockUser = token ? getUserFromSessionToken(token) : null;
-
-  if (mockUser && token.startsWith("mock-token::")) {
-    return NextResponse.json(toAuthPayload(mockUser), { status: 200 });
-  }
-
-  const headers = new Headers();
-
-  if (authHeader) {
-    headers.set("authorization", authHeader);
-  } else if (cookieToken) {
-    headers.set("authorization", `Bearer ${cookieToken}`);
-  }
-  const upstream = await fetch(createBackendUrl("/api/Auth/me"), {
-    headers,
-    method: "GET",
-    redirect: "manual",
-  });
-  const payload =
-    upstream.status === 204 ? null : ((await upstream.json()) as Record<string, unknown> | null);
-  const response = NextResponse.json(payload, { status: upstream.status });
-
-  if (upstream.status === 401) {
-    response.cookies.set(AUTH_COOKIE_NAME, "", {
-      ...AUTH_COOKIE_OPTIONS,
-      maxAge: 0,
+export const GET = async (request: NextRequest) => {
+    const authHeader = request.headers.get("authorization");
+    const cookieToken = request.cookies.get(AUTH_COOKIE_NAME)?.value;
+    const token = authHeader?.replace(/^Bearer\s+/i, "").trim() || cookieToken || "";
+    const mockUser = token ? getUserFromSessionToken(token) : null;
+    if (mockUser && token.startsWith("mock-token::")) {
+        return NextResponse.json(sanitizeAuthPayload(toAuthPayload(mockUser)), { status: 200 });
+    }
+    const headers = new Headers();
+    if (authHeader) {
+        headers.set("authorization", authHeader);
+    }
+    else if (cookieToken) {
+        headers.set("authorization", `Bearer ${cookieToken}`);
+    }
+    const upstream = await fetch(createBackendUrl("/api/Auth/me"), {
+        headers,
+        method: "GET",
+        redirect: "manual",
     });
-  }
-
-  return response;
-}
+    const payload = upstream.status === 204 ? null : ((await upstream.json()) as AuthSessionUser | null);
+    const response = NextResponse.json(payload ? sanitizeAuthPayload(payload) : null, { status: upstream.status });
+    if (upstream.status === 401) {
+        response.cookies.set(AUTH_COOKIE_NAME, "", {
+            ...AUTH_COOKIE_OPTIONS,
+            maxAge: 0,
+        });
+    }
+    return response;
+};

--- a/app/api/Auth/mock-users.ts
+++ b/app/api/Auth/mock-users.ts
@@ -1,3 +1,6 @@
+import type { AuthSessionUser } from "@/lib/auth/auth-contract";
+import { MOCK_TEAM_MEMBERS } from "@/providers/salesFixtures";
+
 export type MockUserRole =
   | "Admin"
   | "SalesManager"
@@ -16,23 +19,94 @@ export interface IMockUser {
   tenantName: string;
 }
 
+const AUTO_SALES_TENANT_ID = "mock-tenant-autosales";
+const AUTO_SALES_TENANT_NAME = "AutoSales Mock Workspace";
+const AUTO_SALES_REP_PASSWORD = "Sales123";
+const AUTO_SALES_ADMIN_MEMBER_IDS = new Set(["tm02"]);
+
+const isClientFacingRole = (role: string) =>
+  [
+    "Account Executive",
+    "Sales Consultant",
+    "Client Success",
+    "Business Development",
+    "Pipeline Director",
+  ].some((token) => role.includes(token));
+
+const toAutoSalesRepEmail = (name: string) =>
+  `${name
+    .toLowerCase()
+    .replace(/[^a-z\s]/g, "")
+    .trim()
+    .replace(/\s+/g, ".")}@autosales.com`;
+
+const createAutoSalesRepUser = (member: (typeof MOCK_TEAM_MEMBERS)[number]): IMockUser => {
+  const [firstName, ...rest] = member.name.split(" ");
+
+  return {
+    clientIds: [],
+    email: toAutoSalesRepEmail(member.name),
+    firstName: firstName ?? member.name,
+    id: member.id,
+    lastName: rest.join(" ") || "Rep",
+    password: AUTO_SALES_REP_PASSWORD,
+    role: AUTO_SALES_ADMIN_MEMBER_IDS.has(member.id) ? "Admin" : "SalesRep",
+    tenantId: AUTO_SALES_TENANT_ID,
+    tenantName: AUTO_SALES_TENANT_NAME,
+  };
+};
+
+const autoSalesRepUsers = MOCK_TEAM_MEMBERS.filter((member) =>
+  isClientFacingRole(member.role),
+).map(createAutoSalesRepUser);
+
 const users = new Map<string, IMockUser>([
   [
     "admin@autosales.com",
     {
+      clientIds: [],
       email: "admin@autosales.com",
       firstName: "Admin",
       id: "legacy-admin",
       lastName: "User",
       password: "Admin123",
       role: "Admin",
-      tenantId: "mock-tenant-autosales",
-      tenantName: "AutoSales Mock Workspace",
+      tenantId: AUTO_SALES_TENANT_ID,
+      tenantName: AUTO_SALES_TENANT_NAME,
+    },
+  ],
+  [
+    "clients@autosales.com",
+    {
+      clientIds: ["c1"],
+      email: "clients@autosales.com",
+      firstName: "Client",
+      id: "legacy-client-viewer",
+      lastName: "Tester",
+      password: "Clients123",
+      role: "SalesRep",
+      tenantId: AUTO_SALES_TENANT_ID,
+      tenantName: AUTO_SALES_TENANT_NAME,
+    },
+  ],
+  [
+    "salesrep@autosales.com",
+    {
+      clientIds: [],
+      email: "salesrep@autosales.com",
+      firstName: "Lebo",
+      id: "tm02",
+      lastName: "Dlamini",
+      password: AUTO_SALES_REP_PASSWORD,
+      role: "Admin",
+      tenantId: AUTO_SALES_TENANT_ID,
+      tenantName: AUTO_SALES_TENANT_NAME,
     },
   ],
   [
     "admin@salesautomation.com",
     {
+      clientIds: [],
       email: "admin@salesautomation.com",
       firstName: "Admin",
       id: "1",
@@ -46,6 +120,7 @@ const users = new Map<string, IMockUser>([
   [
     "salesrep@salesautomation.com",
     {
+      clientIds: [],
       email: "salesrep@salesautomation.com",
       firstName: "Demo",
       id: "2",
@@ -56,6 +131,7 @@ const users = new Map<string, IMockUser>([
       tenantName: "Shared Demo Tenant",
     },
   ],
+  ...autoSalesRepUsers.map((user) => [user.email, user] as const),
 ]);
 
 let nextId = 3;
@@ -94,6 +170,7 @@ export const registerMockUser = ({
   }
 
   const user: IMockUser = {
+    clientIds: [],
     email: normalizedEmail,
     firstName,
     id: String(nextId++),
@@ -109,7 +186,8 @@ export const registerMockUser = ({
   return user;
 };
 
-export const toAuthPayload = (user: IMockUser) => ({
+export const toAuthPayload = (user: IMockUser): AuthSessionUser => ({
+  clientIds: user.clientIds ?? [],
   email: user.email,
   firstName: user.firstName,
   lastName: user.lastName,

--- a/app/api/Auth/register/route.ts
+++ b/app/api/Auth/register/route.ts
@@ -1,35 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
-
-import { AUTH_COOKIE_NAME, AUTH_COOKIE_OPTIONS } from "../session-cookie";
+import { AUTH_COOKIE_NAME, AUTH_COOKIE_OPTIONS, sanitizeAuthPayload } from "../session-cookie";
 import { createBackendUrl } from "@/lib/server/backend-url";
-
 const readJsonBody = async (response: Response) => {
-  const text = await response.text();
-
-  if (!text.trim()) {
-    return {} as Record<string, unknown>;
-  }
-
-  return JSON.parse(text) as Record<string, unknown>;
+    const text = await response.text();
+    if (!text.trim()) {
+        return {} as Record<string, unknown>;
+    }
+    return JSON.parse(text) as Record<string, unknown>;
 };
-
-export async function POST(request: NextRequest) {
-  const upstream = await fetch(createBackendUrl("/api/Auth/register"), {
-    body: await request.text(),
-    headers: {
-      "Content-Type": "application/json",
-    },
-    method: "POST",
-    redirect: "manual",
-  });
-  const payload = await readJsonBody(upstream);
-  const response = NextResponse.json(payload, { status: upstream.status });
-
-  const token = typeof payload.token === "string" ? payload.token : "";
-
-  if (upstream.ok && token) {
-    response.cookies.set(AUTH_COOKIE_NAME, token, AUTH_COOKIE_OPTIONS);
-  }
-
-  return response;
-}
+export const POST = async (request: NextRequest) => {
+    const upstream = await fetch(createBackendUrl("/api/Auth/register"), {
+        body: await request.text(),
+        headers: {
+            "Content-Type": "application/json",
+        },
+        method: "POST",
+        redirect: "manual",
+    });
+    const payload = await readJsonBody(upstream);
+    const token = typeof payload.token === "string" ? payload.token : "";
+    const response = NextResponse.json(sanitizeAuthPayload(payload), { status: upstream.status });
+    if (upstream.ok && token) {
+        response.cookies.set(AUTH_COOKIE_NAME, token, AUTH_COOKIE_OPTIONS);
+    }
+    return response;
+};

--- a/app/api/Auth/session-cookie.ts
+++ b/app/api/Auth/session-cookie.ts
@@ -7,3 +7,13 @@ export const AUTH_COOKIE_OPTIONS = {
   sameSite: "lax" as const,
   secure: process.env.NODE_ENV === "production",
 };
+
+export const sanitizeAuthPayload = <T extends { token?: string | null }>(payload: T) => {
+  const token = typeof payload.token === "string" ? payload.token : "";
+
+  return {
+    ...payload,
+    isMockSession: token.startsWith("mock-token::"),
+    token: null,
+  };
+};

--- a/lib/auth/auth-contract.ts
+++ b/lib/auth/auth-contract.ts
@@ -1,0 +1,32 @@
+export interface AuthLoginRequestDto {
+  email?: string | null;
+  password?: string | null;
+}
+
+export interface AuthRegisterRequestDto {
+  email?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  password?: string | null;
+  phoneNumber?: string | null;
+  role?: string | null;
+  tenantId?: string | null;
+  tenantName?: string | null;
+}
+
+export interface BackendLoginResponseDto {
+  email?: string | null;
+  expiresAt?: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  roles?: string[] | null;
+  tenantId?: string | null;
+  token?: string | null;
+  userId?: string;
+}
+
+export interface AuthSessionUser extends BackendLoginResponseDto {
+  clientIds?: string[] | null;
+  isMockSession?: boolean;
+  tenantName?: string | null;
+}


### PR DESCRIPTION
## Summary
- sanitize auth API response payloads for cookie-backed sessions
- add shared auth response contract shaping

## Issue
- refs #54

## Notes
- draft PR for scoped review