### PR TITLE
feat: sync assistant mock CRUD across dashboard

### DIFF
--- a/app/api/assistant/route.ts
+++ b/app/api/assistant/route.ts
@@ -29,6 +29,48 @@ const parseMessages = (value: unknown): AssistantMessage[] => {
       const role =
         (message as { role?: unknown }).role === "assistant" ? "assistant" : "user";
       const content = String((message as { content?: unknown }).content ?? "").trim();
+      const rawMutations = (message as { mutations?: unknown }).mutations;
+      let mutations: AssistantMutation[] | undefined;
+
+      if (Array.isArray(rawMutations)) {
+        mutations = rawMutations
+          .flatMap((mutation) => {
+            if (!mutation || typeof mutation !== "object") {
+              return [];
+            }
+
+            const candidate = mutation as {
+              entityId?: unknown;
+              entityType?: unknown;
+              operation?: unknown;
+              record?: unknown;
+              title?: unknown;
+            };
+
+            if (
+              typeof candidate.entityId !== "string" ||
+              typeof candidate.entityType !== "string" ||
+              typeof candidate.operation !== "string" ||
+              typeof candidate.title !== "string"
+            ) {
+              return [];
+            }
+
+            return [
+              {
+                entityId: candidate.entityId,
+                entityType: candidate.entityType as AssistantMutation["entityType"],
+                operation: candidate.operation as AssistantMutation["operation"],
+                record:
+                  candidate.record && typeof candidate.record === "object"
+                    ? (candidate.record as Record<string, unknown>)
+                    : undefined,
+                title: candidate.title,
+              },
+            ];
+          })
+          .slice(0, 8);
+      }
 
       if (!content) {
         throw new Error("Message content is required.");
@@ -36,6 +78,7 @@ const parseMessages = (value: unknown): AssistantMessage[] => {
 
       return {
         content: content.slice(0, MAX_MESSAGE_LENGTH),
+        mutations,
         role,
       };
     });

--- a/app/api/backend/[...path]/route.ts
+++ b/app/api/backend/[...path]/route.ts
@@ -7,27 +7,37 @@ import { getBackendBaseUrl } from "@/lib/server/backend-url";
 import {
   addMockProposalLineItem,
   assignMockOpportunity,
+  createMockActivity,
   createMockClient,
   createMockContact,
+  createMockNote,
   createMockOpportunity,
+  createMockPricingRequest,
   createMockProposal,
+  deleteMockActivity,
   deleteMockClient,
   deleteMockContact,
+  deleteMockNote,
   deleteMockOpportunity,
+  deleteMockPricingRequest,
   deleteMockProposal,
   deleteMockProposalLineItem,
   getMockProposal,
   listMockActivities,
   listMockClients,
   listMockContacts,
+  listMockNotes,
   listMockOpportunities,
+  listMockPricingRequests,
   listMockProposals,
   transitionMockProposal,
   updateMockActivity,
   updateMockClient,
   updateMockContact,
+  updateMockNote,
   updateMockOpportunity,
   updateMockOpportunityStage,
+  updateMockPricingRequest,
   updateMockProposal,
   updateMockProposalLineItem,
 } from "@/lib/server/mock-workspace-store";
@@ -288,6 +298,40 @@ const toActivityDto = (activity: ReturnType<typeof listMockActivities>[number]) 
   typeName: String(activity.type ?? "Task"),
 });
 
+const toPricingRequestDto = (
+  request: ReturnType<typeof listMockPricingRequests>[number],
+) => ({
+  assignedToId: request.assignedToId ?? null,
+  assignedToName: request.assignedToName ?? null,
+  completedDate: request.completedDate ? `${request.completedDate}T09:00:00` : null,
+  createdAt: request.createdAt,
+  description: request.description ?? null,
+  id: request.id,
+  opportunityId: request.opportunityId,
+  opportunityTitle: request.opportunityTitle ?? null,
+  priority: request.priority ?? 2,
+  priorityName: request.priorityLabel ?? null,
+  requestNumber: request.requestNumber ?? null,
+  requestedById: request.requestedById ?? null,
+  requestedByName: request.requestedByName ?? null,
+  requiredByDate: request.requiredByDate ? `${request.requiredByDate}T09:00:00` : null,
+  status:
+    String(request.status) === "In Progress"
+      ? 2
+      : String(request.status) === "Completed"
+        ? 3
+        : String(request.status) === "Cancelled"
+          ? 4
+          : 1,
+  statusName: String(request.status ?? "Pending"),
+  title: request.title,
+  updatedAt: request.updatedAt ?? null,
+});
+
+const toNoteDto = (note: ReturnType<typeof listMockNotes>[number]) => ({
+  ...note,
+});
+
 const handleMockRequest = async (
   request: NextRequest,
   path: string[],
@@ -471,6 +515,26 @@ const handleMockRequest = async (
       return json({ items: items.map(toActivityDto) });
     }
 
+    if (!id && request.method === "POST" && body) {
+      const activity = createMockActivity(user, {
+        assignedToId: body.assignedToId ? String(body.assignedToId) : undefined,
+        assignedToName: body.assignedToName ? String(body.assignedToName) : undefined,
+        description: body.description ? String(body.description) : "",
+        dueDate: body.dueDate ? String(body.dueDate).split("T")[0] : "",
+        duration: body.duration ? Number(body.duration) : undefined,
+        location: body.location ? String(body.location) : undefined,
+        priority: Number(body.priority ?? 2),
+        relatedToId: String(body.relatedToId ?? ""),
+        relatedToType: Number(body.relatedToType ?? 2),
+        status: body.statusName ? String(body.statusName) : "Scheduled",
+        subject: String(body.subject ?? "Untitled activity"),
+        title: body.subject ? String(body.subject) : "Untitled activity",
+        type: body.typeName ? String(body.typeName) : "Task",
+      });
+
+      return json(toActivityDto(activity), 201);
+    }
+
     if (id && request.method === "PUT" && body) {
       const activity = updateMockActivity(user.tenantId, id, {
         assignedToId: body.assignedToId ? String(body.assignedToId) : undefined,
@@ -488,6 +552,141 @@ const handleMockRequest = async (
       });
 
       return activity ? json(toActivityDto(activity)) : json({ message: "Activity not found." }, 404);
+    }
+
+    if (id && request.method === "DELETE") {
+      deleteMockActivity(user.tenantId, id);
+      return new NextResponse(null, { status: 204 });
+    }
+  }
+
+  if (resource === "PricingRequests" || resource === "pricingrequests") {
+    if (!id && request.method === "GET") {
+      const items =
+        resource === "pricingrequests" && path[2] === "my-requests"
+          ? listMockPricingRequests(user.tenantId).filter((item) => item.requestedById === user.id)
+          : listMockPricingRequests(user.tenantId);
+
+      return json({ items: items.map(toPricingRequestDto) });
+    }
+
+    if (resource === "pricingrequests" && id === "my-requests" && request.method === "GET") {
+      const items = listMockPricingRequests(user.tenantId).filter(
+        (item) => item.requestedById === user.id,
+      );
+      return json({ items: items.map(toPricingRequestDto) });
+    }
+
+    if (!id && request.method === "POST" && body) {
+      const requestItem = createMockPricingRequest(user, {
+        assignedToId: body.assignedToId ? String(body.assignedToId) : undefined,
+        assignedToName: body.assignedToName ? String(body.assignedToName) : undefined,
+        description: body.description ? String(body.description) : undefined,
+        opportunityId: String(body.opportunityId ?? ""),
+        opportunityTitle: body.opportunityTitle ? String(body.opportunityTitle) : undefined,
+        priority: Number(body.priority ?? 2),
+        requestNumber: body.requestNumber ? String(body.requestNumber) : undefined,
+        requestedById: user.id,
+        requestedByName: `${user.firstName} ${user.lastName}`.trim(),
+        requiredByDate: body.requiredByDate ? String(body.requiredByDate) : undefined,
+        status: body.statusName ? String(body.statusName) : "Pending",
+        title: String(body.title ?? "Untitled pricing request"),
+        updatedAt: new Date().toISOString(),
+      });
+
+      return json(toPricingRequestDto(requestItem), 201);
+    }
+
+    if (id && nested === "assign" && request.method === "POST" && body) {
+      const requestItem = updateMockPricingRequest(user.tenantId, id, {
+        assignedToId: String(body.userId ?? ""),
+      });
+
+      return requestItem
+        ? json(toPricingRequestDto(requestItem))
+        : json({ message: "Pricing request not found." }, 404);
+    }
+
+    if (id && nested === "complete" && request.method === "PUT") {
+      const requestItem = updateMockPricingRequest(user.tenantId, id, {
+        completedDate: new Date().toISOString().split("T")[0],
+        status: "Completed",
+        updatedAt: new Date().toISOString(),
+      });
+
+      return requestItem
+        ? json(toPricingRequestDto(requestItem))
+        : json({ message: "Pricing request not found." }, 404);
+    }
+
+    if (id && !nested && request.method === "PUT" && body) {
+      const requestItem = updateMockPricingRequest(user.tenantId, id, {
+        assignedToId: body.assignedToId ? String(body.assignedToId) : undefined,
+        assignedToName: body.assignedToName ? String(body.assignedToName) : undefined,
+        description: body.description ? String(body.description) : undefined,
+        opportunityId: body.opportunityId ? String(body.opportunityId) : undefined,
+        opportunityTitle: body.opportunityTitle ? String(body.opportunityTitle) : undefined,
+        priority: body.priority ? Number(body.priority) : undefined,
+        requestNumber: body.requestNumber ? String(body.requestNumber) : undefined,
+        requiredByDate: body.requiredByDate ? String(body.requiredByDate) : undefined,
+        status: body.statusName ? String(body.statusName) : undefined,
+        title: body.title ? String(body.title) : undefined,
+        updatedAt: new Date().toISOString(),
+      });
+
+      return requestItem
+        ? json(toPricingRequestDto(requestItem))
+        : json({ message: "Pricing request not found." }, 404);
+    }
+
+    if (id && request.method === "DELETE") {
+      deleteMockPricingRequest(user.tenantId, id);
+      return new NextResponse(null, { status: 204 });
+    }
+  }
+
+  if (resource === "Notes" || resource === "notes") {
+    if (!id && request.method === "GET") {
+      return json({ items: listMockNotes(user.tenantId).map(toNoteDto) });
+    }
+
+    if (!id && request.method === "POST" && body) {
+      const note = createMockNote(user, {
+        category: String(body.category ?? "General"),
+        clientId: body.clientId ? String(body.clientId) : undefined,
+        content: String(body.content ?? ""),
+        createdDate: body.createdDate ? String(body.createdDate) : new Date().toISOString(),
+        kind: body.kind ? String(body.kind) as "client_feedback" | "client_message" | "general" : undefined,
+        representativeId: body.representativeId ? String(body.representativeId) : undefined,
+        representativeName: body.representativeName ? String(body.representativeName) : undefined,
+        source: body.source ? String(body.source) as "assistant" | "client_portal" | "workspace" : undefined,
+        status: body.status ? String(body.status) as "Acknowledged" | "Sent" : undefined,
+        title: String(body.title ?? "Untitled note"),
+      });
+
+      return json(toNoteDto(note), 201);
+    }
+
+    if (id && request.method === "PUT" && body) {
+      const note = updateMockNote(user.tenantId, id, {
+        category: body.category ? String(body.category) : undefined,
+        clientId: body.clientId ? String(body.clientId) : undefined,
+        content: body.content ? String(body.content) : undefined,
+        createdDate: body.createdDate ? String(body.createdDate) : undefined,
+        kind: body.kind ? String(body.kind) as "client_feedback" | "client_message" | "general" : undefined,
+        representativeId: body.representativeId ? String(body.representativeId) : undefined,
+        representativeName: body.representativeName ? String(body.representativeName) : undefined,
+        source: body.source ? String(body.source) as "assistant" | "client_portal" | "workspace" : undefined,
+        status: body.status ? String(body.status) as "Acknowledged" | "Sent" : undefined,
+        title: body.title ? String(body.title) : undefined,
+      });
+
+      return note ? json(toNoteDto(note)) : json({ message: "Note not found." }, 404);
+    }
+
+    if (id && request.method === "DELETE") {
+      deleteMockNote(user.tenantId, id);
+      return new NextResponse(null, { status: 204 });
     }
   }
 

--- a/components/dashboard/assistant-panel.tsx
+++ b/components/dashboard/assistant-panel.tsx
@@ -21,8 +21,15 @@ type AssistantMessage = {
   content: string;
   mutations?: Array<{
     entityId: string;
-    entityType: "client" | "opportunity" | "proposal";
+    entityType:
+      | "activity"
+      | "client"
+      | "note"
+      | "opportunity"
+      | "pricing_request"
+      | "proposal";
     operation: "create" | "delete" | "update";
+    record?: Record<string, unknown>;
     title: string;
   }>;
   role: "assistant" | "user";
@@ -190,8 +197,15 @@ export function AssistantPanel() {
         model?: string;
         mutations?: Array<{
           entityId: string;
-          entityType: "client" | "opportunity" | "proposal";
+          entityType:
+            | "activity"
+            | "client"
+            | "note"
+            | "opportunity"
+            | "pricing_request"
+            | "proposal";
           operation: "create" | "delete" | "update";
+          record?: Record<string, unknown>;
           title: string;
         }>;
         scopeLabel?: string;

--- a/lib/auth/dashboard-access.ts
+++ b/lib/auth/dashboard-access.ts
@@ -2,11 +2,45 @@ import { dashboardNavItems } from "@/constants/dashboard-nav";
 import type { UserRole } from "@/providers/salesTypes";
 
 export const DASHBOARD_HOME_PATH = "/dashboard";
+const CLIENT_SCOPED_HOME_PATH = "/dashboard";
+
+const CLIENT_SCOPED_ALLOWED_PATHS = [
+  "/dashboard",
+  "/dashboard/clients",
+  "/dashboard/activities",
+  "/dashboard/assistant",
+  "/dashboard/proposals",
+  "/dashboard/documents",
+  "/dashboard/messages",
+] as const;
+
+const matchesScopedPath = (pathname: string, path: string) =>
+  path === "/dashboard"
+    ? pathname === path
+    : pathname === path || pathname.startsWith(`${path}/`);
+
+const isClientScopedPath = (pathname: string) =>
+  CLIENT_SCOPED_ALLOWED_PATHS.some((path) => matchesScopedPath(pathname, path));
 
 export const getDashboardNavItemForPath = (pathname: string) =>
   [...dashboardNavItems]
     .sort((left, right) => right.href.length - left.href.length)
     .find((item) => pathname === item.href || pathname.startsWith(`${item.href}/`));
 
-export const canAccessDashboardPath = (pathname: string, role: UserRole) =>
-  getDashboardNavItemForPath(pathname)?.access.includes(role) ?? true;
+export const isClientScopedUser = (clientIds?: string[] | null) =>
+  Array.isArray(clientIds) && clientIds.length > 0;
+
+export const getDashboardHomePath = (role: UserRole, clientIds?: string[] | null) =>
+  isClientScopedUser(clientIds) ? CLIENT_SCOPED_HOME_PATH : DASHBOARD_HOME_PATH;
+
+export const canAccessDashboardPath = (
+  pathname: string,
+  role: UserRole,
+  clientIds?: string[] | null,
+) => {
+  if (isClientScopedUser(clientIds)) {
+    return isClientScopedPath(pathname);
+  }
+
+  return getDashboardNavItemForPath(pathname)?.access.includes(role) ?? true;
+};

--- a/lib/server/assistant-openai.ts
+++ b/lib/server/assistant-openai.ts
@@ -13,17 +13,27 @@ import { getAssistantServerConfig } from "./assistant-config";
 import type { IAssistantWorkspace } from "./assistant-workspace";
 import { isManagerRole } from "@/lib/auth/roles";
 import {
+  createMockActivity,
   createMockClient,
+  createMockNote,
+  deleteMockClient,
   deleteMockOpportunity,
   deleteMockProposal,
+  deleteMockActivity,
+  deleteMockNote,
+  deleteMockPricingRequest,
   createMockOpportunity,
+  createMockPricingRequest,
   createMockProposal,
   updateMockActivity,
+  updateMockNote,
   updateMockOpportunity,
+  updateMockPricingRequest,
 } from "@/lib/server/mock-workspace-store";
 
 export type AssistantMessage = {
   content: string;
+  mutations?: AssistantMutation[];
   role: "assistant" | "user";
 };
 
@@ -35,8 +45,9 @@ export type AssistantTraceStep = {
 
 export type AssistantMutation = {
   entityId: string;
-  entityType: "activity" | "client" | "opportunity" | "proposal";
+  entityType: "activity" | "client" | "note" | "opportunity" | "pricing_request" | "proposal";
   operation: "create" | "delete" | "update";
+  record?: Record<string, unknown>;
   title: string;
 };
 
@@ -185,10 +196,23 @@ const createAssistantActor = (workspace: IAssistantWorkspace): AssistantActor =>
   tenantName: workspace.scopeLabel,
 });
 
-const createToolset = (workspace: IAssistantWorkspace) => {
+const createToolset = (workspace: IAssistantWorkspace, messages: AssistantMessage[]) => {
   const { salesData } = workspace;
   const opportunityInsights = getOpportunityInsights(salesData);
   const actor = createAssistantActor(workspace);
+  const recentMutations = [...messages]
+    .reverse()
+    .filter((message) => message.role === "assistant")
+    .flatMap((message) => message.mutations ?? []);
+
+  const getRecentMutation = (...entityTypes: AssistantMutation["entityType"][]) =>
+    recentMutations.find(
+      (mutation) =>
+        mutation.operation === "create" && entityTypes.includes(mutation.entityType),
+    );
+
+  const hasValueReference = (value: unknown) =>
+    typeof value === "string" && value.trim().length > 0;
 
   const findClientByReference = (reference: unknown) => {
     if (typeof reference !== "string" || !reference.trim()) {
@@ -272,12 +296,61 @@ const createToolset = (workspace: IAssistantWorkspace) => {
     );
   };
 
-  const resolveClient = (args: Record<string, unknown>) => {
+  const getRecentClient = () => {
+    const recentClientMutation = getRecentMutation("client");
+
+    if (!recentClientMutation) {
+      return null;
+    }
+
+    return findClientByReference(recentClientMutation.entityId) ?? null;
+  };
+
+  const getRecentOpportunity = () => {
+    const recentOpportunityMutation = getRecentMutation("opportunity");
+
+    if (!recentOpportunityMutation) {
+      return null;
+    }
+
+    return findOpportunityByReference(recentOpportunityMutation.entityId) ?? null;
+  };
+
+  const getRecentProposal = () => {
+    const recentProposalMutation = getRecentMutation("proposal");
+
+    if (!recentProposalMutation) {
+      return null;
+    }
+
+    return findProposalByReference(recentProposalMutation.entityId) ?? null;
+  };
+
+  const resolveClient = (
+    args: Record<string, unknown>,
+    options?: { allowRecentFallback?: boolean },
+  ) => {
     const directClient =
       findClientByReference(args.clientId) ??
       findClientByReference(args.clientName) ??
       findClientByReference(args.organizationName) ??
       findClientByReference(args.accountName);
+
+    if (!directClient && options?.allowRecentFallback) {
+      const hasExplicitClientReference =
+        hasValueReference(args.clientId) ||
+        hasValueReference(args.clientName) ||
+        hasValueReference(args.organizationName) ||
+        hasValueReference(args.accountName);
+
+      if (!hasExplicitClientReference) {
+        const recentClient = getRecentClient();
+
+        if (recentClient) {
+          return recentClient;
+        }
+      }
+    }
 
     if (!directClient) {
       throw new Error(
@@ -290,7 +363,7 @@ const createToolset = (workspace: IAssistantWorkspace) => {
 
   const resolveOpportunity = (
     args: Record<string, unknown>,
-    options?: { allowCreateIfMissing?: boolean },
+    options?: { allowCreateIfMissing?: boolean; allowRecentFallback?: boolean },
   ) => {
     const directOpportunity =
       findOpportunityByReference(args.opportunityId) ??
@@ -300,7 +373,20 @@ const createToolset = (workspace: IAssistantWorkspace) => {
       return directOpportunity;
     }
 
-    const client = resolveClient(args);
+    if (options?.allowRecentFallback) {
+      const hasExplicitOpportunityReference =
+        hasValueReference(args.opportunityId) || hasValueReference(args.opportunityTitle);
+
+      if (!hasExplicitOpportunityReference) {
+        const recentOpportunity = getRecentOpportunity();
+
+        if (recentOpportunity) {
+          return recentOpportunity;
+        }
+      }
+    }
+
+    const client = resolveClient(args, { allowRecentFallback: options?.allowRecentFallback });
     const clientOpportunities = salesData.opportunities.filter(
       (opportunity) => opportunity.clientId === client.id,
     );
@@ -361,7 +447,10 @@ const createToolset = (workspace: IAssistantWorkspace) => {
     return generatedOpportunity;
   };
 
-  const resolveProposal = (args: Record<string, unknown>) => {
+  const resolveProposal = (
+    args: Record<string, unknown>,
+    options?: { allowRecentFallback?: boolean },
+  ) => {
     const directProposal =
       findProposalByReference(args.proposalId) ??
       findProposalByReference(args.proposalTitle) ??
@@ -369,6 +458,21 @@ const createToolset = (workspace: IAssistantWorkspace) => {
 
     if (directProposal) {
       return directProposal;
+    }
+
+    if (options?.allowRecentFallback) {
+      const hasExplicitProposalReference =
+        hasValueReference(args.proposalId) ||
+        hasValueReference(args.proposalTitle) ||
+        hasValueReference(args.title);
+
+      if (!hasExplicitProposalReference) {
+        const recentProposal = getRecentProposal();
+
+        if (recentProposal) {
+          return recentProposal;
+        }
+      }
     }
 
     const client =
@@ -628,6 +732,21 @@ const createToolset = (workspace: IAssistantWorkspace) => {
           validUntil: { type: "string" },
         },
         required: ["title", "validUntil"],
+        type: "object",
+      },
+    },
+    {
+      description:
+        "Delete an existing client and its linked mock opportunity and proposal records when the user explicitly asks to remove the account they just created or no longer need.",
+      name: "delete_client",
+      parameters: {
+        additionalProperties: false,
+        properties: {
+          accountName: { type: "string" },
+          clientId: { type: "string" },
+          clientName: { type: "string" },
+          organizationName: { type: "string" },
+        },
         type: "object",
       },
     },
@@ -988,8 +1107,41 @@ const createToolset = (workspace: IAssistantWorkspace) => {
           proposal,
         };
       }
+      case "delete_client": {
+        const client = resolveClient(args, { allowRecentFallback: true });
+
+        deleteMockClient(workspace.tenantId, client.id);
+        workspace.salesData.clients = workspace.salesData.clients.filter(
+          (item) => item.id !== client.id,
+        );
+        workspace.salesData.contacts = workspace.salesData.contacts.filter(
+          (item) => item.clientId !== client.id,
+        );
+        workspace.salesData.opportunities = workspace.salesData.opportunities.filter(
+          (item) => item.clientId !== client.id,
+        );
+        workspace.salesData.proposals = workspace.salesData.proposals.filter(
+          (item) => item.clientId !== client.id,
+        );
+
+        return {
+          deletedClient: {
+            id: client.id,
+            name: client.name,
+          },
+          mutation: {
+            entityId: client.id,
+            entityType: "client" as const,
+            operation: "delete" as const,
+            title: client.name,
+          },
+        };
+      }
       case "delete_opportunity": {
-        const opportunity = resolveOpportunity(args, { allowCreateIfMissing: false });
+        const opportunity = resolveOpportunity(args, {
+          allowCreateIfMissing: false,
+          allowRecentFallback: true,
+        });
 
         deleteMockOpportunity(workspace.tenantId, opportunity.id);
         workspace.salesData.opportunities = workspace.salesData.opportunities.filter(
@@ -1013,7 +1165,7 @@ const createToolset = (workspace: IAssistantWorkspace) => {
         };
       }
       case "delete_proposal": {
-        const proposal = resolveProposal(args);
+        const proposal = resolveProposal(args, { allowRecentFallback: true });
 
         deleteMockProposal(workspace.tenantId, proposal.id);
         workspace.salesData.proposals = workspace.salesData.proposals.filter(
@@ -1337,7 +1489,7 @@ export const runSecureAssistant = async ({
     };
   }
 
-  const { runTool, toolDefinitions } = createToolset(workspace);
+  const { runTool, toolDefinitions } = createToolset(workspace, messages);
   const toolMetadata = createToolMetadata(toolDefinitions);
   const trace: AssistantTraceStep[] = [];
   const mutations: AssistantMutation[] = [];

--- a/lib/server/mock-workspace-store.ts
+++ b/lib/server/mock-workspace-store.ts
@@ -38,6 +38,12 @@ type MockWorkspaceState = {
   salesData: ISalesData;
 };
 
+declare global {
+  // Keep one in-memory store across Next route bundles in the same Node process.
+  // eslint-disable-next-line no-var
+  var __mockWorkspaceStore__: Map<string, MockWorkspaceState> | undefined;
+}
+
 type CreateOpportunityInput = {
   clientId: string;
   contactId?: string;
@@ -70,7 +76,18 @@ type CreateProposalInput = {
   validUntil: string;
 };
 
-const workspaceStore = new Map<string, MockWorkspaceState>();
+type CreateActivityInput = Omit<IActivity, "id"> & {
+  id?: string;
+};
+
+type CreatePricingRequestInput = Omit<IPricingRequest, "createdAt" | "id"> & {
+  id?: string;
+};
+
+const workspaceStore =
+  globalThis.__mockWorkspaceStore__ ?? new Map<string, MockWorkspaceState>();
+
+globalThis.__mockWorkspaceStore__ = workspaceStore;
 
 const createId = (prefix: string) =>
   `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -515,6 +532,33 @@ export const listMockTeamMembers = (tenantId: string): ITeamMember[] =>
 export const listMockActivities = (tenantId: string): IActivity[] =>
   clone(getWorkspaceState(tenantId).salesData.activities);
 
+export const createMockActivity = (user: IMockUser, input: CreateActivityInput) => {
+  const workspace = getWorkspaceState(user.tenantId);
+  const assignedOwner = input.assignedToId
+    ? workspace.salesData.teamMembers.find((member) => member.id === input.assignedToId)
+    : undefined;
+  const activity: IActivity = {
+    ...input,
+    assignedToName: input.assignedToName ?? assignedOwner?.name,
+    completed: input.completed ?? false,
+    createdAt: new Date().toISOString(),
+    dueDate: normalizeDate(input.dueDate),
+    id: input.id ?? createId("act"),
+    status: input.status ?? "Scheduled",
+    title: input.title ?? input.subject,
+  };
+
+  workspace.salesData.activities.push(activity);
+  workspace.salesData.automationFeed.unshift({
+    createdAt: new Date().toISOString(),
+    description: `${user.firstName} ${user.lastName}`.trim() + ` logged ${activity.subject}.`,
+    id: createId("auto"),
+    title: "Activity created",
+  });
+
+  return clone(activity);
+};
+
 export const updateMockActivity = (
   tenantId: string,
   activityId: string,
@@ -533,4 +577,119 @@ export const updateMockActivity = (
   };
 
   return clone(workspace.salesData.activities[index]);
+};
+
+export const deleteMockActivity = (tenantId: string, activityId: string) => {
+  const workspace = getWorkspaceState(tenantId);
+  workspace.salesData.activities = workspace.salesData.activities.filter(
+    (item) => item.id !== activityId,
+  );
+};
+
+export const listMockPricingRequests = (tenantId: string): IPricingRequest[] =>
+  clone(getWorkspaceState(tenantId).pricingRequests);
+
+export const createMockPricingRequest = (
+  user: IMockUser,
+  input: CreatePricingRequestInput,
+) => {
+  const workspace = getWorkspaceState(user.tenantId);
+  const pricingRequest: IPricingRequest = {
+    ...input,
+    createdAt: new Date().toISOString(),
+    id: input.id ?? createId("price"),
+    requiredByDate: normalizeDate(input.requiredByDate),
+  };
+
+  workspace.pricingRequests.push(pricingRequest);
+  workspace.salesData.automationFeed.unshift({
+    createdAt: new Date().toISOString(),
+    description:
+      `${user.firstName} ${user.lastName}`.trim() + ` submitted ${pricingRequest.title}.`,
+    id: createId("auto"),
+    title: "Commercial request created",
+  });
+
+  return clone(pricingRequest);
+};
+
+export const updateMockPricingRequest = (
+  tenantId: string,
+  pricingRequestId: string,
+  patch: Partial<IPricingRequest>,
+) => {
+  const workspace = getWorkspaceState(tenantId);
+  const index = workspace.pricingRequests.findIndex((item) => item.id === pricingRequestId);
+
+  if (index < 0) {
+    return null;
+  }
+
+  workspace.pricingRequests[index] = {
+    ...workspace.pricingRequests[index],
+    ...patch,
+    requiredByDate: normalizeDate(
+      patch.requiredByDate ?? workspace.pricingRequests[index].requiredByDate,
+    ),
+  };
+
+  return clone(workspace.pricingRequests[index]);
+};
+
+export const deleteMockPricingRequest = (tenantId: string, pricingRequestId: string) => {
+  const workspace = getWorkspaceState(tenantId);
+  workspace.pricingRequests = workspace.pricingRequests.filter(
+    (item) => item.id !== pricingRequestId,
+  );
+};
+
+export const listMockNotes = (tenantId: string): INoteItem[] =>
+  clone(getWorkspaceState(tenantId).notes);
+
+export const createMockNote = (
+  user: IMockUser,
+  input: Omit<INoteItem, "id"> & { id?: string },
+) => {
+  const workspace = getWorkspaceState(user.tenantId);
+  const note: INoteItem = {
+    ...input,
+    createdDate: normalizeDate(input.createdDate),
+    id: input.id ?? createId("note"),
+  };
+
+  workspace.notes.push(note);
+  workspace.salesData.automationFeed.unshift({
+    createdAt: new Date().toISOString(),
+    description: `${user.firstName} ${user.lastName}`.trim() + ` captured note "${note.title}".`,
+    id: createId("auto"),
+    title: "Note created",
+  });
+
+  return clone(note);
+};
+
+export const updateMockNote = (
+  tenantId: string,
+  noteId: string,
+  patch: Partial<INoteItem>,
+) => {
+  const workspace = getWorkspaceState(tenantId);
+  const index = workspace.notes.findIndex((item) => item.id === noteId);
+
+  if (index < 0) {
+    return null;
+  }
+
+  workspace.notes[index] = {
+    ...workspace.notes[index],
+    ...patch,
+    createdDate: normalizeDate(patch.createdDate ?? workspace.notes[index].createdDate),
+  };
+
+  return clone(workspace.notes[index]);
+};
+
+export const deleteMockNote = (tenantId: string, noteId: string) => {
+  const workspace = getWorkspaceState(tenantId);
+  workspace.notes = workspace.notes.filter((item) => item.id !== noteId);
 };

--- a/providers/authProvider/context.tsx
+++ b/providers/authProvider/context.tsx
@@ -17,6 +17,7 @@ export interface IUserRegisterRequest {
 }
 
 export interface IUserLoginResponse {
+  clientIds?: string[] | null;
   email?: string | null;
   expiresAt?: string;
   firstName?: string | null;

--- a/providers/domainSeeds.ts
+++ b/providers/domainSeeds.ts
@@ -27,6 +27,11 @@ export interface INoteItem {
   content: string;
   createdDate: string;
   id: string;
+  kind?: "client_feedback" | "client_message" | "general";
+  representativeId?: string;
+  representativeName?: string;
+  source?: "assistant" | "client_portal" | "workspace";
+  status?: "Acknowledged" | "Sent";
   title: string;
 }
 

--- a/providers/noteProvider/index.tsx
+++ b/providers/noteProvider/index.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import { useContext, useReducer } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 
-import { initialNotes } from "@/providers/domainSeeds";
-import { addNoteAction, deleteNoteAction, updateNoteAction } from "./actions";
+import {
+  backendRequest,
+  coerceItems,
+  getSessionToken,
+  isMockSessionToken,
+} from "@/lib/client/backend-api";
+import { useAuthState } from "@/providers/authProvider";
+import { initialNotes, type INoteItem } from "@/providers/domainSeeds";
 import { NoteActionContext, NoteStateContext } from "./context";
-import { NoteReducer } from "./reducers";
 
 export const useNoteState = () => {
   const context = useContext(NoteStateContext);
@@ -30,16 +35,98 @@ export const useNoteActions = () => {
 export default function NoteProvider({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
-  const [state, dispatch] = useReducer(NoteReducer, { notes: initialNotes() });
+  const { isAuthenticated } = useAuthState();
+  const [notes, setNotes] = useState<INoteItem[]>([]);
+  const isDemoMode = isMockSessionToken(getSessionToken());
+
+  const loadNotes = useCallback(async () => {
+    const payload = await backendRequest<{ items?: INoteItem[] } | INoteItem[]>("/api/Notes");
+    setNotes(coerceItems(payload));
+  }, []);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    let isActive = true;
+
+    if (isDemoMode) {
+      const timer = window.setTimeout(() => {
+        void loadNotes().catch((error) => {
+          console.error(error);
+
+          if (isActive) {
+            setNotes(initialNotes());
+          }
+        });
+      }, 0);
+
+      const handleWorkspaceUpdate = () => {
+        void loadNotes().catch((error) => {
+          console.error(error);
+        });
+      };
+
+      window.addEventListener("mock-workspace-updated", handleWorkspaceUpdate);
+
+      return () => {
+        isActive = false;
+        window.clearTimeout(timer);
+        window.removeEventListener("mock-workspace-updated", handleWorkspaceUpdate);
+      };
+    }
+
+    void loadNotes().catch((error) => {
+      console.error(error);
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, [isAuthenticated, isDemoMode, loadNotes]);
 
   return (
-    <NoteStateContext.Provider value={state}>
+    <NoteStateContext.Provider value={{ notes: isAuthenticated ? notes : [] }}>
       <NoteActionContext.Provider
         value={{
-          addNote: (payload) => dispatch(addNoteAction(payload)),
-          deleteNote: (id) => dispatch(deleteNoteAction(id)),
-          updateNote: (id, payload) =>
-            dispatch(updateNoteAction({ id, ...payload })),
+          addNote: (payload) => {
+            void backendRequest<INoteItem>("/api/Notes", {
+              body: JSON.stringify(payload),
+              method: "POST",
+            })
+              .then((note) => {
+                setNotes((current) => [...current, note]);
+              })
+              .catch((error) => {
+                console.error(error);
+              });
+          },
+          deleteNote: (id) => {
+            void backendRequest<void>(`/api/Notes/${id}`, {
+              method: "DELETE",
+            })
+              .then(() => {
+                setNotes((current) => current.filter((item) => item.id !== id));
+              })
+              .catch((error) => {
+                console.error(error);
+              });
+          },
+          updateNote: (id, payload) => {
+            void backendRequest<INoteItem>(`/api/Notes/${id}`, {
+              body: JSON.stringify(payload),
+              method: "PUT",
+            })
+              .then((note) => {
+                setNotes((current) =>
+                  current.map((item) => (item.id === id ? note : item)),
+                );
+              })
+              .catch((error) => {
+                console.error(error);
+              });
+          },
         }}
       >
         {children}

--- a/providers/pricingRequestProvider/index.tsx
+++ b/providers/pricingRequestProvider/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 
 import { getPrimaryUserRole } from "@/lib/auth/roles";
 import {
@@ -53,6 +53,19 @@ export default function PricingRequestProvider({
   const isDemoMode = isMockSessionToken(getSessionToken());
   const role = getPrimaryUserRole(user?.roles);
 
+  const listPath =
+    role === "SalesRep"
+      ? "/api/pricingrequests/my-requests?pageNumber=1&pageSize=100"
+      : "/api/PricingRequests?pageNumber=1&pageSize=100";
+
+  const loadPricingRequests = useCallback(async () => {
+    const payload = await backendRequest<BackendPagedResult<BackendPricingRequestDto> | BackendPricingRequestDto[]>(
+      listPath,
+    );
+
+    setPricingRequests(coerceItems(payload).map(mapBackendPricingRequest));
+  }, [listPath]);
+
   useEffect(() => {
     if (!isAuthenticated) {
       return;
@@ -61,37 +74,39 @@ export default function PricingRequestProvider({
     let isActive = true;
 
     if (isDemoMode) {
-      Promise.resolve().then(() => {
-        if (isActive) {
-          setPricingRequests(initialPricingRequests());
-        }
-      });
+      const timer = window.setTimeout(() => {
+        void loadPricingRequests().catch((error) => {
+          console.error(error);
+
+          if (isActive) {
+            setPricingRequests(initialPricingRequests());
+          }
+        });
+      }, 0);
+
+      const handleWorkspaceUpdate = () => {
+        void loadPricingRequests().catch((error) => {
+          console.error(error);
+        });
+      };
+
+      window.addEventListener("mock-workspace-updated", handleWorkspaceUpdate);
 
       return () => {
         isActive = false;
+        window.clearTimeout(timer);
+        window.removeEventListener("mock-workspace-updated", handleWorkspaceUpdate);
       };
     }
 
-    void backendRequest<BackendPagedResult<BackendPricingRequestDto> | BackendPricingRequestDto[]>(
-      role === "SalesRep"
-        ? "/api/pricingrequests/my-requests?pageNumber=1&pageSize=100"
-        : "/api/PricingRequests?pageNumber=1&pageSize=100",
-    )
-      .then((payload) => {
-        if (!isActive) {
-          return;
-        }
-
-        setPricingRequests(coerceItems(payload).map(mapBackendPricingRequest));
-      })
-      .catch((error) => {
+    void loadPricingRequests().catch((error) => {
         console.error(error);
       });
 
     return () => {
       isActive = false;
     };
-  }, [isAuthenticated, isDemoMode, role]);
+  }, [isAuthenticated, isDemoMode, loadPricingRequests]);
 
   const replacePricingRequest = (request: IPricingRequest) => {
     setPricingRequests((current) => {


### PR DESCRIPTION
## Summary
- make assistant-created mock workspace records visible across dashboard pages
- expose missing mock backend endpoints for notes, pricing requests, and activity mutations
- preserve recent assistant mutations so follow-up actions like delete can resolve against just-created records

## Linked issue
- refs #179

## Validation
- npm run build