### PR TITLE
feat: align client auth flow with cookie sessions refs #55

### DIFF
--- a/hoc/withAuth.tsx
+++ b/hoc/withAuth.tsx
@@ -1,33 +1,23 @@
 "use client";
-
 import React from "react";
 import { Spin } from "antd";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
-
 import { useAuthState } from "@/providers/authProvider";
-
-export function withAuth<TProps extends object>(
-  Component: React.ComponentType<TProps>,
-) {
-  return function AuthenticatedComponent(props: TProps) {
-    const { isAuthenticated, isPending } = useAuthState();
-    const router = useRouter();
-
-    useEffect(() => {
-      if (!isPending && !isAuthenticated) {
-        router.push("/login");
-      }
-    }, [isAuthenticated, isPending, router]);
-
-    if (isPending || !isAuthenticated) {
-      return (
-        <div className="flex min-h-[40vh] items-center justify-center">
-          <Spin size="large" />
-        </div>
-      );
-    }
-
-    return React.createElement(Component, props);
-  };
-}
+export const withAuth = <TProps extends object>(Component: React.ComponentType<TProps>) => {
+    return function AuthenticatedComponent(props: TProps) {
+        const { isAuthenticated, isPending } = useAuthState();
+        const router = useRouter();
+        useEffect(() => {
+            if (!isPending && !isAuthenticated) {
+                router.push("/login");
+            }
+        }, [isAuthenticated, isPending, router]);
+        if (isPending || !isAuthenticated) {
+            return (<div className="flex min-h-[40vh] items-center justify-center">
+          <Spin size="large"/>
+        </div>);
+        }
+        return React.createElement(Component, props);
+    };
+};

--- a/lib/auth/dashboard-access.ts
+++ b/lib/auth/dashboard-access.ts
@@ -2,11 +2,45 @@ import { dashboardNavItems } from "@/constants/dashboard-nav";
 import type { UserRole } from "@/providers/salesTypes";
 
 export const DASHBOARD_HOME_PATH = "/dashboard";
+const CLIENT_SCOPED_HOME_PATH = "/dashboard";
+
+const CLIENT_SCOPED_ALLOWED_PATHS = [
+  "/dashboard",
+  "/dashboard/clients",
+  "/dashboard/activities",
+  "/dashboard/assistant",
+  "/dashboard/proposals",
+  "/dashboard/documents",
+  "/dashboard/messages",
+] as const;
+
+const matchesScopedPath = (pathname: string, path: string) =>
+  path === "/dashboard"
+    ? pathname === path
+    : pathname === path || pathname.startsWith(`${path}/`);
+
+const isClientScopedPath = (pathname: string) =>
+  CLIENT_SCOPED_ALLOWED_PATHS.some((path) => matchesScopedPath(pathname, path));
 
 export const getDashboardNavItemForPath = (pathname: string) =>
   [...dashboardNavItems]
     .sort((left, right) => right.href.length - left.href.length)
     .find((item) => pathname === item.href || pathname.startsWith(`${item.href}/`));
 
-export const canAccessDashboardPath = (pathname: string, role: UserRole) =>
-  getDashboardNavItemForPath(pathname)?.access.includes(role) ?? true;
+export const isClientScopedUser = (clientIds?: string[] | null) =>
+  Array.isArray(clientIds) && clientIds.length > 0;
+
+export const getDashboardHomePath = (role: UserRole, clientIds?: string[] | null) =>
+  isClientScopedUser(clientIds) ? CLIENT_SCOPED_HOME_PATH : DASHBOARD_HOME_PATH;
+
+export const canAccessDashboardPath = (
+  pathname: string,
+  role: UserRole,
+  clientIds?: string[] | null,
+) => {
+  if (isClientScopedUser(clientIds)) {
+    return isClientScopedPath(pathname);
+  }
+
+  return getDashboardNavItemForPath(pathname)?.access.includes(role) ?? true;
+};

--- a/lib/client/auth-session.ts
+++ b/lib/client/auth-session.ts
@@ -1,47 +1,13 @@
 "use client";
 
-import type { IUserLoginResponse } from "@/providers/authProvider/context";
+import type { AuthSessionUser } from "@/lib/auth/auth-contract";
 
-const AUTH_STORAGE_KEY = "auth_user";
+export const getSessionToken = (): string | null => null;
 
-export const getSessionToken = () =>
-  typeof window !== "undefined" ? sessionStorage.getItem("token") : null;
+export const getStoredAuthUser = (): AuthSessionUser | null => null;
 
-export const getStoredAuthUser = () => {
-  if (typeof window === "undefined") {
-    return null;
-  }
-
-  const raw = sessionStorage.getItem(AUTH_STORAGE_KEY);
-
-  if (!raw) {
-    return null;
-  }
-
-  try {
-    return JSON.parse(raw) as IUserLoginResponse;
-  } catch {
-    return null;
-  }
+export const storeAuthSession = (user: AuthSessionUser) => {
+  void user;
 };
 
-export const storeAuthSession = (user: IUserLoginResponse) => {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  if (user.token) {
-    sessionStorage.setItem("token", user.token);
-  }
-
-  sessionStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(user));
-};
-
-export const clearAuthSession = () => {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  sessionStorage.removeItem("token");
-  sessionStorage.removeItem(AUTH_STORAGE_KEY);
-};
+export const clearAuthSession = () => {};

--- a/lib/client/backend-api.ts
+++ b/lib/client/backend-api.ts
@@ -15,7 +15,6 @@ import {
   type ITeamMember,
 } from "@/providers/salesTypes";
 export { getSessionToken } from "@/lib/client/auth-session";
-import { getSessionToken } from "@/lib/client/auth-session";
 
 export type BackendPagedResult<T> = {
   items?: T[] | null;
@@ -184,11 +183,6 @@ export const backendRequest = async <T>(
   init: RequestInit = {},
 ): Promise<T> => {
   const headers = new Headers(init.headers);
-  const token = getSessionToken();
-
-  if (token) {
-    headers.set("Authorization", `Bearer ${token}`);
-  }
 
   if (init.body && !(init.body instanceof FormData) && !headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json");

--- a/providers/authProvider/context.tsx
+++ b/providers/authProvider/context.tsx
@@ -1,32 +1,14 @@
 import { createContext } from "react";
 
-export interface IUserLoginRequest {
-  email?: string | null;
-  password?: string | null;
-}
+import type {
+  AuthLoginRequestDto,
+  AuthRegisterRequestDto,
+  AuthSessionUser,
+} from "@/lib/auth/auth-contract";
 
-export interface IUserRegisterRequest {
-  email?: string | null;
-  firstName?: string | null;
-  lastName?: string | null;
-  password?: string | null;
-  phoneNumber?: string | null;
-  role?: string | null;
-  tenantId?: string | null;
-  tenantName?: string | null;
-}
-
-export interface IUserLoginResponse {
-  email?: string | null;
-  expiresAt?: string;
-  firstName?: string | null;
-  lastName?: string | null;
-  roles?: string[] | null;
-  tenantId?: string | null;
-  tenantName?: string | null;
-  token?: string | null;
-  userId?: string;
-}
+export type IUserLoginRequest = AuthLoginRequestDto;
+export type IUserRegisterRequest = AuthRegisterRequestDto;
+export type IUserLoginResponse = AuthSessionUser;
 
 export interface IAuthStateContext {
   isAuthenticated: boolean;
@@ -51,6 +33,6 @@ export const INITIAL_STATE: IAuthStateContext = {
   user: null,
 };
 
-export const AuthStateContext = createContext<IAuthStateContext>(INITIAL_STATE);
+export const AuthStateContext = createContext<IAuthStateContext | undefined>(undefined);
 
-export const AuthActionContext = createContext<IAuthActionContext>(undefined!);
+export const AuthActionContext = createContext<IAuthActionContext | undefined>(undefined);

--- a/providers/authProvider/index.tsx
+++ b/providers/authProvider/index.tsx
@@ -1,206 +1,138 @@
 "use client";
-
 import { useCallback, useContext, useEffect, useReducer } from "react";
 import { useRouter } from "next/navigation";
-
-import {
-  clearAuthSession,
-  getSessionToken,
-  getStoredAuthUser,
-  storeAuthSession,
-} from "@/lib/client/auth-session";
-import {
-  getMePending,
-  getMeSuccess,
-  loginError,
-  loginPending,
-  loginSuccess,
-  logoutError,
-  logoutPending,
-  logoutSuccess,
-  registerError,
-  registerPending,
-  registerSuccess,
-} from "./actions";
-import {
-  AuthActionContext,
-  AuthStateContext,
-  INITIAL_STATE,
-  type IUserLoginRequest,
-  type IUserLoginResponse,
-  type IUserRegisterRequest,
-} from "./context";
+import { getDashboardHomePath } from "@/lib/auth/dashboard-access";
+import { getPrimaryUserRole } from "@/lib/auth/roles";
+import { clearAuthSession, storeAuthSession, } from "@/lib/client/auth-session";
+import { getMePending, getMeSuccess, loginError, loginPending, loginSuccess, logoutError, logoutPending, logoutSuccess, registerError, registerPending, registerSuccess, } from "./actions";
+import { AuthActionContext, AuthStateContext, INITIAL_STATE, type IUserLoginRequest, type IUserLoginResponse, type IUserRegisterRequest, } from "./context";
 import { AuthReducer } from "./reducers";
 export const useAuthState = () => {
-  const context = useContext(AuthStateContext);
-
-  if (context === undefined) {
-    throw new Error("useAuthState must be used within AuthProvider.");
-  }
-
-  return context;
+    const context = useContext(AuthStateContext);
+    if (context === undefined) {
+        throw new Error("useAuthState must be used within AuthProvider.");
+    }
+    return context;
 };
-
 export const useAuthActions = () => {
-  const context = useContext(AuthActionContext);
-
-  if (context === undefined) {
-    throw new Error("useAuthActions must be used within AuthProvider.");
-  }
-
-  return context;
+    const context = useContext(AuthActionContext);
+    if (context === undefined) {
+        throw new Error("useAuthActions must be used within AuthProvider.");
+    }
+    return context;
 };
-
 type AuthProviderProps = Readonly<{
-  children: React.ReactNode;
+    children: React.ReactNode;
 }>;
-
 const readJsonPayload = async <T,>(response: Response) => {
-  const text = await response.text();
-
-  if (!text.trim()) {
-    return {} as T;
-  }
-
-  return JSON.parse(text) as T;
+    const text = await response.text();
+    if (!text.trim()) {
+        return {} as T;
+    }
+    return JSON.parse(text) as T;
 };
-
-const authRequest = async <T,>(
-  path: "/api/Auth/login" | "/api/Auth/me" | "/api/Auth/register",
-  init: RequestInit = {},
-) => {
-  const headers = new Headers(init.headers);
-
-  if (init.body && !headers.has("Content-Type")) {
-    headers.set("Content-Type", "application/json");
-  }
-
-  const response = await fetch(path, {
-    ...init,
-    credentials: "same-origin",
-    headers,
-  });
-  const payload = (await readJsonPayload<T & { message?: string }>(response));
-
-  if (!response.ok) {
-    throw new Error(payload.message ?? "Authentication failed.");
-  }
-
-  return payload;
-};
-
-const mergeAuthUser = (
-  payload: Partial<IUserLoginResponse>,
-  fallback?: IUserLoginResponse | null,
-): IUserLoginResponse => ({
-  ...fallback,
-  ...payload,
-  roles: payload.roles ?? fallback?.roles ?? null,
-  token: payload.token ?? fallback?.token ?? getSessionToken(),
-});
-
-export default function AuthProvider({ children }: AuthProviderProps) {
-  const [state, dispatch] = useReducer(AuthReducer, INITIAL_STATE);
-  const router = useRouter();
-
-  const authenticate = async (
-    path: "/api/Auth/login" | "/api/Auth/register",
-    payload: IUserLoginRequest | IUserRegisterRequest,
-  ) => {
-    return authRequest<IUserLoginResponse>(path, {
-      body: JSON.stringify(payload),
-      method: "POST",
+const authRequest = async <T,>(path: "/api/Auth/login" | "/api/Auth/me" | "/api/Auth/register", init: RequestInit = {}) => {
+    const headers = new Headers(init.headers);
+    if (init.body && !headers.has("Content-Type")) {
+        headers.set("Content-Type", "application/json");
+    }
+    const response = await fetch(path, {
+        ...init,
+        credentials: "same-origin",
+        headers,
     });
-  };
-
-  const login = async (payload: IUserLoginRequest) => {
-    dispatch(loginPending());
-
-    await authenticate("/api/Auth/login", payload)
-      .then((response) => {
-        storeAuthSession(response);
-        dispatch(loginSuccess(response));
-        router.push("/dashboard");
-      })
-      .catch((error: unknown) => {
-        dispatch(loginError());
-        console.error(error);
-      });
-  };
-
-  const register = async (payload: IUserRegisterRequest) => {
-    dispatch(registerPending());
-
-    await authenticate("/api/Auth/register", payload)
-      .then((response) => {
-        storeAuthSession(response);
-        dispatch(registerSuccess(response));
-        router.push("/dashboard");
-      })
-      .catch((error: unknown) => {
-        dispatch(registerError());
-        console.error(error);
-      });
-  };
-
-  const logout = async () => {
-    dispatch(logoutPending());
-
-    try {
-      await fetch("/api/Auth/logout", {
-        method: "POST",
-      }).catch(() => undefined);
-      clearAuthSession();
-      dispatch(logoutSuccess());
-      router.push("/login");
-    } catch (error) {
-      console.error(error);
-      dispatch(logoutError());
+    const payload = (await readJsonPayload<T & {
+        message?: string;
+    }>(response));
+    if (!response.ok) {
+        throw new Error(payload.message ?? "Authentication failed.");
     }
-  };
-
-  const getMe = useCallback(async () => {
-    dispatch(getMePending());
-    const storedUser = getStoredAuthUser();
-    const token = storedUser?.token ?? getSessionToken();
-
-    if (!token) {
-      clearAuthSession();
-      dispatch(logoutSuccess());
-      return;
-    }
-
-    try {
-      const response = await authRequest<Partial<IUserLoginResponse>>("/api/Auth/me");
-      const nextUser = mergeAuthUser(response, storedUser);
-
-      storeAuthSession(nextUser);
-      dispatch(getMeSuccess(nextUser));
-      return;
-    } catch (error) {
-      console.error(error);
-    }
-
-    clearAuthSession();
-    dispatch(logoutSuccess());
-  }, []);
-
-  useEffect(() => {
-    void getMe();
-  }, [getMe]);
-
-  return (
-    <AuthStateContext.Provider value={state}>
-      <AuthActionContext.Provider
-        value={{
-          getMe,
-          login,
-          logout,
-          register,
-        }}
-      >
+    return payload;
+};
+const mergeAuthUser = (payload: Partial<IUserLoginResponse>, fallback?: IUserLoginResponse | null): IUserLoginResponse => ({
+    ...fallback,
+    ...payload,
+    clientIds: payload.clientIds ?? fallback?.clientIds ?? null,
+    isMockSession: payload.isMockSession ?? fallback?.isMockSession ?? false,
+    roles: payload.roles ?? fallback?.roles ?? null,
+    token: null,
+});
+export const AuthProvider = ({ children }: AuthProviderProps) => {
+    const [state, dispatch] = useReducer(AuthReducer, INITIAL_STATE);
+    const router = useRouter();
+    const authenticate = async (path: "/api/Auth/login" | "/api/Auth/register", payload: IUserLoginRequest | IUserRegisterRequest) => {
+        return authRequest<IUserLoginResponse>(path, {
+            body: JSON.stringify(payload),
+            method: "POST",
+        });
+    };
+    const login = async (payload: IUserLoginRequest) => {
+        dispatch(loginPending());
+        await authenticate("/api/Auth/login", payload)
+            .then((response) => {
+            storeAuthSession(response);
+            dispatch(loginSuccess(response));
+            router.push(getDashboardHomePath(getPrimaryUserRole(response.roles), response.clientIds));
+        })
+            .catch((error: unknown) => {
+            dispatch(loginError());
+            console.error(error);
+        });
+    };
+    const register = async (payload: IUserRegisterRequest) => {
+        dispatch(registerPending());
+        await authenticate("/api/Auth/register", payload)
+            .then((response) => {
+            storeAuthSession(response);
+            dispatch(registerSuccess(response));
+            router.push(getDashboardHomePath(getPrimaryUserRole(response.roles), response.clientIds));
+        })
+            .catch((error: unknown) => {
+            dispatch(registerError());
+            console.error(error);
+        });
+    };
+    const logout = async () => {
+        dispatch(logoutPending());
+        try {
+            await fetch("/api/Auth/logout", {
+                method: "POST",
+            }).catch(() => undefined);
+            clearAuthSession();
+            dispatch(logoutSuccess());
+            router.push("/login");
+        }
+        catch (error) {
+            console.error(error);
+            dispatch(logoutError());
+        }
+    };
+    const getMe = useCallback(async () => {
+        dispatch(getMePending());
+        try {
+            const response = await authRequest<Partial<IUserLoginResponse>>("/api/Auth/me");
+            const nextUser = mergeAuthUser(response, null);
+            storeAuthSession(nextUser);
+            dispatch(getMeSuccess(nextUser));
+            return;
+        }
+        catch (error) {
+            console.error(error);
+        }
+        clearAuthSession();
+        dispatch(logoutSuccess());
+    }, []);
+    useEffect(() => {
+        void getMe();
+    }, [getMe]);
+    return (<AuthStateContext.Provider value={state}>
+      <AuthActionContext.Provider value={{
+            getMe,
+            login,
+            logout,
+            register,
+        }}>
         {children}
       </AuthActionContext.Provider>
-    </AuthStateContext.Provider>
-  );
-}
+    </AuthStateContext.Provider>);
+};

--- a/utils/axiosInstance.tsx
+++ b/utils/axiosInstance.tsx
@@ -1,14 +1,10 @@
 import axios from "axios";
 
 export const axiosInstance = () => {
-  const token =
-    typeof window !== "undefined" ? sessionStorage.getItem("token") : null;
-
   return axios.create({
     baseURL: "/api/backend",
     headers: {
       "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
     withCredentials: true,
   });


### PR DESCRIPTION
## Summary
- align client-side auth flow with cookie-backed session behavior
- remove token storage assumptions from client auth helpers

## Issue
- refs #55

## Notes
- draft PR for scoped review