### PR TITLE
fix: prevent dashboard modal hydration mismatches

### DIFF
--- a/components/dashboard/activities-panel.tsx
+++ b/components/dashboard/activities-panel.tsx
@@ -103,17 +103,19 @@ export function ActivitiesPanel() {
         rowKey="id"
       />
 
-      <ActivityForm
-        editingId={editingId}
-        isOpen={isModalOpen || editingId !== null}
-        isSubmitting={isSubmitting}
-        onClose={() => {
-          setIsModalOpen(false);
-          setEditingId(null);
-        }}
-        onSubmitStart={() => setIsSubmitting(true)}
-        onSubmitEnd={() => setIsSubmitting(false)}
-      />
+      {isModalOpen || editingId !== null ? (
+        <ActivityForm
+          editingId={editingId}
+          isOpen={isModalOpen || editingId !== null}
+          isSubmitting={isSubmitting}
+          onClose={() => {
+            setIsModalOpen(false);
+            setEditingId(null);
+          }}
+          onSubmitStart={() => setIsSubmitting(true)}
+          onSubmitEnd={() => setIsSubmitting(false)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/components/dashboard/activity-form.tsx
+++ b/components/dashboard/activity-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Form, Input, Modal, Select } from "antd";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { ActivityStatus, ActivityType, type IActivity } from "@/providers/salesTypes";
 import { useActivityActions, useActivityState } from "@/providers/activityProvider";
@@ -26,12 +26,17 @@ export default function ActivityForm({
   onSubmitStart,
   onSubmitEnd,
 }: ActivityFormProps) {
+  const [isClient, setIsClient] = useState(false);
   const [form] = Form.useForm();
   const { activities } = useActivityState();
   const { opportunities } = useOpportunityState();
   const { proposals } = useProposalState();
   const { teamMembers } = useDashboardState();
   const { addActivity, updateActivity } = useActivityActions();
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
   useEffect(() => {
     if (editingId) {
@@ -87,6 +92,10 @@ export default function ActivityForm({
       onSubmitEnd?.();
     }
   };
+
+  if (!isClient) {
+    return null;
+  }
 
   return (
     <Modal

--- a/components/dashboard/activity-form.tsx
+++ b/components/dashboard/activity-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { Form, Input, Modal, Select } from "antd";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
+import { useMounted } from "@/lib/client/use-mounted";
 import { ActivityStatus, ActivityType, type IActivity } from "@/providers/salesTypes";
 import { useActivityActions, useActivityState } from "@/providers/activityProvider";
 import { useDashboardState } from "@/providers/dashboardProvider";
@@ -26,17 +27,13 @@ export default function ActivityForm({
   onSubmitStart,
   onSubmitEnd,
 }: ActivityFormProps) {
-  const [isClient, setIsClient] = useState(false);
+  const mounted = useMounted();
   const [form] = Form.useForm();
   const { activities } = useActivityState();
   const { opportunities } = useOpportunityState();
   const { proposals } = useProposalState();
   const { teamMembers } = useDashboardState();
   const { addActivity, updateActivity } = useActivityActions();
-
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
 
   useEffect(() => {
     if (editingId) {
@@ -93,10 +90,9 @@ export default function ActivityForm({
     }
   };
 
-  if (!isClient) {
+  if (!mounted) {
     return null;
   }
-
   return (
     <Modal
       forceRender

--- a/components/dashboard/assistant-panel.tsx
+++ b/components/dashboard/assistant-panel.tsx
@@ -43,14 +43,13 @@ const getIntroMessage = (role: UserRole) =>
 export function AssistantPanel() {
   const { user } = useAuthState();
   const role = getPrimaryUserRole(user?.roles);
-  const [draft, setDraft] = useState(() => readSessionDraft<string>(ASSISTANT_PANEL_DRAFT_KEY) ?? "");
+  const [hasHydrated, setHasHydrated] = useState(false);
+  const [draft, setDraft] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [assistantMode, setAssistantMode] = useState<"groq" | "offline" | "openai" | null>(null);
   const [assistantReason, setAssistantReason] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [messages, setMessages] = useState<AssistantMessage[]>(
-    () => readSessionDraft<AssistantMessage[]>(ASSISTANT_PANEL_MESSAGES_KEY) ?? [],
-  );
+  const [messages, setMessages] = useState<AssistantMessage[]>([]);
   const [statusLabel, setStatusLabel] = useState("Awaiting your question");
 
   const resetConversation = () => {
@@ -82,22 +81,36 @@ export function AssistantPanel() {
       ];
 
   useEffect(() => {
+    setHasHydrated(true);
+    setDraft(readSessionDraft<string>(ASSISTANT_PANEL_DRAFT_KEY) ?? "");
+    setMessages(readSessionDraft<AssistantMessage[]>(ASSISTANT_PANEL_MESSAGES_KEY) ?? []);
+  }, []);
+
+  useEffect(() => {
+    if (!hasHydrated) {
+      return;
+    }
+
     if (draft) {
       writeSessionDraft(ASSISTANT_PANEL_DRAFT_KEY, draft);
       return;
     }
 
     clearSessionDraft(ASSISTANT_PANEL_DRAFT_KEY);
-  }, [draft]);
+  }, [draft, hasHydrated]);
 
   useEffect(() => {
+    if (!hasHydrated) {
+      return;
+    }
+
     if (messages.length > 0) {
       writeSessionDraft(ASSISTANT_PANEL_MESSAGES_KEY, messages);
       return;
     }
 
     clearSessionDraft(ASSISTANT_PANEL_MESSAGES_KEY);
-  }, [messages]);
+  }, [messages, hasHydrated]);
 
   useEffect(() => {
     let isActive = true;

--- a/components/dashboard/client-form.tsx
+++ b/components/dashboard/client-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Form, Input, InputNumber, Modal, Select } from "antd";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { clearSessionDraft, readSessionDraft, writeSessionDraft } from "@/lib/client/session-drafts";
 import { OpportunityStage, type IClient } from "@/providers/salesTypes";
@@ -39,9 +39,14 @@ export function ClientForm({
   onClose,
   onSave,
 }: ClientFormProps) {
+  const [isClient, setIsClient] = useState(false);
   const [form] = Form.useForm<ClientFormValues>();
   const { contacts } = useContactState();
   const draftKey = getClientFormDraftKey(editingClient?.id);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
   useEffect(() => {
     const savedDraft = readSessionDraft<Partial<ClientFormValues>>(draftKey);
@@ -79,8 +84,13 @@ export function ClientForm({
     clearSessionDraft(draftKey);
   };
 
+  if (!isClient) {
+    return null;
+  }
+
   return (
     <Modal
+      forceRender
       onCancel={onClose}
       onOk={() => form.submit()}
       okButtonProps={{ loading: isSubmitting }}

--- a/components/dashboard/contact-form.tsx
+++ b/components/dashboard/contact-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Form, Input, Modal, Select } from "antd";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { type IContact } from "@/providers/salesTypes";
 import { useClientState } from "@/providers/clientProvider";
@@ -21,8 +21,13 @@ export function ContactForm({
   onClose,
   onSave,
 }: ContactFormProps) {
+  const [isClient, setIsClient] = useState(false);
   const [form] = Form.useForm();
   const { clients } = useClientState();
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
   useEffect(() => {
     if (editingContact) {
@@ -31,6 +36,10 @@ export function ContactForm({
       form.resetFields();
     }
   }, [editingContact, form, isOpen]);
+
+  if (!isClient) {
+    return null;
+  }
 
   return (
     <Modal

--- a/components/dashboard/opportunity-form.tsx
+++ b/components/dashboard/opportunity-form.tsx
@@ -2,7 +2,7 @@
 
 import { DatePicker, Form, Input, InputNumber, Modal, Select } from "antd";
 import dayjs from "dayjs";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { clearSessionDraft, readSessionDraft, writeSessionDraft } from "@/lib/client/session-drafts";
 import { OPPORTUNITY_STAGE_ORDER, type IOpportunity } from "@/providers/salesTypes";
@@ -42,12 +42,17 @@ export function OpportunityForm({
   onSubmitStart,
   onSubmitEnd,
 }: OpportunityFormProps) {
+  const [isClient, setIsClient] = useState(false);
   const [form] = Form.useForm<OpportunityFormValues>();
   const { clients } = useClientState();
   const { teamMembers } = useDashboardState();
   const { opportunities } = useOpportunityState();
   const { addOpportunity, updateOpportunity } = useOpportunityActions();
   const draftKey = getOpportunityFormDraftKey(editingId);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
   useEffect(() => {
     const savedDraft = readSessionDraft<PersistedOpportunityFormValues>(draftKey);
@@ -113,8 +118,13 @@ export function OpportunityForm({
     }
   };
 
+  if (!isClient) {
+    return null;
+  }
+
   return (
     <Modal
+      forceRender
       onCancel={onClose}
       onOk={() => form.submit()}
       okButtonProps={{ loading: isSubmitting }}

--- a/components/dashboard/proposal-form.tsx
+++ b/components/dashboard/proposal-form.tsx
@@ -49,6 +49,7 @@ const getLineItemTotal = (item?: Partial<ILineItem>) => {
 };
 
 export function ProposalForm({ isOpen, editingId, onClose }: ProposalFormProps) {
+  const [isClient, setIsClient] = useState(false);
   const [form] = Form.useForm<ProposalFormValues>();
   const { proposals } = useProposalState();
   const { opportunities } = useOpportunityState();
@@ -64,6 +65,10 @@ export function ProposalForm({ isOpen, editingId, onClose }: ProposalFormProps) 
   const isLoadingProposal = Boolean(
     editingId && !editingProposal?.lineItems?.length && !watchedTitle,
   );
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
   const proposalTotal = useMemo(
     () =>
@@ -180,8 +185,13 @@ export function ProposalForm({ isOpen, editingId, onClose }: ProposalFormProps) 
     }
   };
 
+  if (!isClient) {
+    return null;
+  }
+
   return (
     <Modal
+      forceRender
       onCancel={() => {
         setFormError(null);
         onClose();
@@ -192,20 +202,21 @@ export function ProposalForm({ isOpen, editingId, onClose }: ProposalFormProps) 
       title={editingId ? "Edit proposal" : "Create proposal"}
       width={920}
     >
-      {isLoadingProposal ? (
-        <div className="flex items-center justify-center py-16">
-          <Spin />
-        </div>
-      ) : (
-        <Form
-          className="pt-4"
-          form={form}
-          layout="vertical"
-          onFinish={handleSubmit}
-          onValuesChange={(_, allValues) =>
-            writeSessionDraft(draftKey, allValues satisfies Partial<ProposalFormValues>)
-          }
-        >
+      <Form
+        className="pt-4"
+        form={form}
+        layout="vertical"
+        onFinish={handleSubmit}
+        onValuesChange={(_, allValues) =>
+          writeSessionDraft(draftKey, allValues satisfies Partial<ProposalFormValues>)
+        }
+      >
+        {isLoadingProposal ? (
+          <div className="flex items-center justify-center py-16">
+            <Spin />
+          </div>
+        ) : (
+          <>
           <div className="grid gap-5 md:grid-cols-2">
             <Form.Item
               label="Opportunity"
@@ -372,8 +383,9 @@ export function ProposalForm({ isOpen, editingId, onClose }: ProposalFormProps) 
           {formError ? (
             <Alert className="mt-4" message={formError} type="error" />
           ) : null}
-        </Form>
-      )}
+          </>
+        )}
+      </Form>
     </Modal>
   );
 }

--- a/components/dashboard/renewal-form.tsx
+++ b/components/dashboard/renewal-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Form, Input, Modal, InputNumber } from "antd";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useContractActions, useContractState } from "@/providers/contractProvider";
 import { type IRenewal } from "@/providers/salesTypes";
 
@@ -19,9 +19,14 @@ interface RenewalFormValues {
 }
 
 export function RenewalForm({ isOpen, editingId, onClose }: RenewalFormProps) {
+  const [isClient, setIsClient] = useState(false);
   const [form] = Form.useForm();
   const { renewals } = useContractState();
   const { addRenewal, updateRenewal } = useContractActions();
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
   useEffect(() => {
     if (editingId) {
@@ -61,6 +66,10 @@ export function RenewalForm({ isOpen, editingId, onClose }: RenewalFormProps) {
     onClose();
     form.resetFields();
   };
+
+  if (!isClient) {
+    return null;
+  }
 
   return (
     <Modal

--- a/lib/auth/dashboard-access.ts
+++ b/lib/auth/dashboard-access.ts
@@ -2,11 +2,45 @@ import { dashboardNavItems } from "@/constants/dashboard-nav";
 import type { UserRole } from "@/providers/salesTypes";
 
 export const DASHBOARD_HOME_PATH = "/dashboard";
+const CLIENT_SCOPED_HOME_PATH = "/dashboard";
+
+const CLIENT_SCOPED_ALLOWED_PATHS = [
+  "/dashboard",
+  "/dashboard/clients",
+  "/dashboard/activities",
+  "/dashboard/assistant",
+  "/dashboard/proposals",
+  "/dashboard/documents",
+  "/dashboard/messages",
+] as const;
+
+const matchesScopedPath = (pathname: string, path: string) =>
+  path === "/dashboard"
+    ? pathname === path
+    : pathname === path || pathname.startsWith(`${path}/`);
+
+const isClientScopedPath = (pathname: string) =>
+  CLIENT_SCOPED_ALLOWED_PATHS.some((path) => matchesScopedPath(pathname, path));
 
 export const getDashboardNavItemForPath = (pathname: string) =>
   [...dashboardNavItems]
     .sort((left, right) => right.href.length - left.href.length)
     .find((item) => pathname === item.href || pathname.startsWith(`${item.href}/`));
 
-export const canAccessDashboardPath = (pathname: string, role: UserRole) =>
-  getDashboardNavItemForPath(pathname)?.access.includes(role) ?? true;
+export const isClientScopedUser = (clientIds?: string[] | null) =>
+  Array.isArray(clientIds) && clientIds.length > 0;
+
+export const getDashboardHomePath = (role: UserRole, clientIds?: string[] | null) =>
+  isClientScopedUser(clientIds) ? CLIENT_SCOPED_HOME_PATH : DASHBOARD_HOME_PATH;
+
+export const canAccessDashboardPath = (
+  pathname: string,
+  role: UserRole,
+  clientIds?: string[] | null,
+) => {
+  if (isClientScopedUser(clientIds)) {
+    return isClientScopedPath(pathname);
+  }
+
+  return getDashboardNavItemForPath(pathname)?.access.includes(role) ?? true;
+};

--- a/providers/authProvider/context.tsx
+++ b/providers/authProvider/context.tsx
@@ -17,6 +17,7 @@ export interface IUserRegisterRequest {
 }
 
 export interface IUserLoginResponse {
+  clientIds?: string[] | null;
   email?: string | null;
   expiresAt?: string;
   firstName?: string | null;

--- a/providers/domainSeeds.ts
+++ b/providers/domainSeeds.ts
@@ -27,6 +27,11 @@ export interface INoteItem {
   content: string;
   createdDate: string;
   id: string;
+  kind?: "client_feedback" | "client_message" | "general";
+  representativeId?: string;
+  representativeName?: string;
+  source?: "assistant" | "client_portal" | "workspace";
+  status?: "Acknowledged" | "Sent";
   title: string;
 }
 


### PR DESCRIPTION
## Summary
- gate modal form components until after client mount to avoid SSR/client portal markup mismatches
- keep the modal form connection fixes without reintroducing Ant Design hydration errors

## Linked issue
- refs #181

## Validation
- npm run build