### PR TITLE
feat: own assistant workflow API and stabilize approvals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ yarn-error.log*
 
 # vercel
 .vercel
+.local-state/
 
 # typescript
 *.tsbuildinfo

--- a/app/api/Auth/login/route.ts
+++ b/app/api/Auth/login/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { findUserByEmail, toAuthPayload } from "../mock-users";
 import { AUTH_COOKIE_NAME, AUTH_COOKIE_OPTIONS } from "../session-cookie";
+import { shouldUseUpstreamAuth } from "@/lib/server/auth-mode";
 import { createBackendUrl } from "@/lib/server/backend-url";
 
 const readJsonBody = async (response: Response) => {
@@ -27,6 +28,10 @@ export async function POST(request: NextRequest) {
     response.cookies.set(AUTH_COOKIE_NAME, payload.token, AUTH_COOKIE_OPTIONS);
 
     return response;
+  }
+
+  if (!shouldUseUpstreamAuth()) {
+    return NextResponse.json({ message: "Invalid email or password." }, { status: 401 });
   }
 
   const upstream = await fetch(createBackendUrl("/api/Auth/login"), {

--- a/app/api/Auth/me/route.ts
+++ b/app/api/Auth/me/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { toAuthPayload, updateMockUser } from "../mock-users";
 import { AUTH_COOKIE_NAME, AUTH_COOKIE_OPTIONS } from "../session-cookie";
+import { shouldUseUpstreamAuth } from "@/lib/server/auth-mode";
 import { createBackendUrl } from "@/lib/server/backend-url";
 import { getUserFromSessionToken } from "@/lib/auth/session-user";
 import { syncMockUserWorkspaceProfile } from "@/lib/server/mock-workspace-store";
@@ -14,6 +15,10 @@ export async function GET(request: NextRequest) {
 
   if (mockUser && token.startsWith("mock-token::")) {
     return NextResponse.json(toAuthPayload(mockUser), { status: 200 });
+  }
+
+  if (!shouldUseUpstreamAuth()) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
   }
 
   const headers = new Headers();
@@ -78,6 +83,10 @@ export async function PATCH(request: NextRequest) {
     });
 
     return NextResponse.json(toAuthPayload(updatedUser), { status: 200 });
+  }
+
+  if (!shouldUseUpstreamAuth()) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
   }
 
   const headers = new Headers();

--- a/app/api/Auth/register/route.ts
+++ b/app/api/Auth/register/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { registerMockUser, toAuthPayload, type MockUserRole } from "../mock-users";
 import { AUTH_COOKIE_NAME, AUTH_COOKIE_OPTIONS } from "../session-cookie";
+import { shouldUseUpstreamAuth } from "@/lib/server/auth-mode";
 import { createBackendUrl } from "@/lib/server/backend-url";
 
 const readJsonBody = async (response: Response) => {
@@ -14,8 +16,59 @@ const readJsonBody = async (response: Response) => {
 };
 
 export async function POST(request: NextRequest) {
+  const rawBody = await request.text();
+
+  if (!shouldUseUpstreamAuth()) {
+    const payload = JSON.parse(rawBody) as {
+      email?: unknown;
+      firstName?: unknown;
+      lastName?: unknown;
+      password?: unknown;
+      role?: unknown;
+      tenantName?: unknown;
+    };
+    const email = String(payload.email ?? "").trim().toLowerCase();
+    const firstName = String(payload.firstName ?? "").trim();
+    const lastName = String(payload.lastName ?? "").trim();
+    const password = String(payload.password ?? "").trim();
+    const role =
+      payload.role === "Admin" ||
+      payload.role === "SalesManager" ||
+      payload.role === "BusinessDevelopmentManager" ||
+      payload.role === "SalesRep" ||
+      payload.role === "Client"
+        ? (payload.role as MockUserRole)
+        : "SalesRep";
+    const tenantName = String(payload.tenantName ?? "").trim();
+
+    if (!email || !firstName || !lastName || !password) {
+      return NextResponse.json(
+        { message: "Email, first name, last name, and password are required." },
+        { status: 400 },
+      );
+    }
+
+    const user = registerMockUser({
+      email,
+      firstName,
+      lastName,
+      password,
+      role,
+      tenantName,
+    });
+
+    if (!user) {
+      return NextResponse.json({ message: "A user with that email already exists." }, { status: 409 });
+    }
+
+    const responsePayload = toAuthPayload(user);
+    const response = NextResponse.json(responsePayload, { status: 200 });
+    response.cookies.set(AUTH_COOKIE_NAME, responsePayload.token, AUTH_COOKIE_OPTIONS);
+    return response;
+  }
+
   const upstream = await fetch(createBackendUrl("/api/Auth/register"), {
-    body: await request.text(),
+    body: rawBody,
     headers: {
       "Content-Type": "application/json",
     },

--- a/app/api/assistant/route.ts
+++ b/app/api/assistant/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { AUTH_COOKIE_NAME } from "@/app/api/Auth/session-cookie";
 import { getAuthorizedUser } from "@/lib/server/assistant-auth";
 import {
   type AssistantMutation,
@@ -128,6 +129,22 @@ const sanitizeTrace = (trace: AssistantTraceStep[] | undefined) =>
 const sanitizeMutations = (mutations: AssistantMutation[] | undefined) =>
   Array.isArray(mutations) ? mutations.slice(0, 8) : [];
 
+const getSessionToken = (request: NextRequest) => {
+  const cookieToken = request.cookies.get(AUTH_COOKIE_NAME)?.value;
+
+  if (cookieToken) {
+    return cookieToken;
+  }
+
+  const authHeader = request.headers.get("authorization");
+
+  if (!authHeader?.startsWith("Bearer ")) {
+    return "";
+  }
+
+  return authHeader.slice("Bearer ".length).trim();
+};
+
 export async function POST(request: NextRequest) {
   const user = getAuthorizedUser(request);
 
@@ -147,7 +164,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const workspace = getAssistantWorkspaceForUser(user);
+    const workspace = await getAssistantWorkspaceForUser(user, getSessionToken(request));
     const result = await runSecureAssistant({ messages, workspace });
 
     return NextResponse.json({

--- a/app/api/openapi/owned-sales-automation/route.ts
+++ b/app/api/openapi/owned-sales-automation/route.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+const specPath = path.join(
+  process.cwd(),
+  "openapi",
+  "owned-sales-automation.json",
+);
+
+export async function GET() {
+  try {
+    const contents = await fs.readFile(specPath, "utf8");
+    return new NextResponse(contents, {
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+      },
+      status: 200,
+    });
+  } catch {
+    return NextResponse.json(
+      { message: "Owned OpenAPI spec not found." },
+      { status: 404 },
+    );
+  }
+}

--- a/app/api/service-requests/[requestId]/assignments/route.ts
+++ b/app/api/service-requests/[requestId]/assignments/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { createServiceRequestAssignments } from "@/lib/server/service-request-store";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ requestId: string }> },
+) {
+  const user = getAuthorizedUser(request);
+
+  if (!user) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { requestId } = await context.params;
+    const body = (await request.json()) as {
+      note?: unknown;
+      representativeUserIds?: unknown;
+    };
+
+    const representativeUserIds = Array.isArray(body.representativeUserIds)
+      ? body.representativeUserIds
+          .filter((value): value is string => typeof value === "string")
+          .map((value) => value.trim())
+          .filter(Boolean)
+      : [];
+
+    const result = createServiceRequestAssignments(user, requestId, {
+      note: typeof body.note === "string" ? body.note : undefined,
+      representativeUserIds,
+    });
+
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "The assignments could not be created.";
+    const status =
+      /not found/i.test(message) ? 404 : /only internal|access/i.test(message) ? 403 : 400;
+    return NextResponse.json({ message }, { status });
+  }
+}

--- a/app/api/service-requests/[requestId]/assignments/route.ts
+++ b/app/api/service-requests/[requestId]/assignments/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { getRequestSessionToken, isLiveSessionToken } from "@/lib/server/request-session-token";
+import { createLiveServiceRequestAssignments } from "@/lib/server/service-request-backend-store";
 import { createServiceRequestAssignments } from "@/lib/server/service-request-store";
 
 export const runtime = "nodejs";
@@ -10,6 +12,7 @@ export async function POST(
   context: { params: Promise<{ requestId: string }> },
 ) {
   const user = getAuthorizedUser(request);
+  const token = getRequestSessionToken(request);
 
   if (!user) {
     return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
@@ -29,10 +32,13 @@ export async function POST(
           .filter(Boolean)
       : [];
 
-    const result = createServiceRequestAssignments(user, requestId, {
+    const payload = {
       note: typeof body.note === "string" ? body.note : undefined,
       representativeUserIds,
-    });
+    };
+    const result = isLiveSessionToken(token)
+      ? await createLiveServiceRequestAssignments(user, token, requestId, payload)
+      : createServiceRequestAssignments(user, requestId, payload);
 
     return NextResponse.json(result, { status: 201 });
   } catch (error) {

--- a/app/api/service-requests/[requestId]/client-decision/route.ts
+++ b/app/api/service-requests/[requestId]/client-decision/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { applyServiceRequestClientDecision } from "@/lib/server/service-request-store";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ requestId: string }> },
+) {
+  const user = getAuthorizedUser(request);
+
+  if (!user) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { requestId } = await context.params;
+    const body = (await request.json()) as {
+      assignmentIds?: unknown;
+      decision?: unknown;
+      note?: unknown;
+    };
+
+    const assignmentIds = Array.isArray(body.assignmentIds)
+      ? body.assignmentIds.filter((value): value is string => typeof value === "string")
+      : [];
+
+    if (body.decision !== "approve" && body.decision !== "reject") {
+      return NextResponse.json(
+        { message: "decision must be approve or reject." },
+        { status: 400 },
+      );
+    }
+
+    const updated = applyServiceRequestClientDecision(user, requestId, {
+      assignmentIds,
+      decision: body.decision,
+      note: typeof body.note === "string" ? body.note : undefined,
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "The client decision could not be applied.";
+    const status =
+      /not found/i.test(message) ? 404 : /only client|access/i.test(message) ? 403 : 400;
+    return NextResponse.json({ message }, { status });
+  }
+}

--- a/app/api/service-requests/[requestId]/client-decision/route.ts
+++ b/app/api/service-requests/[requestId]/client-decision/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { getRequestSessionToken, isLiveSessionToken } from "@/lib/server/request-session-token";
+import { applyLiveServiceRequestClientDecision } from "@/lib/server/service-request-backend-store";
 import { applyServiceRequestClientDecision } from "@/lib/server/service-request-store";
 
 export const runtime = "nodejs";
@@ -10,6 +12,7 @@ export async function POST(
   context: { params: Promise<{ requestId: string }> },
 ) {
   const user = getAuthorizedUser(request);
+  const token = getRequestSessionToken(request);
 
   if (!user) {
     return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
@@ -34,11 +37,14 @@ export async function POST(
       );
     }
 
-    const updated = applyServiceRequestClientDecision(user, requestId, {
+    const payload = {
       assignmentIds,
-      decision: body.decision,
+      decision: body.decision as "approve" | "reject",
       note: typeof body.note === "string" ? body.note : undefined,
-    });
+    };
+    const updated = isLiveSessionToken(token)
+      ? await applyLiveServiceRequestClientDecision(user, token, requestId, payload)
+      : applyServiceRequestClientDecision(user, requestId, payload);
 
     return NextResponse.json(updated);
   } catch (error) {

--- a/app/api/service-requests/[requestId]/messages/route.ts
+++ b/app/api/service-requests/[requestId]/messages/route.ts
@@ -4,6 +4,7 @@ import { getAuthorizedUser } from "@/lib/server/assistant-auth";
 import { getRequestSessionToken, isLiveSessionToken } from "@/lib/server/request-session-token";
 import { addLiveServiceRequestMessage } from "@/lib/server/service-request-backend-store";
 import { addServiceRequestMessage } from "@/lib/server/service-request-store";
+import type { ServiceRequestMessageRecipientType } from "@/lib/client/service-request-api";
 
 export const runtime = "nodejs";
 
@@ -22,10 +23,23 @@ export async function POST(
     const { requestId } = await context.params;
     const body = (await request.json()) as {
       content?: unknown;
+      recipientType?: unknown;
+      representativeUserIds?: unknown;
     };
 
     const payload = {
       content: typeof body.content === "string" ? body.content : "",
+      recipientType:
+        body.recipientType === "client" ||
+        body.recipientType === "representative" ||
+        body.recipientType === "both"
+          ? (body.recipientType as ServiceRequestMessageRecipientType)
+          : "client",
+      representativeUserIds: Array.isArray(body.representativeUserIds)
+        ? body.representativeUserIds.filter(
+            (value): value is string => typeof value === "string" && value.trim().length > 0,
+          )
+        : [],
     };
 
     const result = isLiveSessionToken(token)

--- a/app/api/service-requests/[requestId]/messages/route.ts
+++ b/app/api/service-requests/[requestId]/messages/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { getRequestSessionToken, isLiveSessionToken } from "@/lib/server/request-session-token";
+import { addLiveServiceRequestMessage } from "@/lib/server/service-request-backend-store";
+import { addServiceRequestMessage } from "@/lib/server/service-request-store";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ requestId: string }> },
+) {
+  const user = getAuthorizedUser(request);
+  const token = getRequestSessionToken(request);
+
+  if (!user) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { requestId } = await context.params;
+    const body = (await request.json()) as {
+      content?: unknown;
+    };
+
+    const payload = {
+      content: typeof body.content === "string" ? body.content : "",
+    };
+
+    const result = isLiveSessionToken(token)
+      ? await addLiveServiceRequestMessage(user, token, requestId, payload)
+      : addServiceRequestMessage(user, requestId, payload);
+
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "The service request reply could not be added.";
+    const status =
+      /not found/i.test(message) ? 404 : /access|unauthorized|only/i.test(message) ? 403 : 400;
+    return NextResponse.json({ message }, { status });
+  }
+}

--- a/app/api/service-requests/[requestId]/opportunity/route.ts
+++ b/app/api/service-requests/[requestId]/opportunity/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { getRequestSessionToken, isLiveSessionToken } from "@/lib/server/request-session-token";
+import { attachLiveOpportunityToServiceRequest } from "@/lib/server/service-request-backend-store";
 import { attachOpportunityToServiceRequest } from "@/lib/server/service-request-store";
 
 export const runtime = "nodejs";
@@ -10,6 +12,7 @@ export async function POST(
   context: { params: Promise<{ requestId: string }> },
 ) {
   const user = getAuthorizedUser(request);
+  const token = getRequestSessionToken(request);
 
   if (!user) {
     return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
@@ -27,19 +30,22 @@ export async function POST(
       title?: unknown;
     };
 
-    const result = attachOpportunityToServiceRequest(user, requestId, {
+    const payload = {
       estimatedValue:
         typeof body.estimatedValue === "number"
           ? body.estimatedValue
           : Number(body.estimatedValue ?? 0),
       expectedCloseDate:
         typeof body.expectedCloseDate === "string" ? body.expectedCloseDate : undefined,
-      mode: body.mode === "link" ? "link" : "create",
+      mode: (body.mode === "link" ? "link" : "create") as "create" | "link",
       opportunityId: typeof body.opportunityId === "string" ? body.opportunityId : undefined,
       ownerId: typeof body.ownerId === "string" ? body.ownerId : undefined,
       stage: typeof body.stage === "string" ? body.stage : undefined,
       title: typeof body.title === "string" ? body.title : undefined,
-    });
+    };
+    const result = isLiveSessionToken(token)
+      ? await attachLiveOpportunityToServiceRequest(user, token, requestId, payload)
+      : attachOpportunityToServiceRequest(user, requestId, payload);
 
     return NextResponse.json(result.opportunity);
   } catch (error) {

--- a/app/api/service-requests/[requestId]/opportunity/route.ts
+++ b/app/api/service-requests/[requestId]/opportunity/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { attachOpportunityToServiceRequest } from "@/lib/server/service-request-store";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ requestId: string }> },
+) {
+  const user = getAuthorizedUser(request);
+
+  if (!user) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { requestId } = await context.params;
+    const body = (await request.json()) as {
+      estimatedValue?: unknown;
+      expectedCloseDate?: unknown;
+      mode?: unknown;
+      opportunityId?: unknown;
+      ownerId?: unknown;
+      stage?: unknown;
+      title?: unknown;
+    };
+
+    const result = attachOpportunityToServiceRequest(user, requestId, {
+      estimatedValue:
+        typeof body.estimatedValue === "number"
+          ? body.estimatedValue
+          : Number(body.estimatedValue ?? 0),
+      expectedCloseDate:
+        typeof body.expectedCloseDate === "string" ? body.expectedCloseDate : undefined,
+      mode: body.mode === "link" ? "link" : "create",
+      opportunityId: typeof body.opportunityId === "string" ? body.opportunityId : undefined,
+      ownerId: typeof body.ownerId === "string" ? body.ownerId : undefined,
+      stage: typeof body.stage === "string" ? body.stage : undefined,
+      title: typeof body.title === "string" ? body.title : undefined,
+    });
+
+    return NextResponse.json(result.opportunity);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "The opportunity could not be created.";
+    const status =
+      /not found/i.test(message) ? 404 : /only internal|access/i.test(message) ? 403 : 400;
+    return NextResponse.json({ message }, { status });
+  }
+}

--- a/app/api/service-requests/[requestId]/proposal/route.ts
+++ b/app/api/service-requests/[requestId]/proposal/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { attachProposalToServiceRequest } from "@/lib/server/service-request-store";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ requestId: string }> },
+) {
+  const user = getAuthorizedUser(request);
+
+  if (!user) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { requestId } = await context.params;
+    const body = (await request.json()) as {
+      currency?: unknown;
+      description?: unknown;
+      mode?: unknown;
+      proposalId?: unknown;
+      title?: unknown;
+      validUntil?: unknown;
+    };
+
+    const result = attachProposalToServiceRequest(user, requestId, {
+      currency: typeof body.currency === "string" ? body.currency : undefined,
+      description: typeof body.description === "string" ? body.description : undefined,
+      mode: body.mode === "link" ? "link" : "create",
+      proposalId: typeof body.proposalId === "string" ? body.proposalId : undefined,
+      title: typeof body.title === "string" ? body.title : undefined,
+      validUntil: typeof body.validUntil === "string" ? body.validUntil : undefined,
+    });
+
+    return NextResponse.json(result.proposal);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "The proposal could not be created.";
+    const status =
+      /not found/i.test(message) ? 404 : /only internal|access/i.test(message) ? 403 : 400;
+    return NextResponse.json({ message }, { status });
+  }
+}

--- a/app/api/service-requests/[requestId]/proposal/route.ts
+++ b/app/api/service-requests/[requestId]/proposal/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { getRequestSessionToken, isLiveSessionToken } from "@/lib/server/request-session-token";
+import { attachLiveProposalToServiceRequest } from "@/lib/server/service-request-backend-store";
 import { attachProposalToServiceRequest } from "@/lib/server/service-request-store";
 
 export const runtime = "nodejs";
@@ -10,6 +12,7 @@ export async function POST(
   context: { params: Promise<{ requestId: string }> },
 ) {
   const user = getAuthorizedUser(request);
+  const token = getRequestSessionToken(request);
 
   if (!user) {
     return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
@@ -26,14 +29,17 @@ export async function POST(
       validUntil?: unknown;
     };
 
-    const result = attachProposalToServiceRequest(user, requestId, {
+    const payload = {
       currency: typeof body.currency === "string" ? body.currency : undefined,
       description: typeof body.description === "string" ? body.description : undefined,
-      mode: body.mode === "link" ? "link" : "create",
+      mode: (body.mode === "link" ? "link" : "create") as "create" | "link",
       proposalId: typeof body.proposalId === "string" ? body.proposalId : undefined,
       title: typeof body.title === "string" ? body.title : undefined,
       validUntil: typeof body.validUntil === "string" ? body.validUntil : undefined,
-    });
+    };
+    const result = isLiveSessionToken(token)
+      ? await attachLiveProposalToServiceRequest(user, token, requestId, payload)
+      : attachProposalToServiceRequest(user, requestId, payload);
 
     return NextResponse.json(result.proposal);
   } catch (error) {

--- a/app/api/service-requests/[requestId]/rep-decision/route.ts
+++ b/app/api/service-requests/[requestId]/rep-decision/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { applyServiceRequestRepDecision } from "@/lib/server/service-request-store";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ requestId: string }> },
+) {
+  const user = getAuthorizedUser(request);
+
+  if (!user) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { requestId } = await context.params;
+    const body = (await request.json()) as {
+      assignmentId?: unknown;
+      decision?: unknown;
+      note?: unknown;
+    };
+
+    if (body.decision !== "accept" && body.decision !== "reject") {
+      return NextResponse.json(
+        { message: "decision must be accept or reject." },
+        { status: 400 },
+      );
+    }
+
+    const updated = applyServiceRequestRepDecision(user, requestId, {
+      assignmentId: typeof body.assignmentId === "string" ? body.assignmentId : "",
+      decision: body.decision,
+      note: typeof body.note === "string" ? body.note : undefined,
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "The representative decision could not be applied.";
+    const status = /not found/i.test(message) ? 404 : /access/i.test(message) ? 403 : 400;
+    return NextResponse.json({ message }, { status });
+  }
+}

--- a/app/api/service-requests/[requestId]/rep-decision/route.ts
+++ b/app/api/service-requests/[requestId]/rep-decision/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { getRequestSessionToken, isLiveSessionToken } from "@/lib/server/request-session-token";
+import { applyLiveServiceRequestRepDecision } from "@/lib/server/service-request-backend-store";
 import { applyServiceRequestRepDecision } from "@/lib/server/service-request-store";
 
 export const runtime = "nodejs";
@@ -10,6 +12,7 @@ export async function POST(
   context: { params: Promise<{ requestId: string }> },
 ) {
   const user = getAuthorizedUser(request);
+  const token = getRequestSessionToken(request);
 
   if (!user) {
     return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
@@ -30,11 +33,14 @@ export async function POST(
       );
     }
 
-    const updated = applyServiceRequestRepDecision(user, requestId, {
+    const payload = {
       assignmentId: typeof body.assignmentId === "string" ? body.assignmentId : "",
-      decision: body.decision,
+      decision: body.decision as "accept" | "reject",
       note: typeof body.note === "string" ? body.note : undefined,
-    });
+    };
+    const updated = isLiveSessionToken(token)
+      ? await applyLiveServiceRequestRepDecision(user, token, requestId, payload)
+      : applyServiceRequestRepDecision(user, requestId, payload);
 
     return NextResponse.json(updated);
   } catch (error) {

--- a/app/api/service-requests/[requestId]/review/route.ts
+++ b/app/api/service-requests/[requestId]/review/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { getRequestSessionToken, isLiveSessionToken } from "@/lib/server/request-session-token";
+import { markLiveServiceRequestUnderReview } from "@/lib/server/service-request-backend-store";
 import { markServiceRequestUnderReview } from "@/lib/server/service-request-store";
 
 export const runtime = "nodejs";
@@ -10,6 +12,7 @@ export async function POST(
   context: { params: Promise<{ requestId: string }> },
 ) {
   const user = getAuthorizedUser(request);
+  const token = getRequestSessionToken(request);
 
   if (!user) {
     return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
@@ -17,7 +20,9 @@ export async function POST(
 
   try {
     const { requestId } = await context.params;
-    const updated = markServiceRequestUnderReview(user, requestId);
+    const updated = isLiveSessionToken(token)
+      ? await markLiveServiceRequestUnderReview(user, token, requestId)
+      : markServiceRequestUnderReview(user, requestId);
     return NextResponse.json(updated);
   } catch (error) {
     const message =

--- a/app/api/service-requests/[requestId]/review/route.ts
+++ b/app/api/service-requests/[requestId]/review/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { markServiceRequestUnderReview } from "@/lib/server/service-request-store";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ requestId: string }> },
+) {
+  const user = getAuthorizedUser(request);
+
+  if (!user) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { requestId } = await context.params;
+    const updated = markServiceRequestUnderReview(user, requestId);
+    return NextResponse.json(updated);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "The service request could not be reviewed.";
+    const status =
+      /not found/i.test(message) ? 404 : /only internal|access/i.test(message) ? 403 : 400;
+    return NextResponse.json({ message }, { status });
+  }
+}

--- a/app/api/service-requests/[requestId]/route.ts
+++ b/app/api/service-requests/[requestId]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { getRequestSessionToken, isLiveSessionToken } from "@/lib/server/request-session-token";
+import { getLiveServiceRequestDetail } from "@/lib/server/service-request-backend-store";
 import { getServiceRequestDetail } from "@/lib/server/service-request-store";
 
 export const runtime = "nodejs";
@@ -10,6 +12,7 @@ export async function GET(
   context: { params: Promise<{ requestId: string }> },
 ) {
   const user = getAuthorizedUser(request);
+  const token = getRequestSessionToken(request);
 
   if (!user) {
     return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
@@ -17,7 +20,9 @@ export async function GET(
 
   try {
     const { requestId } = await context.params;
-    const detail = getServiceRequestDetail(user, requestId);
+    const detail = isLiveSessionToken(token)
+      ? await getLiveServiceRequestDetail(user, token, requestId)
+      : getServiceRequestDetail(user, requestId);
     return NextResponse.json(detail);
   } catch (error) {
     const message =

--- a/app/api/service-requests/[requestId]/route.ts
+++ b/app/api/service-requests/[requestId]/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { getServiceRequestDetail } from "@/lib/server/service-request-store";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ requestId: string }> },
+) {
+  const user = getAuthorizedUser(request);
+
+  if (!user) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { requestId } = await context.params;
+    const detail = getServiceRequestDetail(user, requestId);
+    return NextResponse.json(detail);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "The service request could not be loaded.";
+    const status = /not found/i.test(message) ? 404 : /access/i.test(message) ? 403 : 400;
+    return NextResponse.json({ message }, { status });
+  }
+}

--- a/app/api/service-requests/route.ts
+++ b/app/api/service-requests/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import {
+  createServiceRequest,
+  listServiceRequests,
+  type ServiceRequestPriority,
+  type ServiceRequestStatus,
+} from "@/lib/server/service-request-store";
+
+export const runtime = "nodejs";
+
+const VALID_PRIORITIES = new Set<ServiceRequestPriority>([
+  "low",
+  "medium",
+  "high",
+  "critical",
+]);
+
+const VALID_STATUSES = new Set<ServiceRequestStatus>([
+  "submitted",
+  "under_review",
+  "proposal_prepared",
+  "awaiting_client_assignment_approval",
+  "client_rejected_assignment",
+  "client_approved_assignment",
+  "awaiting_rep_acceptance",
+  "rep_rejected_assignment",
+  "active",
+  "closed",
+  "cancelled",
+]);
+
+const parseStatuses = (request: NextRequest) => {
+  const raw = request.nextUrl.searchParams.get("status")?.trim();
+
+  if (!raw) {
+    return [];
+  }
+
+  return raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value): value is ServiceRequestStatus => VALID_STATUSES.has(value as ServiceRequestStatus));
+};
+
+export async function GET(request: NextRequest) {
+  const user = getAuthorizedUser(request);
+
+  if (!user) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  const items = listServiceRequests(user, {
+    statuses: parseStatuses(request),
+  });
+
+  return NextResponse.json({ items });
+}
+
+export async function POST(request: NextRequest) {
+  const user = getAuthorizedUser(request);
+
+  if (!user) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = (await request.json()) as {
+      clientId?: unknown;
+      description?: unknown;
+      priority?: unknown;
+      requestType?: unknown;
+      source?: unknown;
+      title?: unknown;
+    };
+
+    const clientId = String(body.clientId ?? "").trim();
+    const title = String(body.title ?? "").trim();
+    const description = String(body.description ?? "").trim();
+    const priority =
+      typeof body.priority === "string" && VALID_PRIORITIES.has(body.priority as ServiceRequestPriority)
+        ? (body.priority as ServiceRequestPriority)
+        : "medium";
+    const requestType =
+      typeof body.requestType === "string" && body.requestType.trim().length > 0
+        ? body.requestType.trim()
+        : "service_request";
+    const source =
+      body.source === "assistant" || body.source === "client_portal" || body.source === "workspace"
+        ? body.source
+        : undefined;
+
+    if (!clientId || !title || !description) {
+      return NextResponse.json(
+        {
+          message: "clientId, title, and description are required.",
+        },
+        { status: 400 },
+      );
+    }
+
+    if (user.role === "Client" && !(user.clientIds ?? []).includes(clientId)) {
+      return NextResponse.json(
+        {
+          message: "Clients can only create requests for their own workspace.",
+        },
+        { status: 403 },
+      );
+    }
+
+    const serviceRequest = createServiceRequest(user, {
+      clientId,
+      description,
+      priority,
+      requestType,
+      source,
+      title,
+    });
+
+    return NextResponse.json(serviceRequest, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        message:
+          error instanceof Error
+            ? error.message
+            : "The service request could not be created.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/service-requests/route.ts
+++ b/app/api/service-requests/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { isLiveSessionToken, getRequestSessionToken } from "@/lib/server/request-session-token";
+import {
+  createLiveServiceRequest,
+  listLiveServiceRequests,
+} from "@/lib/server/service-request-backend-store";
 import {
   createServiceRequest,
   listServiceRequests,
@@ -46,20 +51,26 @@ const parseStatuses = (request: NextRequest) => {
 
 export async function GET(request: NextRequest) {
   const user = getAuthorizedUser(request);
+  const token = getRequestSessionToken(request);
 
   if (!user) {
     return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
   }
 
-  const items = listServiceRequests(user, {
-    statuses: parseStatuses(request),
-  });
+  const items = isLiveSessionToken(token)
+    ? await listLiveServiceRequests(user, token, {
+        statuses: parseStatuses(request),
+      })
+    : listServiceRequests(user, {
+        statuses: parseStatuses(request),
+      });
 
   return NextResponse.json({ items });
 }
 
 export async function POST(request: NextRequest) {
   const user = getAuthorizedUser(request);
+  const token = getRequestSessionToken(request);
 
   if (!user) {
     return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
@@ -109,14 +120,23 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const serviceRequest = createServiceRequest(user, {
-      clientId,
-      description,
-      priority,
-      requestType,
-      source,
-      title,
-    });
+    const serviceRequest = isLiveSessionToken(token)
+      ? await createLiveServiceRequest(user, token, {
+          clientId,
+          description,
+          priority,
+          requestType,
+          source,
+          title,
+        })
+      : createServiceRequest(user, {
+          clientId,
+          description,
+          priority,
+          requestType,
+          source,
+          title,
+        });
 
     return NextResponse.json(serviceRequest, { status: 201 });
   } catch (error) {

--- a/app/dashboard/(routes)/assistant/page.tsx
+++ b/app/dashboard/(routes)/assistant/page.tsx
@@ -1,5 +1,10 @@
 import { AssistantPanel } from "@/components/dashboard/assistant-panel";
+import { Suspense } from "react";
 
 export default function AssistantPage() {
-  return <AssistantPanel />;
+  return (
+    <Suspense fallback={null}>
+      <AssistantPanel />
+    </Suspense>
+  );
 }

--- a/app/swagger/page.tsx
+++ b/app/swagger/page.tsx
@@ -1,0 +1,54 @@
+import Script from "next/script";
+
+const swaggerInitializer = `
+window.onload = function () {
+  const ui = SwaggerUIBundle({
+    deepLinking: true,
+    dom_id: "#swagger-ui",
+    layout: "BaseLayout",
+    presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+    url: "/api/openapi/owned-sales-automation",
+  });
+
+  window.ui = ui;
+};
+`;
+
+export default function SwaggerPage() {
+  return (
+    <html lang="en">
+      <head>
+        <title>Owned Sales Automation API</title>
+        <link
+          href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css"
+          rel="stylesheet"
+        />
+        <style>{`
+          html, body {
+            background: #f6f7f9;
+            height: 100%;
+            margin: 0;
+          }
+
+          #swagger-ui {
+            min-height: 100vh;
+          }
+        `}</style>
+      </head>
+      <body>
+        <div id="swagger-ui" />
+        <Script
+          src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"
+          strategy="afterInteractive"
+        />
+        <Script
+          src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-standalone-preset.js"
+          strategy="afterInteractive"
+        />
+        <Script id="swagger-ui-init" strategy="afterInteractive">
+          {swaggerInitializer}
+        </Script>
+      </body>
+    </html>
+  );
+}

--- a/components/dashboard/activities-panel.tsx
+++ b/components/dashboard/activities-panel.tsx
@@ -129,7 +129,7 @@ export function ActivitiesPanel() {
         rowKey="id"
       />
 
-      {!isScopedClient ? (
+      {!isScopedClient && (isModalOpen || editingId !== null) ? (
         <ActivityForm
           editingId={editingId}
           isOpen={isModalOpen || editingId !== null}

--- a/components/dashboard/activity-form.tsx
+++ b/components/dashboard/activity-form.tsx
@@ -3,6 +3,7 @@
 import { Form, Input, Modal, Select } from "antd";
 import { useEffect } from "react";
 
+import { useMounted } from "@/lib/client/use-mounted";
 import { ActivityStatus, ActivityType, type IActivity } from "@/providers/salesTypes";
 import { useActivityActions, useActivityState } from "@/providers/activityProvider";
 import { useOpportunityState } from "@/providers/opportunityProvider";
@@ -27,6 +28,7 @@ export default function ActivityForm({
   onSubmitEnd,
 }: ActivityFormProps) {
   const [form] = Form.useForm();
+  const mounted = useMounted();
   const { activities } = useActivityState();
   const { opportunities } = useOpportunityState();
   const { proposals } = useProposalState();
@@ -34,6 +36,10 @@ export default function ActivityForm({
   const { addActivity, updateActivity } = useActivityActions();
 
   useEffect(() => {
+    if (!mounted) {
+      return;
+    }
+
     if (editingId) {
       const activity = activities.find((item) => item.id === editingId);
       if (activity) {
@@ -45,7 +51,7 @@ export default function ActivityForm({
     } else {
       form.resetFields();
     }
-  }, [activities, editingId, form, isOpen]);
+  }, [activities, editingId, form, isOpen, mounted]);
 
   const handleSubmit = async (values: {
     assignedToId?: string;
@@ -88,9 +94,8 @@ export default function ActivityForm({
     }
   };
 
-  return (
+  return mounted ? (
     <Modal
-      forceRender
       onCancel={onClose}
       onOk={() => form.submit()}
       okButtonProps={{ loading: isSubmitting }}
@@ -160,5 +165,5 @@ export default function ActivityForm({
         </Form.Item>
       </Form>
     </Modal>
-  );
+  ) : null;
 }

--- a/components/dashboard/activity-form.tsx
+++ b/components/dashboard/activity-form.tsx
@@ -39,7 +39,6 @@ export default function ActivityForm({
     if (!mounted) {
       return;
     }
-
     if (editingId) {
       const activity = activities.find((item) => item.id === editingId);
       if (activity) {

--- a/components/dashboard/assistant-panel.tsx
+++ b/components/dashboard/assistant-panel.tsx
@@ -7,7 +7,7 @@ import {
   SafetyCertificateOutlined,
   SendOutlined,
 } from "@ant-design/icons";
-import { useEffect, useState } from "react";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
 
 import { isClientScopedUser } from "@/lib/auth/dashboard-access";
 import { getPrimaryUserRole, getUserRoleLabel, isManagerRole } from "@/lib/auth/roles";
@@ -116,6 +116,28 @@ export function AssistantPanel() {
   const [messages, setMessages] = useState<AssistantMessage[]>([]);
   const [loadedStorageIdentity, setLoadedStorageIdentity] = useState<string | null>(null);
   const [statusLabel, setStatusLabel] = useState("Awaiting your question");
+  const [autoPrompt] = useState(() => {
+    if (typeof window === "undefined") {
+      return "";
+    }
+
+    return new URLSearchParams(window.location.search).get("prompt")?.trim() ?? "";
+  });
+  const [shouldAutoRun] = useState(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+
+    return new URLSearchParams(window.location.search).get("autorun") === "1";
+  });
+  const [shouldStartFresh] = useState(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+
+    return new URLSearchParams(window.location.search).get("fresh") === "1";
+  });
+  const autoRunKeyRef = useRef<string | null>(null);
   const storageIdentity = `${draftStorageKey}::${messageStorageKey}`;
   const modeTag = getModeTag(assistantMode);
   const scopeTagLabel = isScopedClientUser
@@ -255,15 +277,16 @@ export function AssistantPanel() {
     };
   }, []);
 
-  const sendMessage = async (content: string) => {
+  const sendMessage = async (content: string, options?: { baseMessages?: AssistantMessage[] }) => {
     const trimmed = content.trim();
 
     if (!trimmed || isSubmitting) {
       return;
     }
 
+    const baseMessages = options?.baseMessages ?? messages;
     const nextMessages = [
-      ...messages,
+      ...baseMessages,
       {
         content: trimmed,
         role: "user" as const,
@@ -351,6 +374,75 @@ export function AssistantPanel() {
       setIsSubmitting(false);
     }
   };
+
+  const runAutoPrompt = useEffectEvent(
+    (prompt: string, fresh: boolean, clearAutorunFlag: () => void) => {
+      const baseMessages = fresh ? [] : messages;
+
+      if (fresh) {
+        setMessages([]);
+        setDraft("");
+        clearSessionDraft(draftStorageKey);
+        clearSessionDraft(messageStorageKey);
+      }
+
+      void sendMessage(prompt, { baseMessages }).finally(() => {
+        clearAutorunFlag();
+      });
+    },
+  );
+
+  useEffect(() => {
+    if (!autoPrompt || !shouldAutoRun || loadedStorageIdentity !== storageIdentity || isSubmitting) {
+      return;
+    }
+
+    const autoRunKey = `${storageIdentity}::${autoPrompt}`;
+
+    if (autoRunKeyRef.current === autoRunKey) {
+      return;
+    }
+
+    const clearAutorunFlag = () => {
+      if (typeof window === "undefined") {
+        return;
+      }
+
+      const params = new URLSearchParams(window.location.search);
+      params.delete("autorun");
+      params.delete("fresh");
+      const nextUrl = params.toString()
+        ? `/dashboard/assistant?${params.toString()}`
+        : "/dashboard/assistant";
+      window.history.replaceState(null, "", nextUrl);
+    };
+
+    if (!shouldStartFresh && messages.length > 0) {
+      autoRunKeyRef.current = autoRunKey;
+      clearAutorunFlag();
+      return;
+    }
+
+    autoRunKeyRef.current = autoRunKey;
+    const timer = window.setTimeout(() => {
+      runAutoPrompt(autoPrompt, shouldStartFresh, clearAutorunFlag);
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [
+    autoPrompt,
+    draftStorageKey,
+    isSubmitting,
+    loadedStorageIdentity,
+    messages,
+    messages.length,
+    messageStorageKey,
+    shouldAutoRun,
+    shouldStartFresh,
+    storageIdentity,
+  ]);
 
   return (
     <div className="space-y-6">

--- a/components/dashboard/assistant-panel.tsx
+++ b/components/dashboard/assistant-panel.tsx
@@ -46,6 +46,7 @@ type AssistantMessage = {
 };
 
 type AssistantRuntimeMode =
+  | "gemini"
   | "groq"
   | "local"
   | "offline"
@@ -213,7 +214,7 @@ export function AssistantPanel() {
         const payload = (await response.json()) as {
           isConfigured?: boolean;
           message?: string;
-          mode?: "groq" | "offline" | "openai";
+          mode?: "gemini" | "groq" | "offline" | "openai";
           model?: string;
           reason?: string | null;
         };
@@ -441,14 +442,6 @@ export function AssistantPanel() {
           </div>
 
           <div className="mt-5 space-y-4">
-            <div className="flex flex-wrap gap-2">
-              {suggestedPrompts.map((prompt) => (
-                <Button key={prompt} onClick={() => void sendMessage(prompt)}>
-                  {prompt}
-                </Button>
-              ))}
-            </div>
-
             <Input.TextArea
               onChange={(event) => setDraft(event.target.value)}
               onPressEnter={(event) => {
@@ -461,6 +454,12 @@ export function AssistantPanel() {
               rows={4}
               value={draft}
             />
+
+            {assistantMode === "offline" ? (
+              <Typography.Text className="block !text-sm !text-amber-700">
+                Live provider actions are unavailable in offline mode. Workspace summaries still work, but create, update, and delete assistant actions need `OPENAI_API_KEY`, `GROQ_API_KEY`, or `GEMINI_API_KEY` configured locally.
+              </Typography.Text>
+            ) : null}
 
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="flex flex-wrap gap-2">
@@ -482,6 +481,14 @@ export function AssistantPanel() {
               </div>
             </div>
 
+            <div className="flex flex-wrap gap-2">
+              {suggestedPrompts.map((prompt) => (
+                <Button key={prompt} onClick={() => void sendMessage(prompt)}>
+                  {prompt}
+                </Button>
+              ))}
+            </div>
+
             {error ? <Alert description={error} showIcon title="Assistant request failed." type="error" /> : null}
           </div>
         </Card>
@@ -495,7 +502,7 @@ export function AssistantPanel() {
               description={
                 assistantReason
                   ? `${assistantReason} Add it to .env.local and restart the Next.js server.`
-                  : "Add OPENAI_API_KEY or GROQ_API_KEY to .env.local and restart the Next.js server."
+                  : "Add OPENAI_API_KEY, GROQ_API_KEY, or GEMINI_API_KEY to .env.local and restart the Next.js server."
               }
             />
           ) : null}

--- a/components/dashboard/assistant-panel.tsx
+++ b/components/dashboard/assistant-panel.tsx
@@ -8,6 +8,7 @@ import {
   SendOutlined,
 } from "@ant-design/icons";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 
 import { isClientScopedUser } from "@/lib/auth/dashboard-access";
 import { getPrimaryUserRole, getUserRoleLabel, isManagerRole } from "@/lib/auth/roles";
@@ -96,6 +97,7 @@ const getResponseStatusLabel = (mode: AssistantRuntimeMode, scopeLabel?: string)
 };
 
 export function AssistantPanel() {
+  const searchParams = useSearchParams();
   const { user } = useAuthState();
   const role = getPrimaryUserRole(user?.roles);
   const isScopedClientUser = isClientScopedUser(user?.clientIds);
@@ -116,27 +118,9 @@ export function AssistantPanel() {
   const [messages, setMessages] = useState<AssistantMessage[]>([]);
   const [loadedStorageIdentity, setLoadedStorageIdentity] = useState<string | null>(null);
   const [statusLabel, setStatusLabel] = useState("Awaiting your question");
-  const [autoPrompt] = useState(() => {
-    if (typeof window === "undefined") {
-      return "";
-    }
-
-    return new URLSearchParams(window.location.search).get("prompt")?.trim() ?? "";
-  });
-  const [shouldAutoRun] = useState(() => {
-    if (typeof window === "undefined") {
-      return false;
-    }
-
-    return new URLSearchParams(window.location.search).get("autorun") === "1";
-  });
-  const [shouldStartFresh] = useState(() => {
-    if (typeof window === "undefined") {
-      return false;
-    }
-
-    return new URLSearchParams(window.location.search).get("fresh") === "1";
-  });
+  const autoPrompt = searchParams.get("prompt")?.trim() ?? "";
+  const shouldAutoRun = searchParams.get("autorun") === "1";
+  const shouldStartFresh = searchParams.get("fresh") === "1";
   const autoRunKeyRef = useRef<string | null>(null);
   const storageIdentity = `${draftStorageKey}::${messageStorageKey}`;
   const modeTag = getModeTag(assistantMode);
@@ -391,6 +375,12 @@ export function AssistantPanel() {
       });
     },
   );
+
+  useEffect(() => {
+    if (!shouldAutoRun) {
+      autoRunKeyRef.current = null;
+    }
+  }, [shouldAutoRun]);
 
   useEffect(() => {
     if (!autoPrompt || !shouldAutoRun || loadedStorageIdentity !== storageIdentity || isSubmitting) {

--- a/components/dashboard/assistant-panel.tsx
+++ b/components/dashboard/assistant-panel.tsx
@@ -135,14 +135,16 @@ export function AssistantPanel() {
     setMessages([]);
     setError(null);
     setLastResponseReason(null);
-    clearSessionDraft(draftStorageKey);
-    clearSessionDraft(messageStorageKey);
+    clearSessionDraft(draftStorageKey, { storage: "local" });
+    clearSessionDraft(messageStorageKey, { storage: "local" });
   };
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      setDraft(readSessionDraft<string>(draftStorageKey) ?? "");
-      setMessages(readSessionDraft<AssistantMessage[]>(messageStorageKey) ?? []);
+      setDraft(readSessionDraft<string>(draftStorageKey, { storage: "local" }) ?? "");
+      setMessages(
+        readSessionDraft<AssistantMessage[]>(messageStorageKey, { storage: "local" }) ?? [],
+      );
       setError(null);
       setLastResponseReason(null);
       setLoadedStorageIdentity(storageIdentity);
@@ -188,11 +190,11 @@ export function AssistantPanel() {
     }
 
     if (draft) {
-      writeSessionDraft(draftStorageKey, draft);
+      writeSessionDraft(draftStorageKey, draft, { storage: "local" });
       return;
     }
 
-    clearSessionDraft(draftStorageKey);
+    clearSessionDraft(draftStorageKey, { storage: "local" });
   }, [draft, draftStorageKey, loadedStorageIdentity, storageIdentity]);
 
   useEffect(() => {
@@ -201,11 +203,11 @@ export function AssistantPanel() {
     }
 
     if (messages.length > 0) {
-      writeSessionDraft(messageStorageKey, messages);
+      writeSessionDraft(messageStorageKey, messages, { storage: "local" });
       return;
     }
 
-    clearSessionDraft(messageStorageKey);
+    clearSessionDraft(messageStorageKey, { storage: "local" });
   }, [loadedStorageIdentity, messageStorageKey, messages, storageIdentity]);
 
   useEffect(() => {
@@ -279,7 +281,7 @@ export function AssistantPanel() {
 
     setMessages(nextMessages);
     setDraft("");
-    clearSessionDraft(draftStorageKey);
+    clearSessionDraft(draftStorageKey, { storage: "local" });
     setError(null);
     setLastResponseReason(null);
     setIsSubmitting(true);
@@ -366,8 +368,8 @@ export function AssistantPanel() {
       if (fresh) {
         setMessages([]);
         setDraft("");
-        clearSessionDraft(draftStorageKey);
-        clearSessionDraft(messageStorageKey);
+        clearSessionDraft(draftStorageKey, { storage: "local" });
+        clearSessionDraft(messageStorageKey, { storage: "local" });
       }
 
       void sendMessage(prompt, { baseMessages }).finally(() => {

--- a/components/dashboard/client-form.tsx
+++ b/components/dashboard/client-form.tsx
@@ -3,6 +3,7 @@
 import { Form, Input, InputNumber, Modal, Select } from "antd";
 import { useEffect } from "react";
 
+import { useMounted } from "@/lib/client/use-mounted";
 import { clearSessionDraft, readSessionDraft, writeSessionDraft } from "@/lib/client/session-drafts";
 import { OpportunityStage, type IClient } from "@/providers/salesTypes";
 import { getClientFormDraftKey } from "./draft-storage";
@@ -34,9 +35,14 @@ export function ClientForm({
   onSave,
 }: ClientFormProps) {
   const [form] = Form.useForm<ClientFormValues>();
+  const mounted = useMounted();
   const draftKey = getClientFormDraftKey(editingClient?.id);
 
   useEffect(() => {
+    if (!mounted) {
+      return;
+    }
+
     const savedDraft = readSessionDraft<Partial<ClientFormValues>>(draftKey);
 
     if (editingClient) {
@@ -55,16 +61,15 @@ export function ClientForm({
     if (savedDraft) {
       form.setFieldsValue(savedDraft);
     }
-  }, [draftKey, editingClient, form, isOpen]);
+  }, [draftKey, editingClient, form, isOpen, mounted]);
 
   const handleFinish = async (values: ClientFormValues) => {
     await onSave(values);
     clearSessionDraft(draftKey);
   };
 
-  return (
+  return mounted ? (
     <Modal
-      forceRender
       onCancel={onClose}
       onOk={() => form.submit()}
       okButtonProps={{ loading: isSubmitting }}
@@ -163,5 +168,5 @@ export function ClientForm({
         ) : null}
       </Form>
     </Modal>
-  );
+  ) : null;
 }

--- a/components/dashboard/client-message-center.tsx
+++ b/components/dashboard/client-message-center.tsx
@@ -13,17 +13,26 @@ import {
   Typography,
   message,
 } from "antd";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import {
-  CLIENT_MESSAGE_CATEGORY,
   isClientRequestThread,
   isTeamAssignmentThread,
 } from "@/lib/dashboard/message-threads";
+import {
+  createServiceRequest,
+  applyServiceRequestClientDecision,
+  getServiceRequestDetail,
+  listServiceRequests,
+  type ServiceRequestAssignmentRecord,
+  type ServiceRequestDetail,
+  type ServiceRequestRecord,
+} from "@/lib/client/service-request-api";
+import { useMounted } from "@/lib/client/use-mounted";
 import { useAuthState } from "@/providers/authProvider";
 import { useClientState } from "@/providers/clientProvider";
 import type { INoteItem } from "@/providers/domainSeeds";
-import { useNoteActions, useNoteState } from "@/providers/noteProvider";
+import { useNoteState } from "@/providers/noteProvider";
 import { useStyles } from "./client-message-center.styles";
 
 type ClientMessageCenterProps = Readonly<{
@@ -34,9 +43,6 @@ type MessageFormValues = {
   content: string;
   subject: string;
 };
-
-const createMessageId = () =>
-  `client-message-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
 
 const getMessageStatusColor = (status?: INoteItem["status"]) => {
   switch (status) {
@@ -74,11 +80,15 @@ export const ClientMessageCenter = ({
   const { user } = useAuthState();
   const { clients } = useClientState();
   const { notes } = useNoteState();
-  const { addNote, updateNote } = useNoteActions();
   const { styles } = useStyles();
   const [messageApi, contextHolder] = message.useMessage();
+  const mounted = useMounted();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [serviceRequests, setServiceRequests] = useState<ServiceRequestRecord[]>([]);
+  const [serviceRequestDetails, setServiceRequestDetails] = useState<
+    Record<string, ServiceRequestDetail>
+  >({});
   const [form] = Form.useForm<MessageFormValues>();
 
   const primaryClientId = user?.clientIds?.[0];
@@ -94,13 +104,42 @@ export const ClientMessageCenter = ({
       .sort((left, right) => right.createdDate.localeCompare(left.createdDate));
   }, [client, notes]);
 
+  const clientServiceRequests = useMemo(
+    () =>
+      client
+        ? serviceRequests
+            .filter((request) => request.clientId === client.id)
+            .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+        : [],
+    [client, serviceRequests],
+  );
+
   const assignmentProposals = useMemo(
     () =>
-      clientMessages.filter(
-        (note) =>
-          isTeamAssignmentThread(note) && note.status === "Pending client response",
-      ),
-    [clientMessages],
+      clientServiceRequests.flatMap((request) => {
+        const detail = serviceRequestDetails[request.id];
+
+        if (!detail) {
+          return [];
+        }
+
+        const pendingAssignments = detail.assignments.filter(
+          (assignment) => assignment.status === "pending_client_approval",
+        );
+
+        if (pendingAssignments.length === 0) {
+          return [];
+        }
+
+        return [
+          {
+            assignments: pendingAssignments,
+            createdAt: pendingAssignments[0]?.createdAt ?? request.updatedAt,
+            request,
+          },
+        ];
+      }),
+    [clientServiceRequests, serviceRequestDetails],
   );
 
   const visibleHistory = useMemo(
@@ -111,6 +150,56 @@ export const ClientMessageCenter = ({
       ),
     [clientMessages],
   );
+
+  const loadServiceRequests = async () => {
+    try {
+      return await listServiceRequests();
+    } catch (error) {
+      console.error(error);
+      return [];
+    }
+  };
+
+  useEffect(() => {
+    let isActive = true;
+
+    void loadServiceRequests().then((items) => {
+      if (isActive) {
+        setServiceRequests(items);
+      }
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let isActive = true;
+
+    if (clientServiceRequests.length === 0) {
+      return () => {
+        isActive = false;
+      };
+    }
+
+    void Promise.all(
+      clientServiceRequests.map(async (request) => [
+        request.id,
+        await getServiceRequestDetail(request.id),
+      ] as const),
+    ).then((entries) => {
+      if (!isActive) {
+        return;
+      }
+
+      setServiceRequestDetails(Object.fromEntries(entries));
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, [clientServiceRequests]);
 
   const openComposer = () => {
     form.setFieldsValue({
@@ -134,19 +223,15 @@ export const ClientMessageCenter = ({
     setIsSubmitting(true);
 
     try {
-      await addNote({
-        category: CLIENT_MESSAGE_CATEGORY,
+      await createServiceRequest({
         clientId: client.id,
-        content: values.content.trim(),
-        createdDate: new Date().toISOString().split("T")[0],
-        id: createMessageId(),
-        kind: "client_message",
-        requestType: "client_request",
+        description: values.content.trim(),
+        priority: "high",
+        requestType: "service_request",
         source: "client_portal",
-        status: "Pending admin review",
-        submittedBy: user?.email ?? undefined,
         title: values.subject.trim(),
       });
+      setServiceRequests(await loadServiceRequests());
       messageApi.success("Request sent to the workspace admin for assignment.");
       closeComposer();
     } catch (error) {
@@ -157,18 +242,33 @@ export const ClientMessageCenter = ({
     }
   };
 
+  const refreshServiceRequests = async () => {
+    const nextRequests = await loadServiceRequests();
+    setServiceRequests(nextRequests);
+
+    const detailEntries = await Promise.all(
+      nextRequests.map(async (request) => [request.id, await getServiceRequestDetail(request.id)] as const),
+    );
+    setServiceRequestDetails(Object.fromEntries(detailEntries));
+  };
+
   const respondToAssignment = async (
-    note: INoteItem,
-    status: "Accepted" | "Rejected",
+    request: ServiceRequestRecord,
+    assignments: ServiceRequestAssignmentRecord[],
+    decision: "approve" | "reject",
   ) => {
     setIsSubmitting(true);
 
     try {
-      await updateNote(note.id, { status });
+      await applyServiceRequestClientDecision(request.id, {
+        assignmentIds: assignments.map((assignment) => assignment.id),
+        decision,
+      });
+      await refreshServiceRequests();
       messageApi.success(
-        status === "Accepted"
-          ? `${note.representativeName ?? "The sales rep"} was accepted.`
-          : `${note.representativeName ?? "The sales rep"} was rejected.`,
+        decision === "approve"
+          ? "The assigned sales reps were approved."
+          : "The assigned sales reps were rejected.",
       );
     } catch (error) {
       console.error(error);
@@ -180,7 +280,7 @@ export const ClientMessageCenter = ({
 
   return (
     <Card className={styles.card}>
-      {contextHolder}
+      {mounted ? contextHolder : null}
 
       <div className={styles.container}>
         <div className={styles.header}>
@@ -200,23 +300,24 @@ export const ClientMessageCenter = ({
 
         {assignmentProposals.length > 0 ? (
           <div className={styles.list}>
-            {assignmentProposals.map((note) => (
-              <div className={styles.messageCard} key={note.id}>
+            {assignmentProposals.map(({ assignments, createdAt, request }) => (
+              <div className={styles.messageCard} key={request.id}>
                 <div className={styles.messageHeader}>
                   <div className={styles.metaGroup}>
                     <Typography.Title className={styles.messageTitle} level={5}>
-                      {note.representativeName ?? "Assigned sales rep"}
+                      {assignments.map((assignment) => assignment.representativeName).join(", ")}
                     </Typography.Title>
                     <Space size="small" wrap>
                       <Tag color="gold">Pending your decision</Tag>
-                      <Tag color="geekblue">{note.createdDate}</Tag>
+                      <Tag color="default">{request.title}</Tag>
+                      <Tag color="geekblue">{createdAt.split("T")[0]}</Tag>
                     </Space>
                   </div>
                   <Space size="small" wrap>
                     <Button
                       icon={<CheckOutlined />}
                       loading={isSubmitting}
-                      onClick={() => void respondToAssignment(note, "Accepted")}
+                      onClick={() => void respondToAssignment(request, assignments, "approve")}
                       type="primary"
                     >
                       Accept
@@ -225,17 +326,18 @@ export const ClientMessageCenter = ({
                       danger
                       icon={<StopOutlined />}
                       loading={isSubmitting}
-                      onClick={() => void respondToAssignment(note, "Rejected")}
+                      onClick={() => void respondToAssignment(request, assignments, "reject")}
                     >
                       Reject
                     </Button>
                   </Space>
                 </div>
                 <Typography.Paragraph className={styles.messageText}>
-                  {note.content}
+                  {request.description}
                 </Typography.Paragraph>
                 <Typography.Text className={styles.messageFooter}>
-                  Assigned by {note.assignedByUserName ?? "workspace admin"}.
+                  Assigned by workspace admin. Waiting for your approval before the reps are asked
+                  to accept.
                 </Typography.Text>
               </div>
             ))}
@@ -289,40 +391,70 @@ export const ClientMessageCenter = ({
                 </Typography.Text>
               </div>
             ))}
+            {clientServiceRequests.map((request) => (
+              <div className={styles.messageCard} key={request.id}>
+                <div className={styles.messageHeader}>
+                  <div className={styles.metaGroup}>
+                    <Typography.Title className={styles.messageTitle} level={5}>
+                      {request.title}
+                    </Typography.Title>
+                    <Space size="small" wrap>
+                      <Tag color="default">You</Tag>
+                      <Tag color="orange">
+                        {request.status === "submitted"
+                          ? "Pending admin review"
+                          : request.status.replace(/_/g, " ")}
+                      </Tag>
+                      <Tag color="default">{request.createdAt.split("T")[0]}</Tag>
+                    </Space>
+                  </div>
+                  <Button icon={<MailOutlined />} onClick={() => openComposer()}>
+                    New request
+                  </Button>
+                </div>
+                <Typography.Paragraph className={styles.messageText}>
+                  {request.description}
+                </Typography.Paragraph>
+                <Typography.Text className={styles.messageFooter}>
+                  Submitted through the owned workflow API.
+                </Typography.Text>
+              </div>
+            ))}
           </div>
         )}
       </div>
 
-      <Modal
-        forceRender
-        onCancel={closeComposer}
-        onOk={() => form.submit()}
-        okButtonProps={{ loading: isSubmitting }}
-        okText="Send request"
-        open={isModalOpen}
-        title="Submit account team request"
-      >
-        <Form className={styles.modalForm} form={form} layout="vertical" onFinish={handleSubmit}>
-          <Form.Item
-            label="Subject"
-            name="subject"
-            rules={[{ message: "Please add a subject", required: true }]}
-          >
-            <Input placeholder="e.g. Proposal clarification" />
-          </Form.Item>
+      {mounted ? (
+        <Modal
+          onCancel={closeComposer}
+          onOk={() => form.submit()}
+          okButtonProps={{ loading: isSubmitting }}
+          okText="Send request"
+          open={isModalOpen}
+          title="Submit account team request"
+        >
+          <Form className={styles.modalForm} form={form} layout="vertical" onFinish={handleSubmit}>
+            <Form.Item
+              label="Subject"
+              name="subject"
+              rules={[{ message: "Please add a subject", required: true }]}
+            >
+              <Input placeholder="e.g. Proposal clarification" />
+            </Form.Item>
 
-          <Form.Item
-            label="Message"
-            name="content"
-            rules={[{ message: "Please enter your message", required: true }]}
-          >
-            <Input.TextArea
-              placeholder="Share what you need, the context, and any deadlines"
-              rows={5}
-            />
-          </Form.Item>
-        </Form>
-      </Modal>
+            <Form.Item
+              label="Message"
+              name="content"
+              rules={[{ message: "Please enter your message", required: true }]}
+            >
+              <Input.TextArea
+                placeholder="Share what you need, the context, and any deadlines"
+                rows={5}
+              />
+            </Form.Item>
+          </Form>
+        </Modal>
+      ) : null}
     </Card>
   );
 };

--- a/components/dashboard/contact-detail-view.tsx
+++ b/components/dashboard/contact-detail-view.tsx
@@ -3,10 +3,15 @@
 import { ArrowLeftOutlined } from "@ant-design/icons";
 import { Card, Col, Descriptions, Empty, Row, Skeleton, Space, Tag, Typography } from "antd";
 import Link from "next/link";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { isClientScopedUser } from "@/lib/auth/dashboard-access";
 import { getPrimaryUserRole, isAdminRole, isManagerRole } from "@/lib/auth/roles";
+import {
+  getServiceRequestDetail,
+  listServiceRequests,
+  type ServiceRequestDetail,
+} from "@/lib/client/service-request-api";
 import { useActivityState } from "@/providers/activityProvider";
 import { useAuthState } from "@/providers/authProvider";
 import { useClientState } from "@/providers/clientProvider";
@@ -29,10 +34,33 @@ export function ContactDetailView({ contactId }: ContactDetailViewProps) {
   const { notes } = useNoteState();
   const { opportunities } = useOpportunityState();
   const { teamMembers } = useTeamMembersState();
+  const [serviceRequestDetails, setServiceRequestDetails] = useState<ServiceRequestDetail[]>([]);
 
   const isClientUser = isClientScopedUser(user?.clientIds);
   const canManageContacts = !isClientUser;
   const isPrivileged = isAdminRole(role) || isManagerRole(role);
+
+  useEffect(() => {
+    let isActive = true;
+
+    if (!isClientUser) {
+      return () => {
+        isActive = false;
+      };
+    }
+
+    void listServiceRequests().then(async (requests) => {
+      const details = await Promise.all(requests.map((request) => getServiceRequestDetail(request.id)));
+
+      if (isActive) {
+        setServiceRequestDetails(details);
+      }
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, [isClientUser]);
 
   const rows = useMemo(
     () =>
@@ -45,6 +73,7 @@ export function ContactDetailView({ contactId }: ContactDetailViewProps) {
         isPrivileged,
         notes,
         opportunities,
+        serviceRequestDetails,
         teamMembers,
         userClientIds: user?.clientIds,
         userId: user?.userId,
@@ -58,6 +87,7 @@ export function ContactDetailView({ contactId }: ContactDetailViewProps) {
       isPrivileged,
       notes,
       opportunities,
+      serviceRequestDetails,
       teamMembers,
       user?.clientIds,
       user?.userId,

--- a/components/dashboard/contact-directory.ts
+++ b/components/dashboard/contact-directory.ts
@@ -1,3 +1,4 @@
+import type { ServiceRequestDetail } from "@/lib/client/service-request-api";
 import { isTeamAssignmentThread } from "@/lib/dashboard/message-threads";
 import type { INoteItem } from "@/providers/domainSeeds";
 import type { IContact, ITeamMember } from "@/providers/salesTypes";
@@ -23,12 +24,15 @@ type BuildContactDirectoryInput = {
     id: string;
     ownerId?: string;
   }>;
+  serviceRequestDetails?: ServiceRequestDetail[];
   teamMembers: ITeamMember[];
   userClientIds?: string[] | null;
   userId?: string;
 };
 
 export type ContactRow = {
+  assignmentId?: string;
+  assignmentRequestId?: string;
   assignmentNoteId?: string;
   assignmentStatus?: "Accepted" | "Pending client response" | "Rejected";
   category: "client" | "internal" | "admin";
@@ -76,6 +80,7 @@ export const buildContactDirectory = ({
   isPrivileged,
   notes,
   opportunities,
+  serviceRequestDetails = [],
   teamMembers,
   userClientIds,
   userId,
@@ -139,46 +144,85 @@ export const buildContactDirectory = ({
         }
       });
 
-      const workflowRows = notes
-        .filter(
-          (note) =>
-            isTeamAssignmentThread(note) &&
-            note.representativeId &&
-            note.representativeName &&
-            note.clientId &&
-            involvedClientIds.has(note.clientId) &&
-            note.status !== "Rejected",
-        )
-        .map((note) => {
-          const representativeName = note.representativeName ?? "Assigned sales rep";
-          const assignmentStatus: ContactRow["assignmentStatus"] =
-            note.status === "Accepted"
-              ? "Accepted"
-              : note.status === "Pending client response"
-                ? "Pending client response"
-                : note.status === "Rejected"
-                  ? "Rejected"
-                  : undefined;
-          const clientNames = clients
-            .filter((client) => note.clientId === client.id)
-            .map((client) => client.name);
+      const workflowRowsFromRequests = serviceRequestDetails
+        .filter(({ request }) => involvedClientIds.has(request.clientId))
+        .flatMap(({ assignments, request }) =>
+          assignments
+            .filter((assignment) => assignment.status !== "client_rejected")
+            .map((assignment) => {
+              const representativeName = assignment.representativeName || "Assigned sales rep";
+              const assignmentStatus: ContactRow["assignmentStatus"] =
+                assignment.status === "pending_client_approval"
+                  ? "Pending client response"
+                  : assignment.status === "client_rejected" ||
+                      assignment.status === "rep_rejected"
+                    ? "Rejected"
+                    : "Accepted";
+              const clientNames = clients
+                .filter((client) => client.id === request.clientId)
+                .map((client) => client.name);
 
-          return {
-            assignmentNoteId: note.id,
-            assignmentStatus,
-            category: "internal" as const,
-            clientLabel: clientNames.join(", ") || "Assigned account team",
-            clientNames,
-            email: `${representativeName.toLowerCase().replace(/\s+/g, ".")}@autosales.com`,
-            id: `assignment-${note.id}`,
-            isEditable: false,
-            name: representativeName,
-            phoneNumber: undefined,
-            position:
-              teamMembers.find((member) => member.id === note.representativeId)?.role ??
-              "Assigned sales rep",
-          };
-        });
+              return {
+                assignmentId: assignment.id,
+                assignmentRequestId: request.id,
+                assignmentStatus,
+                category: "internal" as const,
+                clientLabel: clientNames.join(", ") || "Assigned account team",
+                clientNames,
+                email: `${representativeName.toLowerCase().replace(/\s+/g, ".")}@autosales.com`,
+                id: `assignment-${assignment.id}`,
+                isEditable: false,
+                name: representativeName,
+                phoneNumber: undefined,
+                position:
+                  teamMembers.find((member) => member.id === assignment.representativeUserId)
+                    ?.role ?? "Assigned sales rep",
+              };
+            }),
+        );
+      const workflowRows =
+        workflowRowsFromRequests.length > 0
+          ? workflowRowsFromRequests
+          : notes
+              .filter(
+                (note) =>
+                  isTeamAssignmentThread(note) &&
+                  note.representativeId &&
+                  note.representativeName &&
+                  note.clientId &&
+                  involvedClientIds.has(note.clientId) &&
+                  note.status !== "Rejected",
+              )
+              .map((note) => {
+                const representativeName = note.representativeName ?? "Assigned sales rep";
+                const assignmentStatus: ContactRow["assignmentStatus"] =
+                  note.status === "Accepted"
+                    ? "Accepted"
+                    : note.status === "Pending client response"
+                      ? "Pending client response"
+                      : note.status === "Rejected"
+                        ? "Rejected"
+                        : undefined;
+                const clientNames = clients
+                  .filter((client) => note.clientId === client.id)
+                  .map((client) => client.name);
+
+                return {
+                  assignmentNoteId: note.id,
+                  assignmentStatus,
+                  category: "internal" as const,
+                  clientLabel: clientNames.join(", ") || "Assigned account team",
+                  clientNames,
+                  email: `${representativeName.toLowerCase().replace(/\s+/g, ".")}@autosales.com`,
+                  id: `assignment-${note.id}`,
+                  isEditable: false,
+                  name: representativeName,
+                  phoneNumber: undefined,
+                  position:
+                    teamMembers.find((member) => member.id === note.representativeId)?.role ??
+                    "Assigned sales rep",
+                };
+              });
       const workflowRowIds = new Set(workflowRows.map((row) => row.name));
       const involvedRows = teamMembers
         .filter((member) => involvedMemberIds.has(member.id))

--- a/components/dashboard/contact-form.tsx
+++ b/components/dashboard/contact-form.tsx
@@ -3,6 +3,7 @@
 import { Form, Input, Modal, Select } from "antd";
 import { useEffect } from "react";
 
+import { useMounted } from "@/lib/client/use-mounted";
 import { useClientState } from "@/providers/clientProvider";
 import type { IContact } from "@/providers/salesTypes";
 
@@ -32,9 +33,14 @@ export function ContactForm({
   onSave,
 }: ContactFormProps) {
   const [form] = Form.useForm<ContactFormValues>();
+  const mounted = useMounted();
   const { clients } = useClientState();
 
   useEffect(() => {
+    if (!mounted) {
+      return;
+    }
+
     if (!isOpen) {
       return;
     }
@@ -49,7 +55,7 @@ export function ContactForm({
       clientId: clients[0]?.id,
       isPrimaryContact: false,
     });
-  }, [clients, editingContact, form, isOpen]);
+  }, [clients, editingContact, form, isOpen, mounted]);
 
   const handleFinish = async (values: ContactFormValues) => {
     await onSave({
@@ -63,9 +69,8 @@ export function ContactForm({
     });
   };
 
-  return (
+  return mounted ? (
     <Modal
-      forceRender
       onCancel={onClose}
       onOk={() => form.submit()}
       okButtonProps={{ loading: isSubmitting }}
@@ -138,5 +143,5 @@ export function ContactForm({
         </div>
       </Form>
     </Modal>
-  );
+  ) : null;
 }

--- a/components/dashboard/contacts-panel.tsx
+++ b/components/dashboard/contacts-panel.tsx
@@ -3,10 +3,16 @@
 import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
 import { Button, Tag, Typography } from "antd";
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { isClientScopedUser } from "@/lib/auth/dashboard-access";
 import { getPrimaryUserRole, isAdminRole, isManagerRole } from "@/lib/auth/roles";
+import {
+  applyServiceRequestClientDecision,
+  getServiceRequestDetail,
+  listServiceRequests,
+  type ServiceRequestDetail,
+} from "@/lib/client/service-request-api";
 import { useActivityState } from "@/providers/activityProvider";
 import { useAuthState } from "@/providers/authProvider";
 import { useClientState } from "@/providers/clientProvider";
@@ -30,6 +36,7 @@ export function ContactsPanel() {
   const { updateNote } = useNoteActions();
   const { opportunities } = useOpportunityState();
   const { teamMembers } = useTeamMembersState();
+  const [serviceRequestDetails, setServiceRequestDetails] = useState<ServiceRequestDetail[]>([]);
   const [editingContact, setEditingContact] = useState<IContact | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -37,6 +44,28 @@ export function ContactsPanel() {
   const isClientUser = isClientScopedUser(user?.clientIds);
   const canManageContacts = !isClientUser;
   const isPrivileged = isAdminRole(role) || isManagerRole(role);
+
+  useEffect(() => {
+    let isActive = true;
+
+    if (!isClientUser) {
+      return () => {
+        isActive = false;
+      };
+    }
+
+    void listServiceRequests().then(async (requests) => {
+      const details = await Promise.all(requests.map((request) => getServiceRequestDetail(request.id)));
+
+      if (isActive) {
+        setServiceRequestDetails(details);
+      }
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, [isClientUser]);
 
   const rows = useMemo(() => {
     return buildContactDirectory({
@@ -48,6 +77,7 @@ export function ContactsPanel() {
       isPrivileged,
       notes,
       opportunities,
+      serviceRequestDetails,
       teamMembers,
       userClientIds: user?.clientIds,
       userId: user?.userId,
@@ -61,6 +91,7 @@ export function ContactsPanel() {
     isPrivileged,
     notes,
     opportunities,
+    serviceRequestDetails,
     teamMembers,
     user?.clientIds,
     user?.userId,
@@ -70,14 +101,33 @@ export function ContactsPanel() {
     record: ContactRow,
     status: "Accepted" | "Rejected",
   ) => {
-    if (!record.assignmentNoteId) {
+    if (!record.assignmentRequestId || !record.assignmentId) {
+      if (!record.assignmentNoteId) {
+        return;
+      }
+
+      setIsSubmitting(true);
+
+      try {
+        await updateNote(record.assignmentNoteId, { status });
+      } finally {
+        setIsSubmitting(false);
+      }
+
       return;
     }
 
     setIsSubmitting(true);
 
     try {
-      await updateNote(record.assignmentNoteId, { status });
+      await applyServiceRequestClientDecision(record.assignmentRequestId, {
+        assignmentIds: [record.assignmentId],
+        decision: status === "Accepted" ? "approve" : "reject",
+      });
+      const requests = await listServiceRequests();
+      setServiceRequestDetails(
+        await Promise.all(requests.map((request) => getServiceRequestDetail(request.id))),
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/components/dashboard/dashboard-frame.tsx
+++ b/components/dashboard/dashboard-frame.tsx
@@ -14,9 +14,8 @@ import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
 import { getSessionToken } from "@/lib/client/backend-api";
-import { backendRequest } from "@/lib/client/backend-api";
+import { listServiceRequests } from "@/lib/client/service-request-api";
 import { getPrimaryUserRole, getUserRoleLabel, isManagerRole } from "@/lib/auth/roles";
-import type { INoteItem } from "@/providers/domainSeeds";
 import { dashboardNavItems } from "@/constants/dashboard-nav";
 import {
   canAccessDashboardPath,
@@ -110,14 +109,9 @@ export function DashboardFrame({ children }: DashboardFrameProps) {
 
     const loadPendingAdminRequests = async () => {
       try {
-        const payload = await backendRequest<{ items?: INoteItem[] } | INoteItem[]>("/api/Notes");
-        const notes = Array.isArray(payload) ? payload : payload.items ?? [];
-        const pendingRequests = notes
-          .filter(
-            (note) =>
-              note.requestType === "client_request" && note.status === "Pending admin review",
-          )
-          .sort((left, right) => right.createdDate.localeCompare(left.createdDate));
+        const pendingRequests = (await listServiceRequests(["submitted"])).sort((left, right) =>
+          right.createdAt.localeCompare(left.createdAt),
+        );
         const count = pendingRequests.length;
 
         if (isActive) {
@@ -154,7 +148,7 @@ export function DashboardFrame({ children }: DashboardFrameProps) {
       }
       window.removeEventListener("mock-workspace-updated", handleWorkspaceUpdate);
     };
-  }, [activeRole, isAuthenticated, pathname]);
+  }, [activeRole, isAuthenticated]);
 
   const currentAlertSignature = `${latestPendingRequestId ?? "none"}:${pendingAdminRequestCount}`;
   const isAdminAlertDismissed =
@@ -242,7 +236,7 @@ export function DashboardFrame({ children }: DashboardFrameProps) {
       />
 
       <Layout className={`dashboard-main ${collapsed ? "dashboard-main--expanded" : ""}`}>
-        <Header className="dashboard-header sticky top-0 z-30 flex flex-wrap items-center justify-between gap-3">
+        <Header className="dashboard-header sticky top-0 z-30 flex flex-wrap items-center justify-between gap-3 !h-auto !leading-normal">
           <Space align="center" className="min-w-0">
             <Button
               className="dashboard-header-toggle !text-white"
@@ -267,39 +261,29 @@ export function DashboardFrame({ children }: DashboardFrameProps) {
               pendingAdminRequestCount > 0 && !isAdminAlertDismissed ? (
                 <div
                   aria-label={`${pendingAdminRequestCount} client requests need admin attention`}
-                  className="dashboard-admin-alert-link"
+                  className="flex max-w-[24rem] items-center gap-2 rounded-full border border-amber-300 bg-amber-50 px-2 py-1 text-amber-950 shadow-sm"
                   role="region"
                 >
-                  <div className="dashboard-admin-alert dashboard-admin-alert--live">
-                    <span className="dashboard-admin-alert__beacon" aria-hidden="true" />
-                    <span className="dashboard-admin-alert__copy">
-                      <span className="dashboard-admin-alert__eyebrow">Action required</span>
-                      <span className="dashboard-admin-alert__title">
-                        {pendingAdminRequestCount} client request
-                        {pendingAdminRequestCount === 1 ? "" : "s"} waiting
-                      </span>
-                      <span className="dashboard-admin-alert__text">
-                        {latestPendingRequestTitle ?? "Open the request queue now."}
-                      </span>
-                    </span>
-                    <Badge count={pendingAdminRequestCount} size="small">
-                      <button
-                        className="dashboard-admin-alert__button"
-                        onClick={openAdminRequestQueue}
-                        type="button"
-                      >
-                        Review now
-                      </button>
-                    </Badge>
+                  <Badge count={pendingAdminRequestCount} size="small">
                     <button
-                      aria-label="Dismiss admin request alert"
-                      className="dashboard-admin-alert__dismiss"
-                      onClick={dismissAdminAlert}
+                      className="flex items-center gap-2 rounded-full bg-transparent px-2 py-1 text-left text-xs font-medium text-amber-950 transition hover:bg-amber-100"
+                      onClick={openAdminRequestQueue}
                       type="button"
                     >
-                      <CloseOutlined />
+                      <BellOutlined />
+                      <span className="max-w-[14rem] truncate">
+                        {latestPendingRequestTitle ?? `${pendingAdminRequestCount} request${pendingAdminRequestCount === 1 ? "" : "s"} waiting`}
+                      </span>
                     </button>
-                  </div>
+                  </Badge>
+                  <button
+                    aria-label="Dismiss admin request alert"
+                    className="flex h-6 w-6 items-center justify-center rounded-full text-amber-700 transition hover:bg-amber-100"
+                    onClick={dismissAdminAlert}
+                    type="button"
+                  >
+                    <CloseOutlined />
+                  </button>
                 </div>
               ) : (
                 <Button

--- a/components/dashboard/dashboard-frame.tsx
+++ b/components/dashboard/dashboard-frame.tsx
@@ -5,15 +5,16 @@ import {
   CloseOutlined,
   HomeOutlined,
   LogoutOutlined,
+  MailOutlined,
   MenuFoldOutlined,
   MenuUnfoldOutlined,
 } from "@ant-design/icons";
 import { Badge, Button, Layout, Menu, Space, Tag, Typography } from "antd";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { getSessionToken } from "@/lib/client/backend-api";
+import { backendRequest, coerceItems, getSessionToken } from "@/lib/client/backend-api";
 import { listServiceRequests } from "@/lib/client/service-request-api";
 import { getPrimaryUserRole, getUserRoleLabel, isManagerRole } from "@/lib/auth/roles";
 import { dashboardNavItems } from "@/constants/dashboard-nav";
@@ -23,6 +24,7 @@ import {
   getDashboardNavItemForPath,
 } from "@/lib/auth/dashboard-access";
 import { useAuthActions, useAuthState } from "@/providers/authProvider";
+import type { INoteItem } from "@/providers/domainSeeds";
 import { type UserRole } from "@/providers/salesTypes";
 import { BoxfusionLogo } from "./boxfusion-logo";
 
@@ -34,13 +36,19 @@ type DashboardFrameProps = Readonly<{
 
 export function DashboardFrame({ children }: DashboardFrameProps) {
   const alertDismissKey = "dashboard-admin-alert-dismissed";
+  const messageDismissKey = "dashboard-message-alert-dismissed";
   const [collapsed, setCollapsed] = useState(false);
   const [dismissedAlertSignature, setDismissedAlertSignature] = useState<string | null>(() =>
     typeof window === "undefined" ? null : window.sessionStorage.getItem(alertDismissKey),
   );
+  const [dismissedMessageSignature, setDismissedMessageSignature] = useState<string | null>(() =>
+    typeof window === "undefined" ? null : window.sessionStorage.getItem(messageDismissKey),
+  );
   const [pendingAdminRequestCount, setPendingAdminRequestCount] = useState(0);
   const [latestPendingRequestId, setLatestPendingRequestId] = useState<string | null>(null);
   const [latestPendingRequestTitle, setLatestPendingRequestTitle] = useState<string | null>(null);
+  const [incomingMessageCount, setIncomingMessageCount] = useState(0);
+  const [latestIncomingMessage, setLatestIncomingMessage] = useState<INoteItem | null>(null);
   const pathname = usePathname();
   const router = useRouter();
   const { logout } = useAuthActions();
@@ -150,9 +158,94 @@ export function DashboardFrame({ children }: DashboardFrameProps) {
     };
   }, [activeRole, isAuthenticated]);
 
+  const isPlainMessage = (note: INoteItem) =>
+    note.kind === "client_message" && !note.requestType;
+
+  const getIncomingMessages = useCallback(
+    (notes: INoteItem[]) => {
+      const clientIdSet = new Set(user?.clientIds ?? []);
+
+      if (clientIdSet.size > 0) {
+        return notes.filter(
+          (note) =>
+            isPlainMessage(note) &&
+            Boolean(note.clientId) &&
+            clientIdSet.has(note.clientId as string) &&
+            note.source !== "client_portal",
+        );
+      }
+
+      if (activeRole === "SalesRep" && user?.userId) {
+        return notes.filter(
+          (note) =>
+            isPlainMessage(note) &&
+            note.representativeId === user.userId &&
+            note.source !== "client_portal",
+        );
+      }
+
+      return notes.filter(
+        (note) => isPlainMessage(note) && note.source === "client_portal",
+      );
+    },
+    [activeRole, user?.clientIds, user?.userId],
+  );
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    let isActive = true;
+    let pollTimer: number | null = null;
+
+    const loadIncomingMessages = async () => {
+      try {
+        const payload = await backendRequest<{ items?: INoteItem[] } | INoteItem[]>("/api/Notes");
+        const incomingMessages = getIncomingMessages(coerceItems(payload)).sort((left, right) =>
+          right.createdDate.localeCompare(left.createdDate),
+        );
+
+        if (isActive) {
+          setIncomingMessageCount(incomingMessages.length);
+          setLatestIncomingMessage(incomingMessages[0] ?? null);
+        }
+      } catch (error) {
+        console.error(error);
+
+        if (isActive) {
+          setIncomingMessageCount(0);
+          setLatestIncomingMessage(null);
+        }
+      }
+    };
+
+    void loadIncomingMessages();
+    pollTimer = window.setInterval(() => {
+      void loadIncomingMessages();
+    }, 5000);
+
+    const handleWorkspaceUpdate = () => {
+      void loadIncomingMessages();
+    };
+
+    window.addEventListener("mock-workspace-updated", handleWorkspaceUpdate);
+
+    return () => {
+      isActive = false;
+      if (pollTimer !== null) {
+        window.clearInterval(pollTimer);
+      }
+      window.removeEventListener("mock-workspace-updated", handleWorkspaceUpdate);
+    };
+  }, [getIncomingMessages, isAuthenticated]);
+
   const currentAlertSignature = `${latestPendingRequestId ?? "none"}:${pendingAdminRequestCount}`;
   const isAdminAlertDismissed =
     pendingAdminRequestCount > 0 && dismissedAlertSignature === currentAlertSignature;
+  const currentMessageAlertSignature = `${latestIncomingMessage?.id ?? "none"}:${incomingMessageCount}`;
+  const isMessageAlertDismissed =
+    incomingMessageCount > 0 && dismissedMessageSignature === currentMessageAlertSignature;
 
   const dismissAdminAlert = () => {
     if (typeof window !== "undefined") {
@@ -160,6 +253,14 @@ export function DashboardFrame({ children }: DashboardFrameProps) {
     }
 
     setDismissedAlertSignature(currentAlertSignature);
+  };
+
+  const dismissMessageAlert = () => {
+    if (typeof window !== "undefined") {
+      window.sessionStorage.setItem(messageDismissKey, currentMessageAlertSignature);
+    }
+
+    setDismissedMessageSignature(currentMessageAlertSignature);
   };
 
   const openAdminRequestQueue = () => {
@@ -173,6 +274,30 @@ export function DashboardFrame({ children }: DashboardFrameProps) {
     }
 
     router.push(`/dashboard/messages?${params.toString()}`);
+  };
+
+  const openIncomingMessages = () => {
+    dismissMessageAlert();
+
+    const params = new URLSearchParams();
+
+    if (latestIncomingMessage?.clientId) {
+      params.set("clientId", latestIncomingMessage.clientId);
+    }
+
+    if (latestIncomingMessage?.representativeId) {
+      params.set("representativeId", latestIncomingMessage.representativeId);
+    }
+
+    if (latestIncomingMessage?.id) {
+      params.set("threadId", latestIncomingMessage.id);
+    }
+
+    if (latestIncomingMessage?.source) {
+      params.set("source", latestIncomingMessage.source);
+    }
+
+    router.push(params.toString() ? `/dashboard/messages?${params.toString()}` : "/dashboard/messages");
   };
 
   return (
@@ -296,6 +421,44 @@ export function DashboardFrame({ children }: DashboardFrameProps) {
                 </Button>
               )
             ) : null}
+            {incomingMessageCount > 0 && !isMessageAlertDismissed ? (
+              <div
+                aria-label={`${incomingMessageCount} message notifications`}
+                className="flex max-w-[24rem] items-center gap-2 rounded-full border border-sky-300 bg-sky-50 px-2 py-1 text-sky-950 shadow-sm"
+                role="region"
+              >
+                <Badge count={incomingMessageCount} size="small">
+                  <button
+                    className="flex items-center gap-2 rounded-full bg-transparent px-2 py-1 text-left text-xs font-medium text-sky-950 transition hover:bg-sky-100"
+                    onClick={openIncomingMessages}
+                    type="button"
+                  >
+                    <MailOutlined />
+                    <span className="max-w-[14rem] truncate">
+                      {latestIncomingMessage?.title ??
+                        `${incomingMessageCount} message${incomingMessageCount === 1 ? "" : "s"} waiting`}
+                    </span>
+                  </button>
+                </Badge>
+                <button
+                  aria-label="Dismiss message alert"
+                  className="flex h-6 w-6 items-center justify-center rounded-full text-sky-700 transition hover:bg-sky-100"
+                  onClick={dismissMessageAlert}
+                  type="button"
+                >
+                  <CloseOutlined />
+                </button>
+              </div>
+            ) : (
+              <Button
+                className="dashboard-header-home-button"
+                icon={<MailOutlined />}
+                onClick={openIncomingMessages}
+                type="default"
+              >
+                Messages
+              </Button>
+            )}
             {!isHomeRoute ? (
               <Button
                 className="dashboard-header-home-button"

--- a/components/dashboard/dashboard-frame.tsx
+++ b/components/dashboard/dashboard-frame.tsx
@@ -424,21 +424,21 @@ export function DashboardFrame({ children }: DashboardFrameProps) {
             {incomingMessageCount > 0 && !isMessageAlertDismissed ? (
               <div
                 aria-label={`${incomingMessageCount} message notifications`}
-                className="flex max-w-[24rem] items-center gap-2 rounded-full border border-sky-300 bg-sky-50 px-2 py-1 text-sky-950 shadow-sm"
+                className="flex max-w-[24rem] items-center gap-2"
                 role="region"
               >
                 <Badge count={incomingMessageCount} size="small">
-                  <button
-                    className="flex items-center gap-2 rounded-full bg-transparent px-2 py-1 text-left text-xs font-medium text-sky-950 transition hover:bg-sky-100"
+                  <Button
+                    className="dashboard-header-home-button border-sky-300 !bg-sky-50 !text-sky-950 hover:!border-sky-400 hover:!bg-sky-100 hover:!text-sky-950"
+                    icon={<MailOutlined />}
                     onClick={openIncomingMessages}
-                    type="button"
+                    type="default"
                   >
-                    <MailOutlined />
                     <span className="max-w-[14rem] truncate">
                       {latestIncomingMessage?.title ??
                         `${incomingMessageCount} message${incomingMessageCount === 1 ? "" : "s"} waiting`}
                     </span>
-                  </button>
+                  </Button>
                 </Badge>
                 <button
                   aria-label="Dismiss message alert"

--- a/components/dashboard/documents-panel.tsx
+++ b/components/dashboard/documents-panel.tsx
@@ -5,6 +5,7 @@ import { DeleteOutlined, DownloadOutlined, PlusOutlined } from "@ant-design/icon
 import { useState } from "react";
 
 import { isClientScopedUser } from "@/lib/auth/dashboard-access";
+import { useMounted } from "@/lib/client/use-mounted";
 import { useAuthState } from "@/providers/authProvider";
 import { type IDocumentItem } from "@/providers/domainSeeds";
 import { useDocumentActions, useDocumentState } from "@/providers/documentProvider";
@@ -18,6 +19,7 @@ export function DocumentsPanel() {
   const { user } = useAuthState();
   const { documents } = useDocumentState();
   const { addDocument, deleteDocument } = useDocumentActions();
+  const mounted = useMounted();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [form] = Form.useForm<DocumentFormValues>();
   const isScopedClient = isClientScopedUser(user?.clientIds);
@@ -84,9 +86,8 @@ export function DocumentsPanel() {
           rowKey="id"
         />
       )}
-      {!isScopedClient ? (
+      {!isScopedClient && mounted ? (
         <Modal
-          forceRender
           onCancel={() => setIsModalOpen(false)}
           onOk={() => form.submit()}
           open={isModalOpen}

--- a/components/dashboard/messages-panel.tsx
+++ b/components/dashboard/messages-panel.tsx
@@ -23,6 +23,16 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { AnimatedDashboardTable } from "@/components/dashboard/animated-dashboard-table";
 import { ClientMessageCenter } from "@/components/dashboard/client-message-center";
 import { isClientScopedUser } from "@/lib/auth/dashboard-access";
+import {
+  applyServiceRequestRepresentativeDecision,
+  createServiceRequestAssignments,
+  getServiceRequestDetail,
+  listServiceRequests,
+  type ServiceRequestAssignmentRecord,
+  type ServiceRequestDetail,
+  type ServiceRequestRecord,
+} from "@/lib/client/service-request-api";
+import { useMounted } from "@/lib/client/use-mounted";
 import { getPrimaryUserRole } from "@/lib/auth/roles";
 import {
   CLIENT_MESSAGE_CATEGORY,
@@ -90,6 +100,7 @@ function MessagesPanelContent({
   const { styles } = useStyles();
   const role = getPrimaryUserRole(user?.roles);
   const [messageApi, contextHolder] = message.useMessage();
+  const mounted = useMounted();
   const [selectedClientId, setSelectedClientId] = useState<string>(initialClientId);
   const [selectedRepresentativeId, setSelectedRepresentativeId] = useState<string>(
     initialRepresentativeId,
@@ -98,11 +109,59 @@ function MessagesPanelContent({
   const [isReplyModalOpen, setIsReplyModalOpen] = useState(false);
   const [isAssignModalOpen, setIsAssignModalOpen] = useState(false);
   const [activeThread, setActiveThread] = useState<INoteItem | null>(null);
+  const [activeServiceRequest, setActiveServiceRequest] = useState<ServiceRequestRecord | null>(
+    null,
+  );
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [serviceRequests, setServiceRequests] = useState<ServiceRequestRecord[]>([]);
+  const [serviceRequestDetailsById, setServiceRequestDetailsById] = useState<
+    Record<string, ServiceRequestDetail>
+  >({});
   const [replyForm] = Form.useForm<MessageFormValues>();
   const [assignmentForm] = Form.useForm<AssignmentFormValues>();
 
   const isScopedClientUser = isClientScopedUser(user?.clientIds);
+
+  const loadServiceRequests = useCallback(async () => {
+    try {
+      const requests = await listServiceRequests();
+      setServiceRequests(requests);
+      const details = await Promise.all(
+        requests.map(async (request) => [request.id, await getServiceRequestDetail(request.id)] as const),
+      );
+      setServiceRequestDetailsById(Object.fromEntries(details));
+    } catch (error) {
+      console.error(error);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isScopedClientUser) {
+      return;
+    }
+
+    let isActive = true;
+
+    void listServiceRequests()
+      .then(async (items) => {
+        if (isActive) {
+          setServiceRequests(items);
+          const details = await Promise.all(
+            items.map(async (request) => [request.id, await getServiceRequestDetail(request.id)] as const),
+          );
+          if (isActive) {
+            setServiceRequestDetailsById(Object.fromEntries(details));
+          }
+        }
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [isScopedClientUser]);
 
   const messageThreads = useMemo(
     () =>
@@ -206,19 +265,45 @@ function MessagesPanelContent({
     [representativeOptions, scopedRepresentativeIds],
   );
 
-  const pendingAdminReviewCount = messageThreads.filter(
-    (note) => isClientRequestThread(note) && note.status === "Pending admin review",
-  ).length;
-  const pendingAdminRequests = useMemo(
+  const pendingWorkflowRequests = useMemo(
     () =>
-      messageThreads.filter(
-        (note) => isClientRequestThread(note) && note.status === "Pending admin review",
-      ),
-    [messageThreads],
+      serviceRequests
+        .filter((request) => request.status === "submitted")
+        .sort((left, right) => right.createdAt.localeCompare(left.createdAt)),
+    [serviceRequests],
   );
-  const pendingClientResponseCount = messageThreads.filter(
-    (note) => note.requestType === "team_assignment" && note.status === "Pending client response",
-  ).length;
+  const pendingAdminReviewCount = pendingWorkflowRequests.length;
+  const pendingAdminRequests = useMemo(
+    () => pendingWorkflowRequests,
+    [pendingWorkflowRequests],
+  );
+  const pendingRepresentativeAssignments = useMemo(
+    () =>
+      Object.values(serviceRequestDetailsById).flatMap((detail) =>
+        detail.assignments
+          .filter(
+            (assignment) =>
+              assignment.representativeUserId === user?.userId &&
+              assignment.status === "pending_rep_response",
+          )
+          .map((assignment) => ({
+            assignment,
+            request: detail.request,
+          })),
+      ),
+    [serviceRequestDetailsById, user?.userId],
+  );
+  const pendingClientResponseCount = useMemo(
+    () =>
+      Object.values(serviceRequestDetailsById).reduce(
+        (total, detail) =>
+          total +
+          detail.assignments.filter((assignment) => assignment.status === "pending_client_approval")
+            .length,
+        0,
+      ),
+    [serviceRequestDetailsById],
+  );
   const outboundCount = messageThreads.filter((note) => note.source === "workspace").length;
   const uniqueClientCount = new Set(
     messageThreads.map((note) => note.clientId).filter(Boolean),
@@ -227,6 +312,30 @@ function MessagesPanelContent({
     () => visibleThreads.find((note) => note.id === selectedThreadId) ?? null,
     [selectedThreadId, visibleThreads],
   );
+  const selectedServiceRequest = useMemo(
+    () => serviceRequests.find((request) => request.id === selectedThreadId) ?? null,
+    [selectedThreadId, serviceRequests],
+  );
+  const selectedServiceRequestDetail = useMemo(
+    () =>
+      selectedServiceRequest
+        ? serviceRequestDetailsById[selectedServiceRequest.id] ?? null
+        : null,
+    [selectedServiceRequest, serviceRequestDetailsById],
+  );
+  const selectedRepresentativeAssignment = useMemo(() => {
+    if (!selectedServiceRequestDetail || !user) {
+      return null;
+    }
+
+    return (
+      selectedServiceRequestDetail.assignments.find(
+        (assignment) =>
+          assignment.representativeUserId === user.userId &&
+          assignment.status === "pending_rep_response",
+      ) ?? null
+    );
+  }, [selectedServiceRequestDetail, user]);
   const selectedConversationMessages = useMemo(() => {
     if (!selectedConversationRoot?.clientId) {
       return [];
@@ -260,6 +369,40 @@ function MessagesPanelContent({
     }
 
     router.push(`/dashboard/messages?${params.toString()}`);
+  };
+
+  const openServiceRequestConversation = (request: ServiceRequestRecord) => {
+    const params = new URLSearchParams();
+    params.set("source", request.source);
+    params.set("threadId", request.id);
+    params.set("clientId", request.clientId);
+    router.push(`/dashboard/messages?${params.toString()}`);
+  };
+
+  const applyRepresentativeDecision = async (
+    request: ServiceRequestRecord,
+    assignment: ServiceRequestAssignmentRecord,
+    decision: "accept" | "reject",
+  ) => {
+    setIsSubmitting(true);
+
+    try {
+      await applyServiceRequestRepresentativeDecision(request.id, {
+        assignmentId: assignment.id,
+        decision,
+      });
+      await loadServiceRequests();
+      messageApi.success(
+        decision === "accept"
+          ? "Assignment accepted."
+          : "Assignment rejected and returned for reassignment.",
+      );
+    } catch (error) {
+      console.error(error);
+      messageApi.error("Could not update the representative decision.");
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const openReplyComposer = (note?: INoteItem) => {
@@ -338,12 +481,27 @@ function MessagesPanelContent({
       representativeIds: [],
     });
     setActiveThread(note);
+    setActiveServiceRequest(null);
     setIsAssignModalOpen(true);
   }, [assignmentForm]);
+
+  const openServiceRequestAssignModal = useCallback(
+    async (request: ServiceRequestRecord) => {
+      assignmentForm.setFieldsValue({
+        assignmentMessage: `We are assigning the right sales reps to support "${request.title}".`,
+        representativeIds: [],
+      });
+      setActiveThread(null);
+      setActiveServiceRequest(request);
+      setIsAssignModalOpen(true);
+    },
+    [assignmentForm],
+  );
 
   const closeAssignModal = () => {
     setIsAssignModalOpen(false);
     setActiveThread(null);
+    setActiveServiceRequest(null);
     assignmentForm.resetFields();
     if (selectedThreadId) {
       const params = new URLSearchParams();
@@ -365,6 +523,36 @@ function MessagesPanelContent({
   };
 
   const handleAssignSubmit = async (values: AssignmentFormValues) => {
+    if (activeServiceRequest) {
+      const selectedRepresentatives = teamMembers.filter((member) =>
+        values.representativeIds.includes(member.id),
+      );
+
+      if (selectedRepresentatives.length === 0) {
+        messageApi.error("Select at least one representative.");
+        return;
+      }
+
+      setIsSubmitting(true);
+
+      try {
+        await createServiceRequestAssignments(activeServiceRequest.id, {
+          note: values.assignmentMessage.trim(),
+          representativeUserIds: selectedRepresentatives.map((member) => member.id),
+        });
+        await loadServiceRequests();
+        messageApi.success("Assignment shared with the client for review.");
+        closeAssignModal();
+      } catch (error) {
+        console.error(error);
+        messageApi.error("Could not save the assignment.");
+      } finally {
+        setIsSubmitting(false);
+      }
+
+      return;
+    }
+
     if (!activeThread?.clientId) {
       messageApi.error("Choose a client request before assigning a representative.");
       return;
@@ -512,13 +700,34 @@ function MessagesPanelContent({
     }
   }, [isAssignModalOpen, isScopedClientUser, openAssignModal, selectedThreadId, visibleThreads]);
 
+  useEffect(() => {
+    if (!selectedServiceRequest || isScopedClientUser || isAssignModalOpen) {
+      return;
+    }
+
+    if (selectedServiceRequest.status !== "submitted") {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      void openServiceRequestAssignModal(selectedServiceRequest);
+    }, 0);
+
+    return () => window.clearTimeout(timer);
+  }, [
+    isAssignModalOpen,
+    isScopedClientUser,
+    openServiceRequestAssignModal,
+    selectedServiceRequest,
+  ]);
+
   if (isScopedClientUser) {
     return <ClientMessageCenter />;
   }
 
   return (
     <div className={styles.container}>
-      {contextHolder}
+      {mounted ? contextHolder : null}
 
       {!isScopedClientUser && pendingAdminRequests.length > 0 ? (
         <Alert
@@ -547,7 +756,7 @@ function MessagesPanelContent({
               <div className="space-y-1">
                 {pendingAdminRequests.slice(0, 3).map((request) => (
                   <Typography.Text className="block !text-slate-700" key={request.id}>
-                    {request.createdDate} - {clients.find((client) => client.id === request.clientId)?.name ?? "Unlinked client"} - {request.title}
+                    {request.createdAt.split("T")[0]} - {clients.find((client) => client.id === request.clientId)?.name ?? "Unlinked client"} - {request.title}
                   </Typography.Text>
                 ))}
               </div>
@@ -586,30 +795,39 @@ function MessagesPanelContent({
                         {clients.find((client) => client.id === request.clientId)?.name ??
                           "Unlinked client"}
                       </Tag>
-                      <Tag color="default">{request.createdDate}</Tag>
-                      {request.submittedBy ? (
-                        <Tag color="default">{request.submittedBy}</Tag>
-                      ) : null}
+                      <Tag color="default">{request.createdAt.split("T")[0]}</Tag>
                     </Space>
                   </div>
                   <Space size="small" wrap>
-                    <Button onClick={() => openConversation(request)} type="default">
+                    <Button onClick={() => openServiceRequestConversation(request)} type="default">
                       Open chat
                     </Button>
                     <Button
                       icon={<TeamOutlined />}
-                      onClick={() => openAssignModal(request)}
+                      onClick={() => void openServiceRequestAssignModal(request)}
                       type="primary"
                     >
                       Assign reps
                     </Button>
-                    <Button onClick={() => openReplyComposer(request)}>
+                    <Button
+                      onClick={() =>
+                        openReplyComposer({
+                          category: CLIENT_MESSAGE_CATEGORY,
+                          clientId: request.clientId,
+                          content: request.description,
+                          createdDate: request.createdAt.split("T")[0],
+                          id: request.id,
+                          source: request.source,
+                          title: request.title,
+                        } as INoteItem)
+                      }
+                    >
                       Reply first
                     </Button>
                   </Space>
                 </div>
                 <Typography.Paragraph className={styles.messageText}>
-                  {request.content}
+                  {request.description}
                 </Typography.Paragraph>
                 <Typography.Text className={styles.messageFooter}>
                   Client request from{" "}
@@ -623,7 +841,163 @@ function MessagesPanelContent({
         </Card>
       ) : null}
 
-      {selectedConversationRoot ? (
+      {role === "SalesRep" && pendingRepresentativeAssignments.length > 0 ? (
+        <Card className={styles.card} title="Representative action queue">
+          <div className={styles.requestQueue}>
+            {pendingRepresentativeAssignments.map(({ assignment, request }) => (
+              <div className={styles.messageCard} key={assignment.id}>
+                <div className={styles.messageHeader}>
+                  <div className="space-y-2">
+                    <Typography.Title className="!m-0" level={5}>
+                      {request.title}
+                    </Typography.Title>
+                    <Space size="small" wrap>
+                      <Tag color="purple">Waiting for your acceptance</Tag>
+                      <Tag color="geekblue">
+                        {clients.find((client) => client.id === request.clientId)?.name ??
+                          "Unlinked client"}
+                      </Tag>
+                      <Tag color="default">{assignment.createdAt.split("T")[0]}</Tag>
+                    </Space>
+                  </div>
+                  <Space size="small" wrap>
+                    <Button onClick={() => openServiceRequestConversation(request)} type="default">
+                      Open chat
+                    </Button>
+                    <Button
+                      loading={isSubmitting}
+                      onClick={() => void applyRepresentativeDecision(request, assignment, "accept")}
+                      type="primary"
+                    >
+                      Accept
+                    </Button>
+                    <Button
+                      danger
+                      loading={isSubmitting}
+                      onClick={() => void applyRepresentativeDecision(request, assignment, "reject")}
+                    >
+                      Reject
+                    </Button>
+                  </Space>
+                </div>
+                <Typography.Paragraph className={styles.messageText}>
+                  {request.description}
+                </Typography.Paragraph>
+                <Typography.Text className={styles.messageFooter}>
+                  You were assigned as {assignment.representativeName}. Confirm to activate the
+                  workflow for your side.
+                </Typography.Text>
+              </div>
+            ))}
+          </div>
+        </Card>
+      ) : null}
+
+      {selectedServiceRequest ? (
+        <Card className={styles.card} title="Open conversation">
+          <div className={styles.conversationThread}>
+            <div className={styles.selectedConversationHeader}>
+              <div>
+                <Typography.Title className="!mb-0" level={4}>
+                  {selectedServiceRequest.title}
+                </Typography.Title>
+                <Typography.Text className={styles.metricText}>
+                  {clients.find((client) => client.id === selectedServiceRequest.clientId)?.name ??
+                    "Unlinked client"}
+                </Typography.Text>
+              </div>
+              <Space size="small" wrap>
+                {selectedServiceRequest.status === "submitted" ? (
+                  <Button
+                    icon={<TeamOutlined />}
+                    onClick={() => void openServiceRequestAssignModal(selectedServiceRequest)}
+                    type="primary"
+                  >
+                    Assign reps
+                  </Button>
+                ) : null}
+                {selectedRepresentativeAssignment ? (
+                  <>
+                    <Button
+                      loading={isSubmitting}
+                      onClick={() =>
+                        void applyRepresentativeDecision(
+                          selectedServiceRequest,
+                          selectedRepresentativeAssignment,
+                          "accept",
+                        )
+                      }
+                      type="primary"
+                    >
+                      Accept assignment
+                    </Button>
+                    <Button
+                      danger
+                      loading={isSubmitting}
+                      onClick={() =>
+                        void applyRepresentativeDecision(
+                          selectedServiceRequest,
+                          selectedRepresentativeAssignment,
+                          "reject",
+                        )
+                      }
+                    >
+                      Reject assignment
+                    </Button>
+                  </>
+                ) : null}
+                <Button
+                  icon={<SendOutlined />}
+                  onClick={() =>
+                    openReplyComposer({
+                      category: CLIENT_MESSAGE_CATEGORY,
+                      clientId: selectedServiceRequest.clientId,
+                      content: selectedServiceRequest.description,
+                      createdDate: selectedServiceRequest.createdAt.split("T")[0],
+                      id: selectedServiceRequest.id,
+                      source: selectedServiceRequest.source,
+                      title: selectedServiceRequest.title,
+                    } as INoteItem)
+                  }
+                >
+                  Reply
+                </Button>
+              </Space>
+            </div>
+
+            <div className={`${styles.conversationBubble} ${styles.conversationBubbleClient}`}>
+              <Typography.Text className={styles.conversationMeta}>
+                Client · {selectedServiceRequest.createdAt.split("T")[0]} · {selectedServiceRequest.status}
+              </Typography.Text>
+              <Typography.Paragraph className={styles.messageText}>
+                {selectedServiceRequest.description}
+              </Typography.Paragraph>
+            </div>
+
+            {selectedServiceRequestDetail?.events.map((event) => (
+              <div
+                className={`${styles.conversationBubble} ${styles.conversationBubbleWorkspace}`}
+                key={event.id}
+              >
+                <Typography.Text className={styles.conversationMeta}>
+                  {event.actorType} · {event.createdAt.split("T")[0]} · {event.eventType}
+                </Typography.Text>
+                <Typography.Paragraph className={styles.messageText}>
+                  {event.eventType === "service_request_assignments_created"
+                    ? "Assignments were prepared and sent for client review."
+                    : event.eventType === "service_request_review_started"
+                      ? "Admin review started."
+                      : event.eventType === "service_request_client_decision"
+                        ? "The client responded to the proposed assignment."
+                        : event.eventType === "service_request_representative_decision"
+                          ? "A representative responded to the assignment."
+                          : "Workflow event recorded."}
+                </Typography.Paragraph>
+              </div>
+            ))}
+          </div>
+        </Card>
+      ) : selectedConversationRoot ? (
         <Card className={styles.card} title="Open conversation">
           <div className={styles.conversationThread}>
             <div className={styles.selectedConversationHeader}>
@@ -853,80 +1227,82 @@ function MessagesPanelContent({
         )}
       </Card>
 
-      <Modal
-        forceRender
-        onCancel={closeReplyComposer}
-        onOk={() => replyForm.submit()}
-        okButtonProps={{ loading: isSubmitting }}
-        okText="Send reply"
-        open={isReplyModalOpen}
-        title="Reply from workspace"
-      >
-        <Form className={styles.modalForm} form={replyForm} layout="vertical" onFinish={handleReplySubmit}>
-          <Form.Item
-            label="Client"
-            name="clientId"
-            rules={[{ message: "Choose a client", required: true }]}
+      {mounted ? (
+        <>
+          <Modal
+            onCancel={closeReplyComposer}
+            onOk={() => replyForm.submit()}
+            okButtonProps={{ loading: isSubmitting }}
+            okText="Send reply"
+            open={isReplyModalOpen}
+            title="Reply from workspace"
           >
-            <Select options={clientOptions} placeholder="Select client" />
-          </Form.Item>
-          <Form.Item
-            label="Representative"
-            name="representativeId"
-            rules={[{ message: "Choose a representative", required: true }]}
-          >
-            <Select options={representativeOptions} placeholder="Select representative" />
-          </Form.Item>
-          <Form.Item
-            label="Subject"
-            name="subject"
-            rules={[{ message: "Add a subject", required: true }]}
-          >
-            <Input placeholder="Message subject" />
-          </Form.Item>
-          <Form.Item
-            label="Message"
-            name="content"
-            rules={[{ message: "Enter the message", required: true }]}
-          >
-            <Input.TextArea placeholder="Write the reply" rows={5} />
-          </Form.Item>
-        </Form>
-      </Modal>
+            <Form className={styles.modalForm} form={replyForm} layout="vertical" onFinish={handleReplySubmit}>
+              <Form.Item
+                label="Client"
+                name="clientId"
+                rules={[{ message: "Choose a client", required: true }]}
+              >
+                <Select options={clientOptions} placeholder="Select client" />
+              </Form.Item>
+              <Form.Item
+                label="Representative"
+                name="representativeId"
+                rules={[{ message: "Choose a representative", required: true }]}
+              >
+                <Select options={representativeOptions} placeholder="Select representative" />
+              </Form.Item>
+              <Form.Item
+                label="Subject"
+                name="subject"
+                rules={[{ message: "Add a subject", required: true }]}
+              >
+                <Input placeholder="Message subject" />
+              </Form.Item>
+              <Form.Item
+                label="Message"
+                name="content"
+                rules={[{ message: "Enter the message", required: true }]}
+              >
+                <Input.TextArea placeholder="Write the reply" rows={5} />
+              </Form.Item>
+            </Form>
+          </Modal>
 
-      <Modal
-        forceRender
-        onCancel={closeAssignModal}
-        onOk={() => assignmentForm.submit()}
-        okButtonProps={{ loading: isSubmitting }}
-        okText="Assign reps"
-        open={isAssignModalOpen}
-        title="Assign the right sales reps"
-      >
-        <Form className={styles.modalForm} form={assignmentForm} layout="vertical" onFinish={handleAssignSubmit}>
-          <Form.Item
-            label="Representatives"
-            name="representativeIds"
-            rules={[{ message: "Choose at least one representative", required: true }]}
+          <Modal
+            onCancel={closeAssignModal}
+            onOk={() => assignmentForm.submit()}
+            okButtonProps={{ loading: isSubmitting }}
+            okText="Assign reps"
+            open={isAssignModalOpen}
+            title="Assign the right sales reps"
           >
-            <Select
-              mode="multiple"
-              options={representativeOptions}
-              placeholder="Select one or more representatives"
-            />
-          </Form.Item>
-          <Form.Item
-            label="Client-facing assignment message"
-            name="assignmentMessage"
-            rules={[{ message: "Add the assignment message", required: true }]}
-          >
-            <Input.TextArea
-              placeholder="Explain who is being assigned and why"
-              rows={5}
-            />
-          </Form.Item>
-        </Form>
-      </Modal>
+            <Form className={styles.modalForm} form={assignmentForm} layout="vertical" onFinish={handleAssignSubmit}>
+              <Form.Item
+                label="Representatives"
+                name="representativeIds"
+                rules={[{ message: "Choose at least one representative", required: true }]}
+              >
+                <Select
+                  mode="multiple"
+                  options={representativeOptions}
+                  placeholder="Select one or more representatives"
+                />
+              </Form.Item>
+              <Form.Item
+                label="Client-facing assignment message"
+                name="assignmentMessage"
+                rules={[{ message: "Add the assignment message", required: true }]}
+              >
+                <Input.TextArea
+                  placeholder="Explain who is being assigned and why"
+                  rows={5}
+                />
+              </Form.Item>
+            </Form>
+          </Modal>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/components/dashboard/messages-panel.tsx
+++ b/components/dashboard/messages-panel.tsx
@@ -740,7 +740,11 @@ function MessagesPanelContent({
                   Open request
                 </Button>
               </Link>
-              <Link href="/dashboard/assistant">
+              <Link
+                href={`/dashboard/assistant?prompt=${encodeURIComponent(
+                  "Review the latest client request, create the right opportunity and proposal if needed, and assign the best reps.",
+                )}&autorun=1&fresh=1`}
+              >
                 <Button icon={<MailOutlined />}>Handle with AI</Button>
               </Link>
             </Space>
@@ -775,7 +779,11 @@ function MessagesPanelContent({
               <Typography.Text className={styles.metricText}>
                 These are the actual client requests waiting for admin action.
               </Typography.Text>
-              <Link href="/dashboard/assistant">
+              <Link
+                href={`/dashboard/assistant?prompt=${encodeURIComponent(
+                  "What client requests are waiting for admin review?",
+                )}&autorun=1&fresh=1`}
+              >
                 <Button icon={<MailOutlined />} type="default">
                   Summarize with AI
                 </Button>

--- a/components/dashboard/messages-panel.tsx
+++ b/components/dashboard/messages-panel.tsx
@@ -29,6 +29,7 @@ import {
   createServiceRequestAssignments,
   getServiceRequestDetail,
   listServiceRequests,
+  type ServiceRequestMessageRecipientType,
   type ServiceRequestAssignmentRecord,
   type ServiceRequestDetail,
   type ServiceRequestRecord,
@@ -59,6 +60,8 @@ type MessageFormValues = {
   clientId: string;
   content: string;
   representativeId: string;
+  representativeIds?: string[];
+  recipientType?: ServiceRequestMessageRecipientType;
   subject: string;
 };
 
@@ -132,6 +135,34 @@ const clientFacingRole = (role: string) =>
     "Proposal Manager",
     "Deal Desk Specialist",
   ].some((token) => role.includes(token));
+
+const getServiceRequestMessageRecipientSummary = (payload: Record<string, unknown>) => {
+  const recipientType =
+    payload.recipientType === "client" ||
+    payload.recipientType === "representative" ||
+    payload.recipientType === "both"
+      ? payload.recipientType
+      : "client";
+  const representativeNames = Array.isArray(payload.representativeNames)
+    ? payload.representativeNames.filter(
+        (value): value is string => typeof value === "string" && value.trim().length > 0,
+      )
+    : [];
+
+  if (recipientType === "both") {
+    return representativeNames.length > 0
+      ? `To client and reps: ${representativeNames.join(", ")}`
+      : "To client and reps";
+  }
+
+  if (recipientType === "representative") {
+    return representativeNames.length > 0
+      ? `To reps: ${representativeNames.join(", ")}`
+      : "To reps";
+  }
+
+  return "To client";
+};
 
 type MessagePanelContentProps = Readonly<{
   initialClientId: string;
@@ -512,14 +543,13 @@ function MessagesPanelContent({
       )?.ownerId;
 
     replyForm.setFieldsValue({
-      clientId: note?.clientId ?? clients[0]?.id ?? "",
+      clientId: note?.clientId ?? undefined,
       content: note ? `Hi, regarding "${note.title}"...` : "",
       representativeId:
         note?.representativeId ??
         accountLeadId ??
         representativeOptions.find((option) => option.value === user?.userId)?.value ??
-        representativeOptions[0]?.value ??
-        "",
+        undefined,
       subject: note ? `Re: ${note.title}` : "Client follow-up",
     });
     setActiveThread(note ?? null);
@@ -527,10 +557,16 @@ function MessagesPanelContent({
   };
 
   const openServiceRequestReplyComposer = (request: ServiceRequestRecord) => {
+    const requestDetail = serviceRequestDetailsById[request.id];
+    const assignedRepresentativeIds =
+      requestDetail?.assignments.map((assignment) => assignment.representativeUserId) ?? [];
+
     replyForm.setFieldsValue({
       clientId: request.clientId,
       content: "",
+      recipientType: "client",
       representativeId: "",
+      representativeIds: assignedRepresentativeIds,
       subject: `Re: ${request.title}`,
     });
     setActiveThread(null);
@@ -552,6 +588,11 @@ function MessagesPanelContent({
       try {
         const detail = await addServiceRequestMessage(activeServiceRequest.id, {
           content: values.content.trim(),
+          recipientType: values.recipientType ?? "client",
+          representativeUserIds:
+            values.recipientType === "representative" || values.recipientType === "both"
+              ? values.representativeIds ?? []
+              : [],
         });
         setServiceRequestDetailsById((current) => ({
           ...current,
@@ -570,25 +611,22 @@ function MessagesPanelContent({
       return;
     }
 
-    const representative = teamMembers.find((member) => member.id === values.representativeId);
-
-    if (!representative) {
-      messageApi.error("Choose a representative before sending the reply.");
-      return;
-    }
+    const representative = values.representativeId
+      ? teamMembers.find((member) => member.id === values.representativeId)
+      : null;
 
     setIsSubmitting(true);
 
     try {
       await addNote({
         category: CLIENT_MESSAGE_CATEGORY,
-        clientId: values.clientId,
+        clientId: values.clientId || undefined,
         content: values.content.trim(),
         createdDate: new Date().toISOString().split("T")[0],
         id: createMessageId(),
         kind: "client_message",
-        representativeId: representative.id,
-        representativeName: representative.name,
+        representativeId: representative?.id,
+        representativeName: representative?.name,
         source: "workspace",
         status: "Acknowledged",
         submittedBy: user?.email ?? undefined,
@@ -1131,7 +1169,10 @@ function MessagesPanelContent({
                 key={event.id}
               >
                 <Typography.Text className={styles.conversationMeta}>
-                  {event.actorType} · {event.createdAt.split("T")[0]} · {event.eventType}
+                  {event.actorType} · {event.createdAt.split("T")[0]} ·{" "}
+                  {event.eventType === "service_request_message_added"
+                    ? getServiceRequestMessageRecipientSummary(event.payloadJson)
+                    : event.eventType}
                 </Typography.Text>
                 <Typography.Paragraph className={styles.messageText}>
                   {event.eventType === "service_request_message_added"
@@ -1396,16 +1437,18 @@ function MessagesPanelContent({
                   <Form.Item
                     label="Client"
                     name="clientId"
-                    rules={[{ message: "Choose a client", required: true }]}
                   >
-                    <Select options={clientOptions} placeholder="Select client" />
+                    <Select allowClear options={clientOptions} placeholder="No client selected" />
                   </Form.Item>
                   <Form.Item
                     label="Representative"
                     name="representativeId"
-                    rules={[{ message: "Choose a representative", required: true }]}
                   >
-                    <Select options={representativeOptions} placeholder="Select representative" />
+                    <Select
+                      allowClear
+                      options={representativeOptions}
+                      placeholder="No representative selected"
+                    />
                   </Form.Item>
                   <Form.Item
                     label="Subject"
@@ -1416,6 +1459,66 @@ function MessagesPanelContent({
                   </Form.Item>
                 </>
               )}
+              {activeServiceRequest ? (
+                <>
+                  <Form.Item
+                    label="Send to"
+                    name="recipientType"
+                    rules={[{ message: "Choose who should receive the reply", required: true }]}
+                  >
+                    <Select
+                      options={[
+                        { label: "Client", value: "client" },
+                        { label: "Representative", value: "representative" },
+                        { label: "Client and representative", value: "both" },
+                      ]}
+                      placeholder="Choose the message audience"
+                    />
+                  </Form.Item>
+                  <Form.Item
+                    dependencies={["recipientType"]}
+                    label="Representatives"
+                    name="representativeIds"
+                    rules={[
+                      ({ getFieldValue }) => ({
+                        validator(_, value: string[] | undefined) {
+                          const recipientType = getFieldValue("recipientType");
+
+                          if (
+                            recipientType !== "representative" &&
+                            recipientType !== "both"
+                          ) {
+                            return Promise.resolve();
+                          }
+
+                          if (Array.isArray(value) && value.length > 0) {
+                            return Promise.resolve();
+                          }
+
+                          return Promise.reject(
+                            new Error("Choose at least one representative recipient."),
+                          );
+                        },
+                      }),
+                    ]}
+                  >
+                    <Select
+                      mode="multiple"
+                      options={
+                        (
+                          activeServiceRequest
+                            ? serviceRequestDetailsById[activeServiceRequest.id]?.assignments ?? []
+                            : []
+                        ).map((assignment) => ({
+                          label: assignment.representativeName,
+                          value: assignment.representativeUserId,
+                        }))
+                      }
+                      placeholder="Choose one or more assigned representatives"
+                    />
+                  </Form.Item>
+                </>
+              ) : null}
               <Form.Item
                 label={activeServiceRequest ? "Reply" : "Message"}
                 name="content"

--- a/components/dashboard/messages-panel.tsx
+++ b/components/dashboard/messages-panel.tsx
@@ -24,6 +24,7 @@ import { AnimatedDashboardTable } from "@/components/dashboard/animated-dashboar
 import { ClientMessageCenter } from "@/components/dashboard/client-message-center";
 import { isClientScopedUser } from "@/lib/auth/dashboard-access";
 import {
+  addServiceRequestMessage,
   applyServiceRequestRepresentativeDecision,
   createServiceRequestAssignments,
   getServiceRequestDetail,
@@ -32,6 +33,7 @@ import {
   type ServiceRequestDetail,
   type ServiceRequestRecord,
 } from "@/lib/client/service-request-api";
+import { clearSessionDraft } from "@/lib/client/session-drafts";
 import { useMounted } from "@/lib/client/use-mounted";
 import { getPrimaryUserRole } from "@/lib/auth/roles";
 import {
@@ -46,6 +48,11 @@ import type { INoteItem } from "@/providers/domainSeeds";
 import { useNoteActions, useNoteState } from "@/providers/noteProvider";
 import { useOpportunityState } from "@/providers/opportunityProvider";
 import { useTeamMembersState } from "@/providers/teamMembersProvider";
+import {
+  ASSISTANT_PANEL_DRAFT_KEY,
+  ASSISTANT_PANEL_MESSAGES_KEY,
+  getScopedDraftKey,
+} from "./draft-storage";
 import { useStyles } from "./messages-panel.styles";
 
 type MessageFormValues = {
@@ -56,7 +63,6 @@ type MessageFormValues = {
 };
 
 type AssignmentFormValues = {
-  assignmentMessage: string;
   representativeIds: string[];
 };
 
@@ -65,6 +71,56 @@ const createMessageId = () =>
 
 const createAssignmentId = () =>
   `team-assignment-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+const summarizeRequestText = (value: string, maxLength = 220) => {
+  const normalized = value.replace(/\s+/g, " ").trim();
+
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  const truncated = normalized.slice(0, maxLength);
+  const lastBoundary = Math.max(
+    truncated.lastIndexOf(". "),
+    truncated.lastIndexOf("! "),
+    truncated.lastIndexOf("? "),
+    truncated.lastIndexOf(", "),
+    truncated.lastIndexOf(" "),
+  );
+
+  return `${truncated.slice(0, lastBoundary > 80 ? lastBoundary : maxLength).trim()}...`;
+};
+
+const isWorkflowInstructionText = (value: string) =>
+  /\breview the (?:latest|client) request\b/i.test(value) &&
+  /\bassign the best reps\b/i.test(value);
+
+const summarizeServiceRequest = (
+  request: ServiceRequestRecord,
+  clientName: string,
+) => {
+  const description = request.description.trim();
+
+  if (description && !isWorkflowInstructionText(description)) {
+    return summarizeRequestText(description);
+  }
+
+  if (request.requestType === "proposal_support") {
+    return `${clientName} needs proposal support.`;
+  }
+
+  if (request.requestType === "pricing_support") {
+    return `${clientName} needs pricing and commercial support.`;
+  }
+
+  const normalizedTitle = request.title.trim().replace(/[.\s]+$/, "");
+
+  if (/support|help|request/i.test(normalizedTitle)) {
+    return `${clientName} needs ${normalizedTitle.toLowerCase()}.`;
+  }
+
+  return `${clientName} needs support with ${normalizedTitle}.`;
+};
 
 const clientFacingRole = (role: string) =>
   [
@@ -119,6 +175,34 @@ function MessagesPanelContent({
   >({});
   const [replyForm] = Form.useForm<MessageFormValues>();
   const [assignmentForm] = Form.useForm<AssignmentFormValues>();
+  const assistantDraftStorageKey = getScopedDraftKey(ASSISTANT_PANEL_DRAFT_KEY, {
+    tenantId: user?.tenantId,
+    userId: user?.userId,
+  });
+  const assistantMessageStorageKey = getScopedDraftKey(ASSISTANT_PANEL_MESSAGES_KEY, {
+    tenantId: user?.tenantId,
+    userId: user?.userId,
+  });
+  const buildRequestHandlingPrompt = useCallback(
+    (request: ServiceRequestRecord) => {
+      const clientName =
+        clients.find((client) => client.id === request.clientId)?.name ?? "the client";
+
+      return `Review the client request "${request.title}" for ${clientName} (request id ${request.id}), create the right opportunity and proposal if needed, and assign the best reps for this request only.`;
+    },
+    [clients],
+  );
+
+  const openAssistantWithFreshContext = useCallback(
+    (prompt: string) => {
+      clearSessionDraft(assistantDraftStorageKey);
+      clearSessionDraft(assistantMessageStorageKey);
+      router.push(
+        `/dashboard/assistant?prompt=${encodeURIComponent(prompt)}&autorun=1&fresh=1`,
+      );
+    },
+    [assistantDraftStorageKey, assistantMessageStorageKey, router],
+  );
 
   const isScopedClientUser = isClientScopedUser(user?.clientIds);
 
@@ -336,6 +420,21 @@ function MessagesPanelContent({
       ) ?? null
     );
   }, [selectedServiceRequestDetail, user]);
+  const activeServiceRequestSummary = useMemo(() => {
+    if (!activeServiceRequest) {
+      return null;
+    }
+
+    const clientName =
+      clients.find((client) => client.id === activeServiceRequest.clientId)?.name ??
+      "Unlinked client";
+
+    return {
+      clientName,
+      description: summarizeServiceRequest(activeServiceRequest, clientName),
+      title: activeServiceRequest.title,
+    };
+  }, [activeServiceRequest, clients]);
   const selectedConversationMessages = useMemo(() => {
     if (!selectedConversationRoot?.clientId) {
       return [];
@@ -427,13 +526,50 @@ function MessagesPanelContent({
     setIsReplyModalOpen(true);
   };
 
+  const openServiceRequestReplyComposer = (request: ServiceRequestRecord) => {
+    replyForm.setFieldsValue({
+      clientId: request.clientId,
+      content: "",
+      representativeId: "",
+      subject: `Re: ${request.title}`,
+    });
+    setActiveThread(null);
+    setActiveServiceRequest(request);
+    setIsReplyModalOpen(true);
+  };
+
   const closeReplyComposer = () => {
     setIsReplyModalOpen(false);
     setActiveThread(null);
+    setActiveServiceRequest(null);
     replyForm.resetFields();
   };
 
   const handleReplySubmit = async (values: MessageFormValues) => {
+    if (activeServiceRequest) {
+      setIsSubmitting(true);
+
+      try {
+        const detail = await addServiceRequestMessage(activeServiceRequest.id, {
+          content: values.content.trim(),
+        });
+        setServiceRequestDetailsById((current) => ({
+          ...current,
+          [activeServiceRequest.id]: detail,
+        }));
+        await loadServiceRequests();
+        messageApi.success("Reply added to the request conversation.");
+        closeReplyComposer();
+      } catch (error) {
+        console.error(error);
+        messageApi.error("Could not save the request reply.");
+      } finally {
+        setIsSubmitting(false);
+      }
+
+      return;
+    }
+
     const representative = teamMembers.find((member) => member.id === values.representativeId);
 
     if (!representative) {
@@ -477,7 +613,6 @@ function MessagesPanelContent({
 
   const openAssignModal = useCallback((note: INoteItem) => {
     assignmentForm.setFieldsValue({
-      assignmentMessage: `We are assigning the right sales reps to support "${note.title}".`,
       representativeIds: [],
     });
     setActiveThread(note);
@@ -488,7 +623,6 @@ function MessagesPanelContent({
   const openServiceRequestAssignModal = useCallback(
     async (request: ServiceRequestRecord) => {
       assignmentForm.setFieldsValue({
-        assignmentMessage: `We are assigning the right sales reps to support "${request.title}".`,
         representativeIds: [],
       });
       setActiveThread(null);
@@ -537,7 +671,6 @@ function MessagesPanelContent({
 
       try {
         await createServiceRequestAssignments(activeServiceRequest.id, {
-          note: values.assignmentMessage.trim(),
           representativeUserIds: selectedRepresentatives.map((member) => member.id),
         });
         await loadServiceRequests();
@@ -577,7 +710,7 @@ function MessagesPanelContent({
             `${user?.firstName ?? ""} ${user?.lastName ?? ""}`.trim() || user?.email || undefined,
           category: CLIENT_MESSAGE_CATEGORY,
           clientId: activeThread.clientId,
-          content: values.assignmentMessage.trim(),
+          content: `Assigned ${representative.name} to support "${activeThread.title}".`,
           createdDate: new Date().toISOString().split("T")[0],
           id: createAssignmentId(),
           kind: "team_assignment",
@@ -740,13 +873,19 @@ function MessagesPanelContent({
                   Open request
                 </Button>
               </Link>
-              <Link
-                href={`/dashboard/assistant?prompt=${encodeURIComponent(
-                  "Review the latest client request, create the right opportunity and proposal if needed, and assign the best reps.",
-                )}&autorun=1&fresh=1`}
-              >
-                <Button icon={<MailOutlined />}>Handle with AI</Button>
-              </Link>
+                <Button
+                  icon={<MailOutlined />}
+                  onClick={() =>
+                    pendingAdminRequests[0]
+                      ? openAssistantWithFreshContext(
+                          buildRequestHandlingPrompt(pendingAdminRequests[0]),
+                        )
+                      : undefined
+                  }
+                  disabled={!pendingAdminRequests[0]}
+                >
+                Handle with AI
+              </Button>
             </Space>
           }
           banner
@@ -779,15 +918,17 @@ function MessagesPanelContent({
               <Typography.Text className={styles.metricText}>
                 These are the actual client requests waiting for admin action.
               </Typography.Text>
-              <Link
-                href={`/dashboard/assistant?prompt=${encodeURIComponent(
-                  "What client requests are waiting for admin review?",
-                )}&autorun=1&fresh=1`}
+              <Button
+                icon={<MailOutlined />}
+                onClick={() =>
+                  openAssistantWithFreshContext(
+                    "What client requests are waiting for admin review?",
+                  )
+                }
+                type="default"
               >
-                <Button icon={<MailOutlined />} type="default">
-                  Summarize with AI
-                </Button>
-              </Link>
+                Summarize with AI
+              </Button>
             </div>
 
             {pendingAdminRequests.map((request) => (
@@ -816,6 +957,14 @@ function MessagesPanelContent({
                       type="primary"
                     >
                       Assign reps
+                    </Button>
+                    <Button
+                      icon={<MailOutlined />}
+                      onClick={() =>
+                        openAssistantWithFreshContext(buildRequestHandlingPrompt(request))
+                      }
+                    >
+                      Handle with AI
                     </Button>
                     <Button
                       onClick={() =>
@@ -956,17 +1105,7 @@ function MessagesPanelContent({
                 ) : null}
                 <Button
                   icon={<SendOutlined />}
-                  onClick={() =>
-                    openReplyComposer({
-                      category: CLIENT_MESSAGE_CATEGORY,
-                      clientId: selectedServiceRequest.clientId,
-                      content: selectedServiceRequest.description,
-                      createdDate: selectedServiceRequest.createdAt.split("T")[0],
-                      id: selectedServiceRequest.id,
-                      source: selectedServiceRequest.source,
-                      title: selectedServiceRequest.title,
-                    } as INoteItem)
-                  }
+                  onClick={() => openServiceRequestReplyComposer(selectedServiceRequest)}
                 >
                   Reply
                 </Button>
@@ -984,14 +1123,20 @@ function MessagesPanelContent({
 
             {selectedServiceRequestDetail?.events.map((event) => (
               <div
-                className={`${styles.conversationBubble} ${styles.conversationBubbleWorkspace}`}
+                className={`${styles.conversationBubble} ${
+                  event.actorType === "client"
+                    ? styles.conversationBubbleClient
+                    : styles.conversationBubbleWorkspace
+                }`}
                 key={event.id}
               >
                 <Typography.Text className={styles.conversationMeta}>
                   {event.actorType} · {event.createdAt.split("T")[0]} · {event.eventType}
                 </Typography.Text>
                 <Typography.Paragraph className={styles.messageText}>
-                  {event.eventType === "service_request_assignments_created"
+                  {event.eventType === "service_request_message_added"
+                    ? String(event.payloadJson.content ?? "")
+                    : event.eventType === "service_request_assignments_created"
                     ? "Assignments were prepared and sent for client review."
                     : event.eventType === "service_request_review_started"
                       ? "Admin review started."
@@ -1246,33 +1391,44 @@ function MessagesPanelContent({
             title="Reply from workspace"
           >
             <Form className={styles.modalForm} form={replyForm} layout="vertical" onFinish={handleReplySubmit}>
+              {activeServiceRequest ? null : (
+                <>
+                  <Form.Item
+                    label="Client"
+                    name="clientId"
+                    rules={[{ message: "Choose a client", required: true }]}
+                  >
+                    <Select options={clientOptions} placeholder="Select client" />
+                  </Form.Item>
+                  <Form.Item
+                    label="Representative"
+                    name="representativeId"
+                    rules={[{ message: "Choose a representative", required: true }]}
+                  >
+                    <Select options={representativeOptions} placeholder="Select representative" />
+                  </Form.Item>
+                  <Form.Item
+                    label="Subject"
+                    name="subject"
+                    rules={[{ message: "Add a subject", required: true }]}
+                  >
+                    <Input placeholder="Message subject" />
+                  </Form.Item>
+                </>
+              )}
               <Form.Item
-                label="Client"
-                name="clientId"
-                rules={[{ message: "Choose a client", required: true }]}
-              >
-                <Select options={clientOptions} placeholder="Select client" />
-              </Form.Item>
-              <Form.Item
-                label="Representative"
-                name="representativeId"
-                rules={[{ message: "Choose a representative", required: true }]}
-              >
-                <Select options={representativeOptions} placeholder="Select representative" />
-              </Form.Item>
-              <Form.Item
-                label="Subject"
-                name="subject"
-                rules={[{ message: "Add a subject", required: true }]}
-              >
-                <Input placeholder="Message subject" />
-              </Form.Item>
-              <Form.Item
-                label="Message"
+                label={activeServiceRequest ? "Reply" : "Message"}
                 name="content"
                 rules={[{ message: "Enter the message", required: true }]}
               >
-                <Input.TextArea placeholder="Write the reply" rows={5} />
+                <Input.TextArea
+                  placeholder={
+                    activeServiceRequest
+                      ? "Write your response to this request"
+                      : "Write the reply"
+                  }
+                  rows={5}
+                />
               </Form.Item>
             </Form>
           </Modal>
@@ -1286,6 +1442,25 @@ function MessagesPanelContent({
             title="Assign the right sales reps"
           >
             <Form className={styles.modalForm} form={assignmentForm} layout="vertical" onFinish={handleAssignSubmit}>
+              {activeServiceRequestSummary ? (
+                <Alert
+                  className="mb-4"
+                  description={
+                    <Space direction="vertical" size={4}>
+                      <Typography.Text strong>{activeServiceRequestSummary.title}</Typography.Text>
+                      <Typography.Text type="secondary">
+                        {activeServiceRequestSummary.clientName}
+                      </Typography.Text>
+                      <Typography.Paragraph className="!mb-0">
+                        {activeServiceRequestSummary.description}
+                      </Typography.Paragraph>
+                    </Space>
+                  }
+                  message="Request summary"
+                  showIcon
+                  type="info"
+                />
+              ) : null}
               <Form.Item
                 label="Representatives"
                 name="representativeIds"
@@ -1295,16 +1470,6 @@ function MessagesPanelContent({
                   mode="multiple"
                   options={representativeOptions}
                   placeholder="Select one or more representatives"
-                />
-              </Form.Item>
-              <Form.Item
-                label="Client-facing assignment message"
-                name="assignmentMessage"
-                rules={[{ message: "Add the assignment message", required: true }]}
-              >
-                <Input.TextArea
-                  placeholder="Explain who is being assigned and why"
-                  rows={5}
                 />
               </Form.Item>
             </Form>

--- a/components/dashboard/notes-panel.tsx
+++ b/components/dashboard/notes-panel.tsx
@@ -4,6 +4,7 @@ import { Button, Empty, Form, Input, Modal, Space, Table, Tag, Typography } from
 import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
 import { useEffect, useState } from "react";
 
+import { useMounted } from "@/lib/client/use-mounted";
 import { type INoteItem } from "@/providers/domainSeeds";
 import { useNoteActions, useNoteState } from "@/providers/noteProvider";
 
@@ -14,6 +15,7 @@ type NoteFormValues = {
 };
 
 export function NotesPanel() {
+  const mounted = useMounted();
   const { notes } = useNoteState();
   const { addNote, deleteNote, updateNote } = useNoteActions();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -21,6 +23,10 @@ export function NotesPanel() {
   const [form] = Form.useForm<NoteFormValues>();
 
   useEffect(() => {
+    if (!mounted) {
+      return;
+    }
+
     if (!editingId) {
       form.resetFields();
       return;
@@ -34,7 +40,7 @@ export function NotesPanel() {
         title: note.title,
       });
     }
-  }, [editingId, form, notes]);
+  }, [editingId, form, mounted, notes]);
 
   const handleSave = (values: NoteFormValues) => {
     if (editingId) {
@@ -106,28 +112,29 @@ export function NotesPanel() {
           rowKey="id"
         />
       )}
-      <Modal
-        forceRender
-        onCancel={() => {
-          setIsModalOpen(false);
-          setEditingId(null);
-        }}
-        onOk={() => form.submit()}
-        open={isModalOpen}
-        title={editingId ? "Edit note" : "Add note"}
-      >
-        <Form className="pt-4" form={form} layout="vertical" onFinish={handleSave}>
-          <Form.Item label="Title" name="title" rules={[{ required: true }]}>
-            <Input />
-          </Form.Item>
-          <Form.Item label="Content" name="content" rules={[{ required: true }]}>
-            <Input.TextArea rows={4} />
-          </Form.Item>
-          <Form.Item label="Category" name="category" rules={[{ required: true }]}>
-            <Input />
-          </Form.Item>
-        </Form>
-      </Modal>
+      {mounted ? (
+        <Modal
+          onCancel={() => {
+            setIsModalOpen(false);
+            setEditingId(null);
+          }}
+          onOk={() => form.submit()}
+          open={isModalOpen}
+          title={editingId ? "Edit note" : "Add note"}
+        >
+          <Form className="pt-4" form={form} layout="vertical" onFinish={handleSave}>
+            <Form.Item label="Title" name="title" rules={[{ required: true }]}>
+              <Input />
+            </Form.Item>
+            <Form.Item label="Content" name="content" rules={[{ required: true }]}>
+              <Input.TextArea rows={4} />
+            </Form.Item>
+            <Form.Item label="Category" name="category" rules={[{ required: true }]}>
+              <Input />
+            </Form.Item>
+          </Form>
+        </Modal>
+      ) : null}
     </div>
   );
 }

--- a/components/dashboard/opportunity-form.tsx
+++ b/components/dashboard/opportunity-form.tsx
@@ -4,6 +4,7 @@ import { DatePicker, Form, Input, InputNumber, Modal, Select } from "antd";
 import dayjs from "dayjs";
 import { useEffect } from "react";
 
+import { useMounted } from "@/lib/client/use-mounted";
 import { clearSessionDraft, readSessionDraft, writeSessionDraft } from "@/lib/client/session-drafts";
 import { OPPORTUNITY_STAGE_ORDER, type IOpportunity } from "@/providers/salesTypes";
 import { useClientState } from "@/providers/clientProvider";
@@ -43,6 +44,7 @@ export function OpportunityForm({
   onSubmitEnd,
 }: OpportunityFormProps) {
   const [form] = Form.useForm<OpportunityFormValues>();
+  const mounted = useMounted();
   const { clients } = useClientState();
   const { teamMembers } = useDashboardState();
   const { opportunities } = useOpportunityState();
@@ -50,6 +52,10 @@ export function OpportunityForm({
   const draftKey = getOpportunityFormDraftKey(editingId);
 
   useEffect(() => {
+    if (!mounted) {
+      return;
+    }
+
     const savedDraft = readSessionDraft<PersistedOpportunityFormValues>(draftKey);
 
     if (editingId) {
@@ -73,7 +79,7 @@ export function OpportunityForm({
           : undefined,
       });
     }
-  }, [draftKey, editingId, form, isOpen, opportunities]);
+  }, [draftKey, editingId, form, isOpen, mounted, opportunities]);
 
   const handleSubmit = async (values: OpportunityFormValues) => {
     onSubmitStart?.();
@@ -113,9 +119,8 @@ export function OpportunityForm({
     }
   };
 
-  return (
+  return mounted ? (
     <Modal
-      forceRender
       onCancel={onClose}
       onOk={() => form.submit()}
       okButtonProps={{ loading: isSubmitting }}
@@ -206,5 +211,5 @@ export function OpportunityForm({
         </Form.Item>
       </Form>
     </Modal>
-  );
+  ) : null;
 }

--- a/components/dashboard/pricing-requests-panel.tsx
+++ b/components/dashboard/pricing-requests-panel.tsx
@@ -14,6 +14,7 @@ import {
   usePricingRequestState,
 } from "@/providers/pricingRequestProvider";
 import { useTeamMembersState } from "@/providers/teamMembersProvider";
+import { useMounted } from "@/lib/client/use-mounted";
 import { AnimatedDashboardTable } from "./animated-dashboard-table";
 
 type PricingRequestFormValues = {
@@ -45,6 +46,7 @@ export function PricingRequestsPanel() {
     updatePricingRequest,
   } = usePricingRequestActions();
   const [messageApi, contextHolder] = message.useMessage();
+  const mounted = useMounted();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
@@ -139,7 +141,7 @@ export function PricingRequestsPanel() {
 
   return (
     <div className="space-y-4">
-      {contextHolder}
+      {mounted ? contextHolder : null}
 
       <div className="flex items-center justify-between">
         <div className="space-y-1">
@@ -239,76 +241,77 @@ export function PricingRequestsPanel() {
         rowKey="id"
       />
 
-      <Modal
-        forceRender
-        onCancel={() => {
-          setFormError(null);
-          setIsModalOpen(false);
-          setEditingId(null);
-        }}
-        onOk={() => form.submit()}
-        okButtonProps={{ loading: isSaving }}
-        open={isModalOpen}
-        title={editingId ? "Edit pricing request" : "New pricing request"}
-      >
-        <Form className="pt-4" form={form} layout="vertical" onFinish={handleSave}>
-          <Form.Item
-            label="Opportunity"
-            name="opportunityId"
-            rules={[{ message: "Please select an opportunity", required: true }]}
-          >
-            <Select
-              options={opportunities.map((opportunity) => ({
-                label: opportunity.name || opportunity.title,
-                value: opportunity.id,
-              }))}
-              placeholder="Select the related opportunity"
-            />
-          </Form.Item>
-
-          <Form.Item
-            label="Request title"
-            name="title"
-            rules={[{ message: "Please enter a title", required: true }]}
-          >
-            <Input placeholder="e.g., Discount approval for enterprise scope" />
-          </Form.Item>
-
-          <Form.Item label="Commercial context" name="description">
-            <Input.TextArea
-              placeholder="What pricing review or exception is needed?"
-              rows={4}
-            />
-          </Form.Item>
-
-          <div className="grid gap-4 md:grid-cols-2">
+      {mounted ? (
+        <Modal
+          onCancel={() => {
+            setFormError(null);
+            setIsModalOpen(false);
+            setEditingId(null);
+          }}
+          onOk={() => form.submit()}
+          okButtonProps={{ loading: isSaving }}
+          open={isModalOpen}
+          title={editingId ? "Edit pricing request" : "New pricing request"}
+        >
+          <Form className="pt-4" form={form} layout="vertical" onFinish={handleSave}>
             <Form.Item
-              label="Priority"
-              name="priority"
-              rules={[{ message: "Please select a priority", required: true }]}
+              label="Opportunity"
+              name="opportunityId"
+              rules={[{ message: "Please select an opportunity", required: true }]}
             >
-              <Select options={PRIORITY_OPTIONS} />
-            </Form.Item>
-
-            <Form.Item label="Required by" name="requiredByDate">
-              <Input type="date" />
-            </Form.Item>
-
-            <Form.Item label="Assign to" name="assignedToId">
               <Select
-                allowClear
-                options={teamMembers.map((member) => ({
-                  label: member.name,
-                  value: member.id,
+                options={opportunities.map((opportunity) => ({
+                  label: opportunity.name || opportunity.title,
+                  value: opportunity.id,
                 }))}
-                placeholder="Choose a deal-desk owner"
+                placeholder="Select the related opportunity"
               />
             </Form.Item>
-          </div>
 
-          {formError ? <Alert message={formError} type="error" /> : null}
-        </Form>
-      </Modal>
+            <Form.Item
+              label="Request title"
+              name="title"
+              rules={[{ message: "Please enter a title", required: true }]}
+            >
+              <Input placeholder="e.g., Discount approval for enterprise scope" />
+            </Form.Item>
+
+            <Form.Item label="Commercial context" name="description">
+              <Input.TextArea
+                placeholder="What pricing review or exception is needed?"
+                rows={4}
+              />
+            </Form.Item>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <Form.Item
+                label="Priority"
+                name="priority"
+                rules={[{ message: "Please select a priority", required: true }]}
+              >
+                <Select options={PRIORITY_OPTIONS} />
+              </Form.Item>
+
+              <Form.Item label="Required by" name="requiredByDate">
+                <Input type="date" />
+              </Form.Item>
+
+              <Form.Item label="Assign to" name="assignedToId">
+                <Select
+                  allowClear
+                  options={teamMembers.map((member) => ({
+                    label: member.name,
+                    value: member.id,
+                  }))}
+                  placeholder="Choose a deal-desk owner"
+                />
+              </Form.Item>
+            </div>
+
+            {formError ? <Alert message={formError} type="error" /> : null}
+          </Form>
+        </Modal>
+      ) : null}
     </div>
   );
 }

--- a/components/dashboard/priority-advisor.tsx
+++ b/components/dashboard/priority-advisor.tsx
@@ -174,8 +174,8 @@ export function PriorityAdvisor() {
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      setDraft(readSessionDraft<string>(draftStorageKey) ?? "");
-      setMessages(readSessionDraft<AdvisorMessage[]>(messageStorageKey) ?? []);
+      setDraft(readSessionDraft<string>(draftStorageKey, { storage: "local" }) ?? "");
+      setMessages(readSessionDraft<AdvisorMessage[]>(messageStorageKey, { storage: "local" }) ?? []);
       setError(null);
       setAssistantReason(null);
       setLoadedStorageIdentity(storageIdentity);
@@ -211,11 +211,11 @@ export function PriorityAdvisor() {
     }
 
     if (draft) {
-      writeSessionDraft(draftStorageKey, draft);
+      writeSessionDraft(draftStorageKey, draft, { storage: "local" });
       return;
     }
 
-    clearSessionDraft(draftStorageKey);
+    clearSessionDraft(draftStorageKey, { storage: "local" });
   }, [draft, draftStorageKey, loadedStorageIdentity, storageIdentity]);
 
   useEffect(() => {
@@ -224,11 +224,11 @@ export function PriorityAdvisor() {
     }
 
     if (messages.length > 0) {
-      writeSessionDraft(messageStorageKey, messages);
+      writeSessionDraft(messageStorageKey, messages, { storage: "local" });
       return;
     }
 
-    clearSessionDraft(messageStorageKey);
+    clearSessionDraft(messageStorageKey, { storage: "local" });
   }, [loadedStorageIdentity, messageStorageKey, messages, storageIdentity]);
 
   const resetConversation = () => {
@@ -239,8 +239,8 @@ export function PriorityAdvisor() {
     setAssistantReason(null);
     setActiveAction("ask");
     setStatusLabel("Awaiting your question");
-    clearSessionDraft(draftStorageKey);
-    clearSessionDraft(messageStorageKey);
+    clearSessionDraft(draftStorageKey, { storage: "local" });
+    clearSessionDraft(messageStorageKey, { storage: "local" });
   };
 
   const requestAdvisor = async (nextPrompt: string) => {
@@ -261,7 +261,7 @@ export function PriorityAdvisor() {
 
     setMessages(nextMessages);
     setDraft("");
-    clearSessionDraft(draftStorageKey);
+    clearSessionDraft(draftStorageKey, { storage: "local" });
     setError(null);
 
     if (clarification) {

--- a/components/dashboard/proposal-form.tsx
+++ b/components/dashboard/proposal-form.tsx
@@ -9,6 +9,7 @@ import {
   backendRequest,
   mapBackendProposal,
 } from "@/lib/client/backend-api";
+import { useMounted } from "@/lib/client/use-mounted";
 import { clearSessionDraft, readSessionDraft, writeSessionDraft } from "@/lib/client/session-drafts";
 import { PROPOSAL_STATUS_COLORS, ProposalStatus, type ILineItem, type IProposal } from "@/providers/salesTypes";
 import { useOpportunityState } from "@/providers/opportunityProvider";
@@ -50,6 +51,7 @@ const getLineItemTotal = (item?: Partial<ILineItem>) => {
 
 export function ProposalForm({ isOpen, editingId, onClose }: ProposalFormProps) {
   const [form] = Form.useForm<ProposalFormValues>();
+  const mounted = useMounted();
   const { proposals } = useProposalState();
   const { opportunities } = useOpportunityState();
   const { addProposal, updateProposal } = useProposalActions();
@@ -75,6 +77,10 @@ export function ProposalForm({ isOpen, editingId, onClose }: ProposalFormProps) 
   );
 
   useEffect(() => {
+    if (!mounted) {
+      return;
+    }
+
     if (!isOpen) {
       return;
     }
@@ -134,7 +140,7 @@ export function ProposalForm({ isOpen, editingId, onClose }: ProposalFormProps) 
     return () => {
       isActive = false;
     };
-  }, [draftKey, editingId, editingProposal, form, isOpen]);
+  }, [draftKey, editingId, editingProposal, form, isOpen, mounted]);
 
   const handleSubmit = async (values: ProposalFormValues) => {
     setIsSaving(true);
@@ -180,9 +186,8 @@ export function ProposalForm({ isOpen, editingId, onClose }: ProposalFormProps) 
     }
   };
 
-  return (
+  return mounted ? (
     <Modal
-      forceRender
       onCancel={() => {
         setFormError(null);
         onClose();
@@ -376,5 +381,5 @@ export function ProposalForm({ isOpen, editingId, onClose }: ProposalFormProps) 
         </Form>
       )}
     </Modal>
-  );
+  ) : null;
 }

--- a/components/dashboard/proposals-panel.tsx
+++ b/components/dashboard/proposals-panel.tsx
@@ -5,6 +5,7 @@ import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
 import { useMemo, useState } from "react";
 
 import { isClientScopedUser } from "@/lib/auth/dashboard-access";
+import { useMounted } from "@/lib/client/use-mounted";
 import { useAuthState } from "@/providers/authProvider";
 import { OpportunityStage, PROPOSAL_STATUS_COLORS, ProposalStatus, type IProposal } from "@/providers/salesTypes";
 import { formatCurrency } from "@/providers/salesSelectors";
@@ -42,6 +43,7 @@ export function ProposalsPanel() {
   const { updateOpportunity } = useOpportunityActions();
   const { deleteProposal, transitionProposal } = useProposalActions();
   const [messageApi, contextHolder] = message.useMessage();
+  const mounted = useMounted();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [rejectingProposalId, setRejectingProposalId] = useState<string | null>(null);
@@ -208,7 +210,7 @@ export function ProposalsPanel() {
 
   return (
     <div className="space-y-6">
-      {contextHolder}
+      {mounted ? contextHolder : null}
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="space-y-1">
@@ -292,40 +294,42 @@ export function ProposalsPanel() {
         />
       ) : null}
 
-      <Modal
-        onCancel={() => {
-          setRejectReason("");
-          setRejectingProposalId(null);
-        }}
-        onOk={() => {
-          if (!rejectingProposalId) {
-            return;
-          }
+      {mounted ? (
+        <Modal
+          onCancel={() => {
+            setRejectReason("");
+            setRejectingProposalId(null);
+          }}
+          onOk={() => {
+            if (!rejectingProposalId) {
+              return;
+            }
 
-          void handleTransition(rejectingProposalId, ProposalStatus.Rejected, rejectReason).finally(
-            () => {
-              setRejectReason("");
-              setRejectingProposalId(null);
-            },
-          );
-        }}
-        okButtonProps={{ danger: true }}
-        okText="Reject proposal"
-        open={!isScopedClient && Boolean(rejectingProposalId)}
-        title="Reject proposal"
-      >
-        <div className="space-y-3 pt-2">
-          <Typography.Text className="!text-slate-500">
-            Capture a reason so the rejection is visible in the proposal history.
-          </Typography.Text>
-          <Input.TextArea
-            onChange={(event) => setRejectReason(event.target.value)}
-            placeholder="Why was this proposal rejected?"
-            rows={4}
-            value={rejectReason}
-          />
-        </div>
-      </Modal>
+            void handleTransition(rejectingProposalId, ProposalStatus.Rejected, rejectReason).finally(
+              () => {
+                setRejectReason("");
+                setRejectingProposalId(null);
+              },
+            );
+          }}
+          okButtonProps={{ danger: true }}
+          okText="Reject proposal"
+          open={!isScopedClient && Boolean(rejectingProposalId)}
+          title="Reject proposal"
+        >
+          <div className="space-y-3 pt-2">
+            <Typography.Text className="!text-slate-500">
+              Capture a reason so the rejection is visible in the proposal history.
+            </Typography.Text>
+            <Input.TextArea
+              onChange={(event) => setRejectReason(event.target.value)}
+              placeholder="Why was this proposal rejected?"
+              rows={4}
+              value={rejectReason}
+            />
+          </div>
+        </Modal>
+      ) : null}
     </div>
   );
 }

--- a/components/dashboard/renewal-form.tsx
+++ b/components/dashboard/renewal-form.tsx
@@ -2,6 +2,7 @@
 
 import { Form, Input, Modal, InputNumber } from "antd";
 import { useEffect } from "react";
+import { useMounted } from "@/lib/client/use-mounted";
 import { useContractActions, useContractState } from "@/providers/contractProvider";
 import { type IRenewal } from "@/providers/salesTypes";
 
@@ -20,10 +21,15 @@ interface RenewalFormValues {
 
 export function RenewalForm({ isOpen, editingId, onClose }: RenewalFormProps) {
   const [form] = Form.useForm();
+  const mounted = useMounted();
   const { renewals } = useContractState();
   const { addRenewal, updateRenewal } = useContractActions();
 
   useEffect(() => {
+    if (!mounted) {
+      return;
+    }
+
     if (editingId) {
       const renewal = renewals.find((r) => r.id === editingId);
       if (renewal) {
@@ -32,7 +38,7 @@ export function RenewalForm({ isOpen, editingId, onClose }: RenewalFormProps) {
     } else {
       form.resetFields();
     }
-  }, [editingId, form, isOpen, renewals]);
+  }, [editingId, form, isOpen, mounted, renewals]);
 
   const calculateDaysUntil = (renewalDate: string) => {
     const today = new Date();
@@ -62,9 +68,8 @@ export function RenewalForm({ isOpen, editingId, onClose }: RenewalFormProps) {
     form.resetFields();
   };
 
-  return (
+  return mounted ? (
     <Modal
-      forceRender
       title={editingId ? "Edit Renewal" : "Add Renewal"}
       open={isOpen}
       onCancel={onClose}
@@ -104,5 +109,5 @@ export function RenewalForm({ isOpen, editingId, onClose }: RenewalFormProps) {
         </Form.Item>
       </Form>
     </Modal>
-  );
+  ) : null;
 }

--- a/docs/assistant-workflow-api.md
+++ b/docs/assistant-workflow-api.md
@@ -1,0 +1,380 @@
+# Assistant Workflow API
+
+## Purpose
+
+This document defines the minimum backend API surface needed to make the
+assistant-driven sales workflow deterministic.
+
+The assistant should interpret requests and collect missing fields, but the
+backend should own:
+
+- record creation
+- workflow state transitions
+- notifications
+- approval decisions
+- idempotency
+
+## Core principle
+
+After the user confirms an action, the assistant should call a concrete API
+endpoint and receive a concrete result.
+
+The assistant should not be the source of truth for workflow state.
+
+## Primary workflow
+
+1. Client submits a service request.
+2. Admin receives a notification and reviews the request.
+3. Assistant or admin creates the linked opportunity and proposal.
+4. Admin assigns one or more reps to the request.
+5. Client accepts or rejects the assigned rep set.
+6. If client accepts, the assigned rep receives the proposal/spec package.
+7. Rep accepts or rejects the assignment.
+8. Admin sees the full state on one timeline.
+
+## Required entities
+
+### `service_requests`
+
+- `id`
+- `tenant_id`
+- `client_id`
+- `submitted_by_user_id`
+- `title`
+- `description`
+- `request_type`
+- `status`
+- `priority`
+- `created_at`
+- `updated_at`
+- `source`
+
+Suggested statuses:
+
+- `submitted`
+- `under_review`
+- `proposal_prepared`
+- `awaiting_client_assignment_approval`
+- `client_rejected_assignment`
+- `client_approved_assignment`
+- `awaiting_rep_acceptance`
+- `rep_rejected_assignment`
+- `active`
+- `closed`
+- `cancelled`
+
+### `request_assignments`
+
+- `id`
+- `service_request_id`
+- `representative_user_id`
+- `assigned_by_user_id`
+- `status`
+- `decision_note`
+- `created_at`
+- `updated_at`
+
+Suggested statuses:
+
+- `pending_client_approval`
+- `client_rejected`
+- `client_approved`
+- `pending_rep_response`
+- `rep_rejected`
+- `rep_accepted`
+
+### `workflow_events`
+
+- `id`
+- `tenant_id`
+- `service_request_id`
+- `actor_user_id`
+- `actor_type`
+- `event_type`
+- `payload_json`
+- `created_at`
+
+This is the audit trail and notification feed source.
+
+### Linked business records
+
+The workflow should link to existing domain records instead of duplicating them:
+
+- `opportunity_id`
+- `proposal_id`
+- `pricing_request_id`
+- `contract_id`
+
+These can live on `service_requests` or a separate linking table.
+
+## Minimum endpoints
+
+### Client request entry
+
+`POST /api/service-requests`
+
+Creates the initial client request.
+
+Request body:
+
+```json
+{
+  "clientId": "c1",
+  "title": "Need a refrigeration operations proposal",
+  "description": "We need a proposal covering rollout, pricing, and implementation scope.",
+  "requestType": "service_proposal",
+  "priority": "high"
+}
+```
+
+Response:
+
+```json
+{
+  "id": "req_123",
+  "status": "submitted"
+}
+```
+
+### Admin request queue
+
+`GET /api/service-requests?status=submitted,under_review`
+
+Returns the admin review queue.
+
+### Request detail / timeline
+
+`GET /api/service-requests/{requestId}`
+
+Returns:
+
+- request details
+- linked client
+- linked opportunity/proposal/pricing request
+- assignments
+- workflow events
+- unread notification state
+
+### Admin acknowledge / review start
+
+`POST /api/service-requests/{requestId}/review`
+
+Moves the request to `under_review`.
+
+### Create or link opportunity
+
+`POST /api/service-requests/{requestId}/opportunity`
+
+Creates a new opportunity from the request or links an existing one.
+
+Request body:
+
+```json
+{
+  "mode": "create",
+  "title": "Boxfusion refrigeration rollout",
+  "estimatedValue": 250000,
+  "expectedCloseDate": "2026-08-29",
+  "stage": "Qualified",
+  "ownerId": "user_45"
+}
+```
+
+### Create or link proposal
+
+`POST /api/service-requests/{requestId}/proposal`
+
+Creates a proposal tied to the workflow.
+
+Request body:
+
+```json
+{
+  "mode": "create",
+  "title": "Boxfusion commercial proposal",
+  "description": "Initial curated proposal for review.",
+  "validUntil": "2026-08-29",
+  "currency": "ZAR"
+}
+```
+
+### Create pricing request
+
+`POST /api/service-requests/{requestId}/pricing-request`
+
+Creates the pricing request when needed.
+
+### Assign reps
+
+`POST /api/service-requests/{requestId}/assignments`
+
+Request body:
+
+```json
+{
+  "representativeUserIds": ["user_10", "user_11"],
+  "note": "Best fit for refrigeration rollout and commercial onboarding."
+}
+```
+
+This should:
+
+- create assignment records
+- change request status to `awaiting_client_assignment_approval`
+- emit workflow events
+- create client-facing notifications
+
+### Client approve or reject assigned reps
+
+`POST /api/service-requests/{requestId}/client-decision`
+
+Request body:
+
+```json
+{
+  "decision": "approve",
+  "assignmentIds": ["assign_1", "assign_2"],
+  "note": "These reps look appropriate."
+}
+```
+
+This should:
+
+- update assignment status
+- update request status
+- emit workflow events
+- notify assigned reps
+
+### Rep accept or reject assignment
+
+`POST /api/service-requests/{requestId}/rep-decision`
+
+Request body:
+
+```json
+{
+  "assignmentId": "assign_1",
+  "decision": "accept",
+  "note": "Ready to take this on."
+}
+```
+
+This should:
+
+- update assignment state
+- update request state when all required approvals are satisfied
+- notify admin
+
+### Send workflow message
+
+`POST /api/service-requests/{requestId}/messages`
+
+This is the real send endpoint the assistant should call.
+
+Request body:
+
+```json
+{
+  "channel": "internal",
+  "recipientUserIds": ["user_10"],
+  "subject": "New request ready for review",
+  "content": "The client approved your assignment. Review the proposal and scope."
+}
+```
+
+The backend can later fan this out to email, Teams, Slack, WhatsApp, or an
+internal inbox.
+
+### Notifications
+
+`GET /api/notifications`
+
+Returns the current user's notifications.
+
+`POST /api/notifications/{notificationId}/acknowledge`
+
+Lets the red-alert style admin notification be dismissed without mutating the
+business record itself.
+
+## Assistant-specific execution contract
+
+The assistant should work against deterministic workflow actions, not open-ended
+CRUD wherever possible.
+
+### Good assistant action
+
+- parse user intent
+- collect missing fields
+- call `POST /api/service-requests/{id}/proposal`
+- report created proposal ID and status
+
+### Bad assistant action
+
+- keep all state in chat
+- ask for confirmation repeatedly
+- rely on model availability to remember what to do next
+
+## Idempotency
+
+Mutation endpoints should support an idempotency key header.
+
+Suggested header:
+
+`Idempotency-Key: <uuid>`
+
+This is required for assistant-driven flows so retries do not create duplicate:
+
+- opportunities
+- proposals
+- assignments
+- messages
+
+## Suggested notification rules
+
+### Admin
+
+Notify when:
+
+- client submits a new request
+- client approves or rejects assignments
+- rep accepts or rejects assignment
+
+### Client
+
+Notify when:
+
+- proposal is ready
+- reps are assigned
+- admin sends a clarification request
+
+### Rep
+
+Notify when:
+
+- client has approved assignment
+- proposal/spec package is ready for review
+
+## Minimum frontend impact
+
+The frontend should stop treating notes as the workflow source of truth for this
+path.
+
+Instead:
+
+- admin queue reads from `service_requests`
+- client contacts/assignment views read from `request_assignments`
+- notification badge reads from `notifications`
+- assistant actions call workflow endpoints, not mock note mutations
+
+## Recommended implementation order
+
+1. `service_requests`
+2. `request_assignments`
+3. `workflow_events`
+4. `notifications`
+5. `service_requests/{id}/opportunity`
+6. `service_requests/{id}/proposal`
+7. client decision endpoint
+8. rep decision endpoint
+9. send message endpoint
+10. assistant integration against these endpoints

--- a/docs/assistant-workflow-api.md
+++ b/docs/assistant-workflow-api.md
@@ -52,6 +52,18 @@ Until those changes are made, the assistant will remain vulnerable to
 "disappearing state" after periods of idleness even if the workflow logic
 itself is correct.
 
+## Local development persistence status
+
+The local development path now persists:
+
+- assistant chat history and advisor chat history in browser `localStorage`
+- auth session state in browser `localStorage`
+- mock workspace state and mock service-request workflow state in
+  `.local-state/assistant-workflow.json`
+
+The remaining production-grade requirement is still a real backend source of
+truth instead of local browser or local filesystem persistence.
+
 ## Primary workflow
 
 1. Client submits a service request.
@@ -306,9 +318,8 @@ Request body:
 
 ```json
 {
-  "channel": "internal",
-  "recipientUserIds": ["user_10"],
-  "subject": "New request ready for review",
+  "recipientType": "both",
+  "representativeUserIds": ["user_10"],
   "content": "The client approved your assignment. Review the proposal and scope."
 }
 ```

--- a/docs/assistant-workflow-api.md
+++ b/docs/assistant-workflow-api.md
@@ -21,6 +21,37 @@ endpoint and receive a concrete result.
 
 The assistant should not be the source of truth for workflow state.
 
+## Current persistence gap
+
+The current app still loses important assistant and workflow state after idle
+time, browser session loss, or local server recycle.
+
+What is volatile today:
+
+- assistant conversation history is stored in `sessionStorage`
+- auth session state is stored in `sessionStorage`
+- mock service-request workflow state is stored in an in-memory server `Map`
+
+What this means:
+
+- assistant chats can disappear when the browser session is cleared or reset
+- auth can be cleared if `/api/Auth/me` fails during a later refresh
+- local workflow requests can disappear if the Next.js server recompiles,
+  restarts, or the process is recycled
+
+What needs to change:
+
+1. Move assistant conversation state off browser `sessionStorage` into durable
+   app storage.
+2. Move workflow state off the in-memory server store into a persistent backend
+   store.
+3. Stop treating transient `/api/Auth/me` failures as an immediate reason to
+   wipe the current client auth session.
+
+Until those changes are made, the assistant will remain vulnerable to
+"disappearing state" after periods of idleness even if the workflow logic
+itself is correct.
+
 ## Primary workflow
 
 1. Client submits a service request.

--- a/lib/client/auth-session.ts
+++ b/lib/client/auth-session.ts
@@ -3,16 +3,48 @@
 import type { IUserLoginResponse } from "@/providers/authProvider/context";
 
 const AUTH_STORAGE_KEY = "auth_user";
+const LEGACY_TOKEN_KEY = "token";
 
-export const getSessionToken = () =>
-  typeof window !== "undefined" ? sessionStorage.getItem("token") : null;
+const getStorage = () => (typeof window === "undefined" ? null : window.localStorage);
 
-export const getStoredAuthUser = () => {
+const migrateLegacySessionValue = (key: string) => {
   if (typeof window === "undefined") {
     return null;
   }
 
-  const raw = sessionStorage.getItem(AUTH_STORAGE_KEY);
+  const localValue = window.localStorage.getItem(key);
+
+  if (localValue) {
+    return localValue;
+  }
+
+  const sessionValue = window.sessionStorage.getItem(key);
+
+  if (!sessionValue) {
+    return null;
+  }
+
+  try {
+    window.localStorage.setItem(key, sessionValue);
+    window.sessionStorage.removeItem(key);
+  } catch {
+    // Ignore migration failures and use the legacy value for this request.
+  }
+
+  return sessionValue;
+};
+
+export const getSessionToken = () =>
+  (getStorage()?.getItem(LEGACY_TOKEN_KEY) ?? migrateLegacySessionValue(LEGACY_TOKEN_KEY));
+
+export const getStoredAuthUser = () => {
+  const storage = getStorage();
+
+  if (!storage) {
+    return null;
+  }
+
+  const raw = storage.getItem(AUTH_STORAGE_KEY) ?? migrateLegacySessionValue(AUTH_STORAGE_KEY);
 
   if (!raw) {
     return null;
@@ -26,15 +58,17 @@ export const getStoredAuthUser = () => {
 };
 
 export const storeAuthSession = (user: IUserLoginResponse) => {
-  if (typeof window === "undefined") {
+  const storage = getStorage();
+
+  if (!storage) {
     return;
   }
 
   if (user.token) {
-    sessionStorage.setItem("token", user.token);
+    storage.setItem(LEGACY_TOKEN_KEY, user.token);
   }
 
-  sessionStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(user));
+  storage.setItem(AUTH_STORAGE_KEY, JSON.stringify(user));
 };
 
 export const clearAuthSession = () => {
@@ -42,6 +76,8 @@ export const clearAuthSession = () => {
     return;
   }
 
-  sessionStorage.removeItem("token");
-  sessionStorage.removeItem(AUTH_STORAGE_KEY);
+  window.localStorage.removeItem(LEGACY_TOKEN_KEY);
+  window.localStorage.removeItem(AUTH_STORAGE_KEY);
+  window.sessionStorage.removeItem(LEGACY_TOKEN_KEY);
+  window.sessionStorage.removeItem(AUTH_STORAGE_KEY);
 };

--- a/lib/client/service-request-api.ts
+++ b/lib/client/service-request-api.ts
@@ -1,0 +1,210 @@
+"use client";
+
+import { getSessionToken } from "@/lib/client/backend-api";
+
+export type ServiceRequestStatus =
+  | "submitted"
+  | "under_review"
+  | "proposal_prepared"
+  | "awaiting_client_assignment_approval"
+  | "client_rejected_assignment"
+  | "client_approved_assignment"
+  | "awaiting_rep_acceptance"
+  | "rep_rejected_assignment"
+  | "active"
+  | "closed"
+  | "cancelled";
+
+export type ServiceRequestPriority = "low" | "medium" | "high" | "critical";
+
+export type ServiceRequestRecord = {
+  clientId: string;
+  contractId?: string;
+  createdAt: string;
+  description: string;
+  id: string;
+  opportunityId?: string;
+  pricingRequestId?: string;
+  priority: ServiceRequestPriority;
+  proposalId?: string;
+  requestType: string;
+  source: "assistant" | "client_portal" | "workspace";
+  status: ServiceRequestStatus;
+  submittedByUserId: string;
+  tenantId: string;
+  title: string;
+  updatedAt: string;
+};
+
+export type ServiceRequestAssignmentStatus =
+  | "pending_client_approval"
+  | "client_rejected"
+  | "client_approved"
+  | "pending_rep_response"
+  | "rep_rejected"
+  | "rep_accepted";
+
+export type ServiceRequestAssignmentRecord = {
+  assignedByUserId: string;
+  createdAt: string;
+  decisionNote?: string;
+  id: string;
+  representativeName: string;
+  representativeUserId: string;
+  serviceRequestId: string;
+  status: ServiceRequestAssignmentStatus;
+  updatedAt: string;
+};
+
+export type WorkflowEventRecord = {
+  actorType: "admin" | "assistant" | "client" | "representative" | "workspace_user";
+  actorUserId?: string;
+  createdAt: string;
+  eventType: string;
+  id: string;
+  payloadJson: Record<string, unknown>;
+  serviceRequestId: string;
+  tenantId: string;
+};
+
+export type ServiceRequestDetail = {
+  assignments: ServiceRequestAssignmentRecord[];
+  events: WorkflowEventRecord[];
+  request: ServiceRequestRecord;
+};
+
+const extractErrorMessage = (value: unknown) => {
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+
+  if (value && typeof value === "object") {
+    const candidate = value as {
+      detail?: unknown;
+      message?: unknown;
+      title?: unknown;
+    };
+
+    if (typeof candidate.message === "string" && candidate.message.trim()) {
+      return candidate.message;
+    }
+
+    if (typeof candidate.detail === "string" && candidate.detail.trim()) {
+      return candidate.detail;
+    }
+
+    if (typeof candidate.title === "string" && candidate.title.trim()) {
+      return candidate.title;
+    }
+  }
+
+  return null;
+};
+
+const serviceRequestApi = async <T>(path: string, init: RequestInit = {}): Promise<T> => {
+  const headers = new Headers(init.headers);
+  const token = getSessionToken();
+
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  if (init.body && !(init.body instanceof FormData) && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const response = await fetch(path, {
+    ...init,
+    credentials: "same-origin",
+    headers,
+  });
+
+  if (response.status === 204) {
+    return null as T;
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  const payload = contentType.includes("application/json")
+    ? await response.json()
+    : await response.text();
+
+  if (!response.ok) {
+    throw new Error(
+      extractErrorMessage(payload) ?? `Request failed with status ${response.status}.`,
+    );
+  }
+
+  return payload as T;
+};
+
+export const listServiceRequests = async (statuses?: ServiceRequestStatus[]) => {
+  const params = new URLSearchParams();
+
+  if (statuses && statuses.length > 0) {
+    params.set("status", statuses.join(","));
+  }
+
+  const path = params.toString()
+    ? `/api/service-requests?${params.toString()}`
+    : "/api/service-requests";
+
+  const payload = await serviceRequestApi<{ items?: ServiceRequestRecord[] }>(path);
+  return payload.items ?? [];
+};
+
+export const createServiceRequest = async (payload: {
+  clientId: string;
+  description: string;
+  priority?: ServiceRequestPriority;
+  requestType?: string;
+  source?: "assistant" | "client_portal" | "workspace";
+  title: string;
+}) =>
+  serviceRequestApi<ServiceRequestRecord>("/api/service-requests", {
+    body: JSON.stringify(payload),
+    method: "POST",
+  });
+
+export const getServiceRequestDetail = async (requestId: string) =>
+  serviceRequestApi<ServiceRequestDetail>(`/api/service-requests/${requestId}`);
+
+export const createServiceRequestAssignments = async (
+  requestId: string,
+  payload: {
+    note?: string;
+    representativeUserIds: string[];
+  },
+) =>
+  serviceRequestApi<{
+    assignments: ServiceRequestAssignmentRecord[];
+    request: ServiceRequestRecord;
+  }>(`/api/service-requests/${requestId}/assignments`, {
+    body: JSON.stringify(payload),
+    method: "POST",
+  });
+
+export const applyServiceRequestClientDecision = async (
+  requestId: string,
+  payload: {
+    assignmentIds: string[];
+    decision: "approve" | "reject";
+    note?: string;
+  },
+) =>
+  serviceRequestApi<ServiceRequestDetail>(`/api/service-requests/${requestId}/client-decision`, {
+    body: JSON.stringify(payload),
+    method: "POST",
+  });
+
+export const applyServiceRequestRepresentativeDecision = async (
+  requestId: string,
+  payload: {
+    assignmentId: string;
+    decision: "accept" | "reject";
+    note?: string;
+  },
+) =>
+  serviceRequestApi<ServiceRequestDetail>(`/api/service-requests/${requestId}/rep-decision`, {
+    body: JSON.stringify(payload),
+    method: "POST",
+  });

--- a/lib/client/service-request-api.ts
+++ b/lib/client/service-request-api.ts
@@ -73,6 +73,8 @@ export type ServiceRequestDetail = {
   request: ServiceRequestRecord;
 };
 
+export type ServiceRequestMessageRecipientType = "client" | "representative" | "both";
+
 const extractErrorMessage = (value: unknown) => {
   if (typeof value === "string" && value.trim()) {
     return value;
@@ -213,6 +215,8 @@ export const addServiceRequestMessage = async (
   requestId: string,
   payload: {
     content: string;
+    recipientType: ServiceRequestMessageRecipientType;
+    representativeUserIds?: string[];
   },
 ) =>
   serviceRequestApi<ServiceRequestDetail>(`/api/service-requests/${requestId}/messages`, {

--- a/lib/client/service-request-api.ts
+++ b/lib/client/service-request-api.ts
@@ -208,3 +208,14 @@ export const applyServiceRequestRepresentativeDecision = async (
     body: JSON.stringify(payload),
     method: "POST",
   });
+
+export const addServiceRequestMessage = async (
+  requestId: string,
+  payload: {
+    content: string;
+  },
+) =>
+  serviceRequestApi<ServiceRequestDetail>(`/api/service-requests/${requestId}/messages`, {
+    body: JSON.stringify(payload),
+    method: "POST",
+  });

--- a/lib/client/session-drafts.ts
+++ b/lib/client/session-drafts.ts
@@ -1,12 +1,31 @@
 "use client";
 
-export const readSessionDraft = <T,>(key: string): T | null => {
+type DraftStorageKind = "local" | "session";
+
+const getStorage = (storage: DraftStorageKind) => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return storage === "local" ? window.localStorage : window.sessionStorage;
+};
+
+export const readSessionDraft = <T,>(
+  key: string,
+  options: { storage?: DraftStorageKind } = {},
+): T | null => {
+  const storage = getStorage(options.storage ?? "session");
+
+  if (!storage) {
+    return null;
+  }
+
   if (typeof window === "undefined") {
     return null;
   }
 
   try {
-    const rawValue = window.sessionStorage.getItem(key);
+    const rawValue = storage.getItem(key);
 
     if (!rawValue) {
       return null;
@@ -18,25 +37,36 @@ export const readSessionDraft = <T,>(key: string): T | null => {
   }
 };
 
-export const writeSessionDraft = (key: string, value: unknown) => {
-  if (typeof window === "undefined") {
+export const writeSessionDraft = (
+  key: string,
+  value: unknown,
+  options: { storage?: DraftStorageKind } = {},
+) => {
+  const storage = getStorage(options.storage ?? "session");
+
+  if (!storage) {
     return;
   }
 
   try {
-    window.sessionStorage.setItem(key, JSON.stringify(value));
+    storage.setItem(key, JSON.stringify(value));
   } catch {
     // Ignore storage failures so drafts do not break the UI.
   }
 };
 
-export const clearSessionDraft = (key: string) => {
-  if (typeof window === "undefined") {
+export const clearSessionDraft = (
+  key: string,
+  options: { storage?: DraftStorageKind } = {},
+) => {
+  const storage = getStorage(options.storage ?? "session");
+
+  if (!storage) {
     return;
   }
 
   try {
-    window.sessionStorage.removeItem(key);
+    storage.removeItem(key);
   } catch {
     // Ignore storage failures so cleanup does not break the UI.
   }

--- a/lib/client/use-mounted.ts
+++ b/lib/client/use-mounted.ts
@@ -1,0 +1,7 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const subscribe = () => () => {};
+
+export const useMounted = () => useSyncExternalStore(subscribe, () => true, () => false);

--- a/lib/server/assistant-backend.ts
+++ b/lib/server/assistant-backend.ts
@@ -1,0 +1,719 @@
+import "server-only";
+
+import type { IMockUser } from "@/app/api/Auth/mock-users";
+import type { INoteItem } from "@/providers/domainSeeds";
+import {
+  ActivityStatus,
+  ActivityType,
+  OpportunityStage,
+  ProposalStatus,
+  type IActivity,
+  type IClient,
+  type IContact,
+  type ILineItem,
+  type IOpportunity,
+  type IPricingRequest,
+  type IProposal,
+  type ISalesData,
+  type ITeamMember,
+} from "@/providers/salesTypes";
+
+import { createBackendUrl } from "./backend-url";
+
+type BackendPagedResult<T> = {
+  items?: T[] | null;
+};
+
+type BackendClientDto = {
+  billingAddress?: string | null;
+  clientType?: number;
+  companySize?: string | null;
+  createdAt?: string | null;
+  id: string;
+  industry?: string | null;
+  isActive?: boolean;
+  name?: string | null;
+  taxNumber?: string | null;
+  website?: string | null;
+};
+
+type BackendContactDto = {
+  clientId: string;
+  email?: string | null;
+  firstName?: string | null;
+  id: string;
+  isPrimaryContact?: boolean;
+  lastName?: string | null;
+  phoneNumber?: string | null;
+  position?: string | null;
+};
+
+type BackendOpportunityDto = {
+  clientId: string;
+  contactId?: string | null;
+  createdAt?: string | null;
+  currency?: string | null;
+  description?: string | null;
+  estimatedValue?: number;
+  expectedCloseDate?: string | null;
+  id: string;
+  ownerId?: string | null;
+  probability?: number;
+  source?: number;
+  stage?: number | string | null;
+  stageName?: string | null;
+  title?: string | null;
+};
+
+type BackendProposalLineItemDto = {
+  description?: string | null;
+  discount?: number;
+  id?: string;
+  productServiceName?: string | null;
+  quantity?: number;
+  taxRate?: number;
+  unitPrice?: number;
+};
+
+type BackendProposalDto = {
+  approvedDate?: string | null;
+  clientId: string;
+  createdAt?: string | null;
+  currency?: string | null;
+  description?: string | null;
+  id: string;
+  lineItems?: BackendProposalLineItemDto[] | null;
+  lineItemsCount?: number;
+  opportunityId: string;
+  proposalNumber?: string | null;
+  status?: number | string | null;
+  statusName?: string | null;
+  submittedDate?: string | null;
+  title?: string | null;
+  totalAmount?: number;
+  validUntil?: string | null;
+};
+
+type BackendPricingRequestDto = {
+  assignedToId?: string | null;
+  assignedToName?: string | null;
+  completedDate?: string | null;
+  createdAt?: string | null;
+  description?: string | null;
+  id: string;
+  opportunityId: string;
+  opportunityTitle?: string | null;
+  priority?: number;
+  priorityName?: string | null;
+  requestNumber?: string | null;
+  requestedById?: string | null;
+  requestedByName?: string | null;
+  requiredByDate?: string | null;
+  status?: number | string | null;
+  statusName?: string | null;
+  title?: string | null;
+  updatedAt?: string | null;
+};
+
+type BackendActivityDto = {
+  assignedToId?: string | null;
+  assignedToName?: string | null;
+  createdAt?: string | null;
+  description?: string | null;
+  dueDate?: string | null;
+  duration?: number | null;
+  id: string;
+  location?: string | null;
+  priority?: number;
+  relatedToId?: string | null;
+  relatedToType?: number;
+  status?: number | string | null;
+  statusName?: string | null;
+  subject?: string | null;
+  type?: number | string | null;
+  typeName?: string | null;
+};
+
+type BackendUserDto = {
+  availabilityPercent?: number;
+  email?: string | null;
+  firstName?: string | null;
+  fullName?: string | null;
+  id: string;
+  lastName?: string | null;
+  region?: string | null;
+  role?: string | null;
+  roles?: string[] | null;
+  skills?: string[] | null;
+};
+
+const toDateOnly = (value?: string | null) => value?.split("T")[0] ?? "";
+
+const toDateTimePayload = (value?: string | null) => {
+  if (!value) {
+    return null;
+  }
+
+  if (value.includes("T")) {
+    return value;
+  }
+
+  return `${value}T09:00:00`;
+};
+
+const extractErrorMessage = (value: unknown) => {
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+
+  if (value && typeof value === "object") {
+    const candidate = value as {
+      detail?: unknown;
+      message?: unknown;
+      title?: unknown;
+    };
+
+    if (typeof candidate.message === "string" && candidate.message.trim()) {
+      return candidate.message;
+    }
+
+    if (typeof candidate.detail === "string" && candidate.detail.trim()) {
+      return candidate.detail;
+    }
+
+    if (typeof candidate.title === "string" && candidate.title.trim()) {
+      return candidate.title;
+    }
+  }
+
+  return null;
+};
+
+const coerceItems = <T>(payload: BackendPagedResult<T> | T[] | null | undefined) => {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  return payload?.items ?? [];
+};
+
+const backendStageNameToLocal = (value?: number | string | null, name?: string | null) => {
+  const normalized = String(name ?? value ?? "").toLowerCase();
+
+  if (normalized.includes("lead") || normalized === "1" || normalized === "new") {
+    return OpportunityStage.New;
+  }
+
+  if (normalized.includes("qualified") || normalized === "2") {
+    return OpportunityStage.Qualified;
+  }
+
+  if (normalized.includes("proposal") || normalized === "3") {
+    return OpportunityStage.ProposalSent;
+  }
+
+  if (normalized.includes("negoti") || normalized === "4") {
+    return OpportunityStage.Negotiating;
+  }
+
+  if (normalized.includes("won") || normalized === "5") {
+    return OpportunityStage.Won;
+  }
+
+  if (normalized.includes("lost") || normalized === "6") {
+    return OpportunityStage.Lost;
+  }
+
+  return OpportunityStage.New;
+};
+
+const localStageToBackend = (stage?: string) => {
+  switch (stage) {
+    case OpportunityStage.Qualified:
+      return 2;
+    case OpportunityStage.ProposalSent:
+      return 3;
+    case OpportunityStage.Negotiating:
+      return 4;
+    case OpportunityStage.Won:
+      return 5;
+    case OpportunityStage.Lost:
+      return 6;
+    case OpportunityStage.New:
+    default:
+      return 1;
+  }
+};
+
+const backendProposalStatusToLocal = (value?: number | string | null, name?: string | null) => {
+  const normalized = String(name ?? value ?? "").toLowerCase().replace(/\s+/g, "");
+
+  if (normalized.includes("draft") || normalized === "1") {
+    return ProposalStatus.Draft;
+  }
+
+  if (normalized.includes("submitted") || normalized === "2") {
+    return ProposalStatus.Submitted;
+  }
+
+  if (normalized.includes("rejected") || normalized.includes("declined") || normalized === "3") {
+    return ProposalStatus.Rejected;
+  }
+
+  if (normalized.includes("approved") || normalized === "4") {
+    return ProposalStatus.Approved;
+  }
+
+  return name?.trim() || ProposalStatus.Draft;
+};
+
+const normalizePricingRequestStatus = (value?: number | string | null, name?: string | null) => {
+  if (typeof name === "string" && name.trim()) {
+    return name.trim();
+  }
+
+  switch (value) {
+    case 1:
+      return "Pending";
+    case 2:
+      return "In Progress";
+    case 3:
+      return "Completed";
+    case 4:
+      return "Cancelled";
+    default:
+      return "Pending";
+  }
+};
+
+const backendActivityTypeToLocal = (value?: number | string | null, name?: string | null) => {
+  const normalized = String(name ?? value ?? "").toLowerCase().replace(/\s+/g, "");
+
+  switch (normalized) {
+    case "1":
+    case "meeting":
+      return ActivityType.Meeting;
+    case "2":
+    case "call":
+      return ActivityType.Call;
+    case "3":
+    case "email":
+      return ActivityType.Email;
+    case "4":
+    case "task":
+      return ActivityType.Task;
+    case "5":
+    case "presentation":
+      return ActivityType.Presentation;
+    default:
+      return ActivityType.Other;
+  }
+};
+
+const backendActivityStatusToLocal = (value?: number | string | null, name?: string | null) => {
+  const normalized = String(name ?? value ?? "").toLowerCase().replace(/\s+/g, "");
+
+  switch (normalized) {
+    case "1":
+    case "scheduled":
+      return ActivityStatus.Scheduled;
+    case "2":
+    case "completed":
+      return ActivityStatus.Completed;
+    case "3":
+    case "cancelled":
+    case "canceled":
+      return ActivityStatus.Cancelled;
+    default:
+      return ActivityStatus.Scheduled;
+  }
+};
+
+const mapBackendProposalLineItem = (item: BackendProposalLineItemDto): ILineItem => ({
+  description: item.description ?? undefined,
+  discount: item.discount ?? 0,
+  id: item.id,
+  productServiceName: item.productServiceName ?? "Line item",
+  quantity: item.quantity ?? 1,
+  taxRate: item.taxRate ?? 0,
+  unitPrice: item.unitPrice ?? 0,
+});
+
+const mapBackendClient = (client: BackendClientDto): IClient => ({
+  billingAddress: client.billingAddress ?? undefined,
+  clientType: client.clientType ?? 2,
+  companySize: client.companySize ?? undefined,
+  createdAt: client.createdAt ?? undefined,
+  id: client.id,
+  industry: client.industry ?? "Unknown industry",
+  isActive: client.isActive ?? true,
+  name: client.name ?? "Unnamed client",
+  segment: client.companySize ?? undefined,
+  taxNumber: client.taxNumber ?? undefined,
+  website: client.website ?? undefined,
+});
+
+const mapBackendContact = (contact: BackendContactDto): IContact => ({
+  clientId: contact.clientId,
+  createdAt: undefined,
+  email: contact.email ?? "",
+  firstName: contact.firstName ?? "",
+  id: contact.id,
+  isPrimaryContact: contact.isPrimaryContact ?? false,
+  lastName: contact.lastName ?? "",
+  phoneNumber: contact.phoneNumber ?? undefined,
+  position: contact.position ?? "",
+});
+
+const mapBackendOpportunity = (opportunity: BackendOpportunityDto): IOpportunity => ({
+  clientId: opportunity.clientId,
+  contactId: opportunity.contactId ?? undefined,
+  createdDate: toDateOnly(opportunity.createdAt),
+  currency: opportunity.currency ?? "ZAR",
+  description: opportunity.description ?? undefined,
+  estimatedValue: opportunity.estimatedValue ?? 0,
+  expectedCloseDate: toDateOnly(opportunity.expectedCloseDate),
+  id: opportunity.id,
+  name: opportunity.title ?? undefined,
+  ownerId: opportunity.ownerId ?? undefined,
+  probability: opportunity.probability ?? 0,
+  source: opportunity.source ?? 1,
+  stage: backendStageNameToLocal(opportunity.stage, opportunity.stageName),
+  title: opportunity.title ?? "Untitled opportunity",
+  value: opportunity.estimatedValue ?? 0,
+});
+
+const mapBackendProposal = (proposal: BackendProposalDto): IProposal => ({
+  approvedDate: toDateOnly(proposal.approvedDate),
+  clientId: proposal.clientId,
+  createdAt: proposal.createdAt ?? undefined,
+  currency: proposal.currency ?? "ZAR",
+  description: proposal.description ?? undefined,
+  id: proposal.id,
+  lineItems: proposal.lineItems?.map(mapBackendProposalLineItem) ?? undefined,
+  lineItemsCount: proposal.lineItemsCount ?? proposal.lineItems?.length ?? 0,
+  opportunityId: proposal.opportunityId,
+  proposalNumber: proposal.proposalNumber ?? undefined,
+  status: backendProposalStatusToLocal(proposal.status, proposal.statusName),
+  submittedDate: toDateOnly(proposal.submittedDate),
+  title: proposal.title ?? "Untitled proposal",
+  validUntil: toDateOnly(proposal.validUntil),
+  value: proposal.totalAmount ?? 0,
+});
+
+const mapBackendPricingRequest = (request: BackendPricingRequestDto): IPricingRequest => ({
+  assignedToId: request.assignedToId ?? undefined,
+  assignedToName: request.assignedToName ?? undefined,
+  completedDate: toDateOnly(request.completedDate),
+  createdAt: request.createdAt ?? new Date().toISOString(),
+  description: request.description ?? undefined,
+  id: request.id,
+  opportunityId: request.opportunityId,
+  opportunityTitle: request.opportunityTitle ?? undefined,
+  priority: request.priority ?? 2,
+  priorityLabel: request.priorityName ?? undefined,
+  requestNumber: request.requestNumber ?? undefined,
+  requestedById: request.requestedById ?? undefined,
+  requestedByName: request.requestedByName ?? undefined,
+  requiredByDate: toDateOnly(request.requiredByDate),
+  status: normalizePricingRequestStatus(request.status, request.statusName),
+  title: request.title ?? "Untitled pricing request",
+  updatedAt: request.updatedAt ?? undefined,
+});
+
+const mapBackendActivity = (activity: BackendActivityDto): IActivity => {
+  const status = backendActivityStatusToLocal(activity.status, activity.statusName);
+
+  return {
+    assignedToId: activity.assignedToId ?? undefined,
+    assignedToName: activity.assignedToName ?? undefined,
+    completed: status === ActivityStatus.Completed,
+    createdAt: activity.createdAt ?? undefined,
+    description: activity.description ?? "",
+    dueDate: toDateOnly(activity.dueDate),
+    duration: activity.duration ?? undefined,
+    id: activity.id,
+    location: activity.location ?? undefined,
+    priority: activity.priority ?? 2,
+    relatedToId: activity.relatedToId ?? "",
+    relatedToType: activity.relatedToType ?? 2,
+    status,
+    subject: activity.subject ?? "Untitled activity",
+    title: activity.subject ?? "Untitled activity",
+    type: backendActivityTypeToLocal(activity.type, activity.typeName),
+  };
+};
+
+const mapBackendUser = (user: BackendUserDto): ITeamMember => {
+  const fullName =
+    user.fullName?.trim() ||
+    `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() ||
+    user.email?.trim() ||
+    "Team member";
+  const role = user.role ?? user.roles?.[0] ?? "Team member";
+
+  return {
+    availabilityPercent: user.availabilityPercent ?? 70,
+    id: user.id,
+    name: fullName,
+    region: user.region ?? "Unassigned",
+    role,
+    skills: user.skills ?? [],
+  };
+};
+
+const toProposalLineItemPayload = (item: ILineItem) => ({
+  description: item.description ?? null,
+  discount: item.discount ?? 0,
+  productServiceName: item.productServiceName,
+  quantity: item.quantity,
+  taxRate: item.taxRate ?? 0,
+  unitPrice: item.unitPrice,
+});
+
+const buildCreateOpportunityPayload = (opportunity: IOpportunity) => ({
+  clientId: opportunity.clientId,
+  contactId: opportunity.contactId ?? null,
+  currency: opportunity.currency ?? "ZAR",
+  description: opportunity.description ?? null,
+  estimatedValue: opportunity.value ?? opportunity.estimatedValue,
+  expectedCloseDate: toDateTimePayload(opportunity.expectedCloseDate),
+  probability: opportunity.probability,
+  source: opportunity.source ?? 1,
+  stage: localStageToBackend(String(opportunity.stage)),
+  title: opportunity.title,
+});
+
+const buildUpdateOpportunityPayload = (opportunity: IOpportunity) => ({
+  contactId: opportunity.contactId ?? null,
+  currency: opportunity.currency ?? "ZAR",
+  description: opportunity.description ?? null,
+  estimatedValue: opportunity.value ?? opportunity.estimatedValue,
+  expectedCloseDate: toDateTimePayload(opportunity.expectedCloseDate),
+  probability: opportunity.probability,
+  source: opportunity.source ?? 1,
+  title: opportunity.title,
+});
+
+const buildCreateProposalPayload = (proposal: IProposal) => ({
+  currency: proposal.currency ?? "ZAR",
+  description: proposal.description ?? null,
+  lineItems: proposal.lineItems?.map(toProposalLineItemPayload) ?? [],
+  opportunityId: proposal.opportunityId,
+  title: proposal.title,
+  validUntil: toDateTimePayload(proposal.validUntil),
+});
+
+const buildUpdateProposalPayload = (proposal: IProposal) => ({
+  currency: proposal.currency ?? "ZAR",
+  description: proposal.description ?? null,
+  title: proposal.title,
+  validUntil: toDateTimePayload(proposal.validUntil),
+});
+
+const fetchBackend = async <T>(
+  token: string,
+  path: string,
+  init: RequestInit = {},
+): Promise<T> => {
+  const headers = new Headers(init.headers);
+  headers.set("Authorization", `Bearer ${token}`);
+
+  if (init.body && !(init.body instanceof FormData) && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const response = await fetch(createBackendUrl(path), {
+    ...init,
+    headers,
+  });
+
+  if (response.status === 204) {
+    return null as T;
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  const payload = contentType.includes("application/json")
+    ? await response.json()
+    : await response.text();
+
+  if (!response.ok) {
+    throw new Error(
+      extractErrorMessage(payload) ?? `Backend request failed with status ${response.status}.`,
+    );
+  }
+
+  return payload as T;
+};
+
+const tryFetchBackend = async <T>(
+  token: string,
+  path: string,
+  fallback: T,
+  init: RequestInit = {},
+) => {
+  try {
+    return await fetchBackend<T>(token, path, init);
+  } catch (error) {
+    console.warn(`Assistant backend loader skipped ${path}.`, error);
+    return fallback;
+  }
+};
+
+export const isMockAssistantSessionToken = (token?: string | null) =>
+  Boolean(token?.startsWith("mock-token::"));
+
+export const loadAssistantLiveWorkspace = async (user: IMockUser, token: string) => {
+  const teamPath = `/api/Users?pageNumber=1&pageSize=100&isActive=true${
+    user.role === "SalesRep" ? "&role=SalesRep" : ""
+  }`;
+
+  const [
+    clientsPayload,
+    contactsPayload,
+    opportunitiesPayload,
+    proposalsPayload,
+    activitiesPayload,
+    pricingRequestsPayload,
+    teamMembersPayload,
+    notesPayload,
+  ] = await Promise.all([
+    fetchBackend<BackendPagedResult<BackendClientDto> | BackendClientDto[]>(token, "/api/Clients?pageNumber=1&pageSize=100"),
+    tryFetchBackend<BackendPagedResult<BackendContactDto> | BackendContactDto[]>(
+      token,
+      "/api/Contacts?pageNumber=1&pageSize=100",
+      [],
+    ),
+    fetchBackend<BackendPagedResult<BackendOpportunityDto> | BackendOpportunityDto[]>(token, "/api/Opportunities?pageNumber=1&pageSize=100"),
+    fetchBackend<BackendPagedResult<BackendProposalDto> | BackendProposalDto[]>(token, "/api/Proposals?pageNumber=1&pageSize=100"),
+    tryFetchBackend<BackendPagedResult<BackendActivityDto> | BackendActivityDto[]>(
+      token,
+      "/api/Activities?pageNumber=1&pageSize=100",
+      [],
+    ),
+    tryFetchBackend<BackendPagedResult<BackendPricingRequestDto> | BackendPricingRequestDto[]>(
+      token,
+      "/api/PricingRequests?pageNumber=1&pageSize=100",
+      [],
+    ),
+    fetchBackend<BackendPagedResult<BackendUserDto> | BackendUserDto[]>(token, teamPath),
+    tryFetchBackend<{ items?: INoteItem[] } | INoteItem[]>(token, "/api/Notes", []),
+  ]);
+
+  const salesData: ISalesData = {
+    activities: coerceItems(activitiesPayload).map(mapBackendActivity),
+    automationFeed: [],
+    clients: coerceItems(clientsPayload).map(mapBackendClient),
+    contacts: coerceItems(contactsPayload).map(mapBackendContact),
+    contracts: [],
+    opportunities: coerceItems(opportunitiesPayload).map(mapBackendOpportunity),
+    proposals: coerceItems(proposalsPayload).map(mapBackendProposal),
+    renewals: [],
+    teamMembers: coerceItems(teamMembersPayload).map(mapBackendUser),
+  };
+
+  return {
+    documents: [],
+    notes: coerceItems(notesPayload),
+    pricingRequests: coerceItems(pricingRequestsPayload).map(mapBackendPricingRequest),
+    salesData,
+  };
+};
+
+export const createLiveOpportunity = async (token: string, payload: IOpportunity) => {
+  let opportunity = mapBackendOpportunity(
+    await fetchBackend<BackendOpportunityDto>(token, "/api/Opportunities", {
+      body: JSON.stringify(buildCreateOpportunityPayload(payload)),
+      method: "POST",
+    }),
+  );
+
+  if (payload.ownerId) {
+    await fetchBackend<void>(token, `/api/Opportunities/${opportunity.id}/assign`, {
+      body: JSON.stringify({ userId: payload.ownerId }),
+      method: "PUT",
+    });
+  }
+
+  if (payload.stage && String(payload.stage) !== OpportunityStage.New) {
+    await fetchBackend<void>(token, `/api/Opportunities/${opportunity.id}/stage`, {
+      body: JSON.stringify({
+        lossReason: null,
+        notes: null,
+        stage: localStageToBackend(String(payload.stage)),
+      }),
+      method: "PUT",
+    });
+  }
+
+  opportunity = mapBackendOpportunity(
+    await fetchBackend<BackendOpportunityDto>(token, `/api/Opportunities/${opportunity.id}`),
+  );
+
+  return opportunity;
+};
+
+export const updateLiveOpportunity = async (token: string, payload: IOpportunity) => {
+  const existing = mapBackendOpportunity(
+    await fetchBackend<BackendOpportunityDto>(token, `/api/Opportunities/${payload.id}`),
+  );
+
+  let opportunity = mapBackendOpportunity(
+    await fetchBackend<BackendOpportunityDto>(token, `/api/Opportunities/${payload.id}`, {
+      body: JSON.stringify(buildUpdateOpportunityPayload(payload)),
+      method: "PUT",
+    }),
+  );
+
+  if (payload.ownerId && payload.ownerId !== existing.ownerId) {
+    await fetchBackend<void>(token, `/api/Opportunities/${payload.id}/assign`, {
+      body: JSON.stringify({ userId: payload.ownerId }),
+      method: "PUT",
+    });
+  }
+
+  if (payload.stage && payload.stage !== existing.stage) {
+    await fetchBackend<void>(token, `/api/Opportunities/${payload.id}/stage`, {
+      body: JSON.stringify({
+        lossReason: null,
+        notes: null,
+        stage: localStageToBackend(String(payload.stage)),
+      }),
+      method: "PUT",
+    });
+  }
+
+  opportunity = mapBackendOpportunity(
+    await fetchBackend<BackendOpportunityDto>(token, `/api/Opportunities/${payload.id}`),
+  );
+
+  return opportunity;
+};
+
+export const deleteLiveOpportunity = async (token: string, opportunityId: string) => {
+  await fetchBackend<void>(token, `/api/Opportunities/${opportunityId}`, {
+    method: "DELETE",
+  });
+};
+
+export const createLiveProposal = async (token: string, payload: IProposal) =>
+  mapBackendProposal(
+    await fetchBackend<BackendProposalDto>(token, "/api/Proposals", {
+      body: JSON.stringify(buildCreateProposalPayload(payload)),
+      method: "POST",
+    }),
+  );
+
+export const updateLiveProposal = async (token: string, payload: IProposal) =>
+  mapBackendProposal(
+    await fetchBackend<BackendProposalDto>(token, `/api/Proposals/${payload.id}`, {
+      body: JSON.stringify(buildUpdateProposalPayload(payload)),
+      method: "PUT",
+    }),
+  );
+
+export const deleteLiveProposal = async (token: string, proposalId: string) => {
+  await fetchBackend<void>(token, `/api/Proposals/${proposalId}`, {
+    method: "DELETE",
+  });
+};

--- a/lib/server/assistant-config.ts
+++ b/lib/server/assistant-config.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-export type AssistantProvider = "groq" | "openai";
+export type AssistantProvider = "gemini" | "groq" | "openai";
 export type AssistantServerConfig = {
   apiKey: string;
   baseUrl: string;
@@ -13,13 +13,15 @@ export type AssistantServerConfig = {
 
 const OPENAI_BASE_URL = "https://api.openai.com/v1";
 const GROQ_BASE_URL = "https://api.groq.com/openai/v1";
+const GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai";
 const DEFAULT_OPENAI_MODEL = process.env.OPENAI_ASSISTANT_MODEL ?? "gpt-5.4-mini";
 const DEFAULT_GROQ_MODEL = process.env.GROQ_ASSISTANT_MODEL ?? "openai/gpt-oss-20b";
+const DEFAULT_GEMINI_MODEL = process.env.GEMINI_ASSISTANT_MODEL ?? "gemini-2.5-flash";
 
 const normalizeProvider = (value: string | undefined): AssistantProvider | null => {
   const normalized = value?.trim().toLowerCase();
 
-  if (normalized === "groq" || normalized === "openai") {
+  if (normalized === "gemini" || normalized === "groq" || normalized === "openai") {
     return normalized;
   }
 
@@ -30,17 +32,29 @@ const buildProviderConfig = (
   provider: AssistantProvider,
   apiKey: string,
 ): AssistantServerConfig => {
-  const model = provider === "groq" ? DEFAULT_GROQ_MODEL : DEFAULT_OPENAI_MODEL;
+  const model =
+    provider === "groq"
+      ? DEFAULT_GROQ_MODEL
+      : provider === "gemini"
+        ? DEFAULT_GEMINI_MODEL
+        : DEFAULT_OPENAI_MODEL;
   const reason =
     apiKey.length > 0
       ? null
       : provider === "groq"
         ? "Missing GROQ_API_KEY in the server environment."
-        : "Missing OPENAI_API_KEY in the server environment.";
+        : provider === "gemini"
+          ? "Missing GEMINI_API_KEY in the server environment."
+          : "Missing OPENAI_API_KEY in the server environment.";
 
   return {
     apiKey,
-    baseUrl: provider === "groq" ? GROQ_BASE_URL : OPENAI_BASE_URL,
+    baseUrl:
+      provider === "groq"
+        ? GROQ_BASE_URL
+        : provider === "gemini"
+          ? GEMINI_BASE_URL
+          : OPENAI_BASE_URL,
     isConfigured: apiKey.length > 0,
     model,
     provider,
@@ -53,11 +67,23 @@ export const getAssistantServerConfigs = (): AssistantServerConfig[] => {
   const configuredProvider = normalizeProvider(process.env.ASSISTANT_PROVIDER) ?? "groq";
   const openaiApiKey = process.env.OPENAI_API_KEY?.trim() ?? "";
   const groqApiKey = process.env.GROQ_API_KEY?.trim() ?? "";
+  const geminiApiKey = process.env.GEMINI_API_KEY?.trim() ?? "";
   const preferredOrder: AssistantProvider[] =
-    configuredProvider === "openai" ? ["openai", "groq"] : ["groq", "openai"];
+    configuredProvider === "openai"
+      ? ["openai", "groq", "gemini"]
+      : configuredProvider === "gemini"
+        ? ["gemini", "groq", "openai"]
+        : ["groq", "openai", "gemini"];
 
   return preferredOrder.map((provider) =>
-    buildProviderConfig(provider, provider === "groq" ? groqApiKey : openaiApiKey),
+    buildProviderConfig(
+      provider,
+      provider === "groq"
+        ? groqApiKey
+        : provider === "gemini"
+          ? geminiApiKey
+          : openaiApiKey,
+    ),
   );
 };
 

--- a/lib/server/assistant-openai.ts
+++ b/lib/server/assistant-openai.ts
@@ -55,6 +55,13 @@ import {
   getServiceRequestDetail,
   markServiceRequestUnderReview,
 } from "@/lib/server/service-request-store";
+import {
+  applyLiveServiceRequestClientDecision,
+  applyLiveServiceRequestRepDecision,
+  createLiveServiceRequestAssignments,
+  getLiveServiceRequestDetail,
+  markLiveServiceRequestUnderReview,
+} from "@/lib/server/service-request-backend-store";
 
 export type AssistantMessage = {
   content: string;
@@ -394,6 +401,83 @@ const createAssistantActor = (workspace: IAssistantWorkspace): AssistantActor =>
   tenantId: workspace.tenantId,
   tenantName: workspace.scopeLabel,
 });
+
+const getServiceRequestDetailForWorkspace = async (
+  workspace: IAssistantWorkspace,
+  requestId: string,
+) =>
+  workspace.isLiveBackend && workspace.sessionToken
+    ? getLiveServiceRequestDetail(createAssistantActor(workspace), workspace.sessionToken, requestId)
+    : Promise.resolve(getServiceRequestDetail(createAssistantActor(workspace), requestId));
+
+const markServiceRequestUnderReviewForWorkspace = async (
+  workspace: IAssistantWorkspace,
+  requestId: string,
+) =>
+  workspace.isLiveBackend && workspace.sessionToken
+    ? markLiveServiceRequestUnderReview(
+        createAssistantActor(workspace),
+        workspace.sessionToken,
+        requestId,
+      )
+    : Promise.resolve(markServiceRequestUnderReview(createAssistantActor(workspace), requestId));
+
+const createServiceRequestAssignmentsForWorkspace = async (
+  workspace: IAssistantWorkspace,
+  requestId: string,
+  input: {
+    note?: string;
+    representativeUserIds: string[];
+  },
+) =>
+  workspace.isLiveBackend && workspace.sessionToken
+    ? createLiveServiceRequestAssignments(
+        createAssistantActor(workspace),
+        workspace.sessionToken,
+        requestId,
+        input,
+      )
+    : Promise.resolve(
+        createServiceRequestAssignments(createAssistantActor(workspace), requestId, input),
+      );
+
+const applyClientDecisionForWorkspace = async (
+  workspace: IAssistantWorkspace,
+  requestId: string,
+  input: {
+    assignmentIds: string[];
+    decision: "approve" | "reject";
+  },
+) =>
+  workspace.isLiveBackend && workspace.sessionToken
+    ? applyLiveServiceRequestClientDecision(
+        createAssistantActor(workspace),
+        workspace.sessionToken,
+        requestId,
+        input,
+      )
+    : Promise.resolve(
+        applyServiceRequestClientDecision(createAssistantActor(workspace), requestId, input),
+      );
+
+const applyRepresentativeDecisionForWorkspace = async (
+  workspace: IAssistantWorkspace,
+  requestId: string,
+  input: {
+    assignmentId: string;
+    decision: "accept" | "reject";
+  },
+) =>
+  workspace.isLiveBackend && workspace.sessionToken
+    ? applyLiveServiceRequestRepDecision(
+        createAssistantActor(workspace),
+        workspace.sessionToken,
+        requestId,
+        input,
+      )
+    : Promise.resolve(
+        applyServiceRequestRepDecision(createAssistantActor(workspace), requestId, input),
+      );
 
 const toIsoDate = (value: Date) => value.toISOString().split("T")[0];
 
@@ -1363,7 +1447,7 @@ const isRepresentativeDecisionIntent = (message: string) => {
   return null;
 };
 
-const createClientAssignmentDecisionConfirmationReply = (
+const createClientAssignmentDecisionConfirmationReply = async (
   latestUserMessage: string,
   workspace: IAssistantWorkspace,
 ) => {
@@ -1383,7 +1467,7 @@ const createClientAssignmentDecisionConfirmationReply = (
     return null;
   }
 
-  const detail = getServiceRequestDetail(createAssistantActor(workspace), request.id);
+  const detail = await getServiceRequestDetailForWorkspace(workspace, request.id);
   const assignmentIds = detail.assignments.map((assignment) => assignment.id);
 
   if (assignmentIds.length === 0) {
@@ -1441,7 +1525,7 @@ const getRecentPendingClientAssignmentDecisionRequest = (
   };
 };
 
-const createRepresentativeDecisionConfirmationReply = (
+const createRepresentativeDecisionConfirmationReply = async (
   latestUserMessage: string,
   workspace: IAssistantWorkspace,
 ) => {
@@ -1461,7 +1545,7 @@ const createRepresentativeDecisionConfirmationReply = (
     return null;
   }
 
-  const detail = getServiceRequestDetail(createAssistantActor(workspace), request.id);
+  const detail = await getServiceRequestDetailForWorkspace(workspace, request.id);
   const assignment =
     detail.assignments.find(
       (item) =>
@@ -1930,7 +2014,7 @@ const createConfirmationResult = (
   ] satisfies AssistantTraceStep[],
 });
 
-const createMutationConfirmationReply = (
+const createMutationConfirmationReply = async (
   latestUserMessage: string,
   workspace: IAssistantWorkspace,
   messages: AssistantMessage[],
@@ -2057,14 +2141,14 @@ const createMutationConfirmationReply = (
   }
 
   const clientAssignmentDecisionConfirmationResult =
-    createClientAssignmentDecisionConfirmationReply(latestUserMessage, workspace);
+    await createClientAssignmentDecisionConfirmationReply(latestUserMessage, workspace);
 
   if (clientAssignmentDecisionConfirmationResult) {
     return clientAssignmentDecisionConfirmationResult;
   }
 
   const representativeDecisionConfirmationResult =
-    createRepresentativeDecisionConfirmationReply(latestUserMessage, workspace);
+    await createRepresentativeDecisionConfirmationReply(latestUserMessage, workspace);
 
   if (representativeDecisionConfirmationResult) {
     return representativeDecisionConfirmationResult;
@@ -2214,7 +2298,7 @@ const shouldRunClientRequestAssignmentWorkflow = (
   isConfirmationMessage(latestUserMessage) &&
   Boolean(getRecentClientRequestAssignmentPlan(messages, workspace));
 
-const createClientRequestAssignmentResult = (
+const createClientRequestAssignmentResult = async (
   workspace: IAssistantWorkspace,
   messages: AssistantMessage[],
 ) => {
@@ -2224,15 +2308,21 @@ const createClientRequestAssignmentResult = (
     return null;
   }
 
-  const actor = createAssistantActor(workspace);
-  const reviewedRequest = markServiceRequestUnderReview(actor, plan.request.id);
-  const createdAssignments = createServiceRequestAssignments(actor, plan.request.id, {
+  const reviewedRequest = await markServiceRequestUnderReviewForWorkspace(
+    workspace,
+    plan.request.id,
+  );
+  const createdAssignments = await createServiceRequestAssignmentsForWorkspace(
+    workspace,
+    plan.request.id,
+    {
     note:
       plan.opportunity
         ? `Linked to ${plan.opportunity.title}.`
         : "Follow up on the requested support.",
     representativeUserIds: plan.representatives.map((member) => member.id),
-  });
+    },
+  );
   workspace.serviceRequests = workspace.serviceRequests.map((request) =>
     request.id === reviewedRequest.id ? reviewedRequest : request,
   );
@@ -2565,7 +2655,7 @@ const shouldRunConfirmedClientAssignmentDecisionWorkflow = (
   isConfirmationMessage(latestUserMessage) &&
   Boolean(getRecentPendingClientAssignmentDecisionRequest(messages));
 
-const createConfirmedClientAssignmentDecisionResult = (
+const createConfirmedClientAssignmentDecisionResult = async (
   workspace: IAssistantWorkspace,
   messages: AssistantMessage[],
 ) => {
@@ -2575,14 +2665,10 @@ const createConfirmedClientAssignmentDecisionResult = (
     return null;
   }
 
-  const updated = applyServiceRequestClientDecision(
-    createAssistantActor(workspace),
-    request.requestId,
-    {
-      assignmentIds: request.assignmentIds,
-      decision: request.decision,
-    },
-  );
+  const updated = await applyClientDecisionForWorkspace(workspace, request.requestId, {
+    assignmentIds: request.assignmentIds,
+    decision: request.decision,
+  });
 
   workspace.serviceRequests = workspace.serviceRequests.map((item) =>
     item.id === updated.id ? updated : item,
@@ -2632,7 +2718,7 @@ const shouldRunConfirmedRepresentativeDecisionWorkflow = (
   isConfirmationMessage(latestUserMessage) &&
   Boolean(getRecentPendingRepresentativeDecisionRequest(messages));
 
-const createConfirmedRepresentativeDecisionResult = (
+const createConfirmedRepresentativeDecisionResult = async (
   workspace: IAssistantWorkspace,
   messages: AssistantMessage[],
 ) => {
@@ -2642,8 +2728,8 @@ const createConfirmedRepresentativeDecisionResult = (
     return null;
   }
 
-  const updated = applyServiceRequestRepDecision(
-    createAssistantActor(workspace),
+  const updated = await applyRepresentativeDecisionForWorkspace(
+    workspace,
     request.requestId,
     {
       assignmentId: request.assignmentId,
@@ -7359,7 +7445,7 @@ export const runSecureAssistant = async ({
         })()
       : null);
 
-  const mutationConfirmationResult = createMutationConfirmationReply(
+  const mutationConfirmationResult = await createMutationConfirmationReply(
     latestUserMessage,
     workspace,
     messages,
@@ -7422,7 +7508,7 @@ export const runSecureAssistant = async ({
     messages,
     workspace,
   )
-    ? createClientRequestAssignmentResult(workspace, messages)
+    ? await createClientRequestAssignmentResult(workspace, messages)
     : null;
 
   if (confirmedClientRequestAssignmentResult) {
@@ -7431,7 +7517,7 @@ export const runSecureAssistant = async ({
 
   const confirmedClientAssignmentDecisionResult =
     shouldRunConfirmedClientAssignmentDecisionWorkflow(latestUserMessage, messages)
-      ? createConfirmedClientAssignmentDecisionResult(workspace, messages)
+      ? await createConfirmedClientAssignmentDecisionResult(workspace, messages)
       : null;
 
   if (confirmedClientAssignmentDecisionResult) {
@@ -7440,7 +7526,7 @@ export const runSecureAssistant = async ({
 
   const confirmedRepresentativeDecisionResult =
     shouldRunConfirmedRepresentativeDecisionWorkflow(latestUserMessage, messages)
-      ? createConfirmedRepresentativeDecisionResult(workspace, messages)
+      ? await createConfirmedRepresentativeDecisionResult(workspace, messages)
       : null;
 
   if (confirmedRepresentativeDecisionResult) {

--- a/lib/server/assistant-openai.ts
+++ b/lib/server/assistant-openai.ts
@@ -24,6 +24,7 @@ import {
   createLiveProposal,
   deleteLiveOpportunity,
   deleteLiveProposal,
+  updateLiveOpportunity,
   updateLiveProposal,
 } from "@/lib/server/assistant-backend";
 import {
@@ -51,6 +52,9 @@ import {
 import {
   applyServiceRequestClientDecision,
   applyServiceRequestRepDecision,
+  attachOpportunityToServiceRequest,
+  attachProposalToServiceRequest,
+  createServiceRequest,
   createServiceRequestAssignments,
   getServiceRequestDetail,
   markServiceRequestUnderReview,
@@ -58,6 +62,9 @@ import {
 import {
   applyLiveServiceRequestClientDecision,
   applyLiveServiceRequestRepDecision,
+  attachLiveOpportunityToServiceRequest,
+  attachLiveProposalToServiceRequest,
+  createLiveServiceRequest,
   createLiveServiceRequestAssignments,
   getLiveServiceRequestDetail,
   markLiveServiceRequestUnderReview,
@@ -247,6 +254,43 @@ type PendingOpportunityCreateRequest = {
   title: string | null;
 };
 
+type PendingOpportunityEditRequest = {
+  estimatedValue: number | null;
+  expectedCloseDate: string | null;
+  opportunityId: string | null;
+  opportunityTitle: string | null;
+  ownerId: string | null;
+  ownerName: string | null;
+  stage: string | null;
+  title: string | null;
+};
+
+type PendingServiceRequestCreateRequest = {
+  clientId: string | null;
+  clientName: string | null;
+  description: string | null;
+  priority: "critical" | "high" | "low" | "medium";
+  requestType: string | null;
+  title: string | null;
+};
+
+type PendingAdminRequestHandlingRequest = {
+  clientId: string | null;
+  clientName: string | null;
+  createOpportunity: boolean;
+  createProposal: boolean;
+  estimatedValue: number | null;
+  expectedCloseDate: string | null;
+  opportunityTitle: string | null;
+  ownerId: string | null;
+  ownerName: string | null;
+  proposalTitle: string | null;
+  proposalValidUntil: string | null;
+  requestId: string | null;
+  requestTitle: string | null;
+  stage: string | null;
+};
+
 type WorkloadBoostPlan = {
   movedActivities: IAssistantWorkspace["salesData"]["activities"];
   opportunity: IAssistantWorkspace["salesData"]["opportunities"][number];
@@ -371,8 +415,8 @@ const normalizeLimit = (value: unknown, fallback: number, max: number) => {
   return Math.min(Math.round(parsed), max);
 };
 
-const normalizeLookupValue = (value: string) =>
-  value
+const normalizeLookupValue = (value: string | null | undefined) =>
+  (value ?? "")
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, " ")
     .trim();
@@ -439,6 +483,72 @@ const createServiceRequestAssignmentsForWorkspace = async (
       )
     : Promise.resolve(
         createServiceRequestAssignments(createAssistantActor(workspace), requestId, input),
+      );
+
+const createServiceRequestForWorkspace = async (
+  workspace: IAssistantWorkspace,
+  input: {
+    clientId: string;
+    description: string;
+    priority?: "critical" | "high" | "low" | "medium";
+    requestType?: string;
+    source?: "assistant" | "client_portal" | "workspace";
+    title: string;
+  },
+) =>
+  workspace.isLiveBackend && workspace.sessionToken
+    ? createLiveServiceRequest(
+        createAssistantActor(workspace),
+        workspace.sessionToken,
+        input,
+      )
+    : Promise.resolve(createServiceRequest(createAssistantActor(workspace), input));
+
+const attachOpportunityToServiceRequestForWorkspace = async (
+  workspace: IAssistantWorkspace,
+  requestId: string,
+  input: {
+    estimatedValue?: number;
+    expectedCloseDate?: string;
+    mode: "create" | "link";
+    opportunityId?: string;
+    ownerId?: string;
+    stage?: string;
+    title?: string;
+  },
+) =>
+  workspace.isLiveBackend && workspace.sessionToken
+    ? attachLiveOpportunityToServiceRequest(
+        createAssistantActor(workspace),
+        workspace.sessionToken,
+        requestId,
+        input,
+      )
+    : Promise.resolve(
+        attachOpportunityToServiceRequest(createAssistantActor(workspace), requestId, input),
+      );
+
+const attachProposalToServiceRequestForWorkspace = async (
+  workspace: IAssistantWorkspace,
+  requestId: string,
+  input: {
+    currency?: string;
+    description?: string;
+    mode: "create" | "link";
+    proposalId?: string;
+    title?: string;
+    validUntil?: string;
+  },
+) =>
+  workspace.isLiveBackend && workspace.sessionToken
+    ? attachLiveProposalToServiceRequest(
+        createAssistantActor(workspace),
+        workspace.sessionToken,
+        requestId,
+        input,
+      )
+    : Promise.resolve(
+        attachProposalToServiceRequest(createAssistantActor(workspace), requestId, input),
       );
 
 const applyClientDecisionForWorkspace = async (
@@ -527,26 +637,174 @@ const parseCurrencyNumber = (value: string) => {
   return Number.isFinite(parsed) ? parsed : 0;
 };
 
+const extractStructuredField = (message: string, labels: string[]) => {
+  for (const label of labels) {
+    const match = message.match(
+      new RegExp(`\\b${label}\\s*:\\s*([^\\n\\r]+)`, "i"),
+    )?.[1]?.trim();
+
+    if (match) {
+      return match;
+    }
+  }
+
+  return null;
+};
+
+const extractEmailAddress = (message: string) =>
+  message.match(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i)?.[0]?.trim() ?? null;
+
+const extractPlainEnglishClientName = (message: string) =>
+  message.match(/\b(?:sale|deal|opportunity|proposal|client|prospect)\s+for\s+([A-Z][A-Za-z0-9&.' -]{2,60}?)(?=[,.]|\s+(?:with|worth|value|deadline|by|who|where|and)\b|$)/i)?.[1]?.trim() ??
+  message.match(/\bfor\s+([A-Z][A-Za-z0-9&.' -]{2,60}?)(?=[,.]|\s+(?:with|worth|value|deadline|by|who|where|and)\b|$)/i)?.[1]?.trim() ??
+  null;
+
+const extractPlainEnglishContactName = (message: string) =>
+  message.match(/\bcontact(?: person)?\s+(?:is\s+)?([A-Z][A-Za-z.'-]+(?:\s+[A-Z][A-Za-z.'-]+){1,3})/i)?.[1]?.trim() ??
+  message.match(/\b([A-Z][A-Za-z.'-]+(?:\s+[A-Z][A-Za-z.'-]+){1,3})\s+is\s+(?:the\s+)?[A-Za-z][A-Za-z\s-]{2,60}?,?\s+email\b/i)?.[1]?.trim() ??
+  message.match(/\bwith\s+([A-Z][A-Za-z.'-]+(?:\s+[A-Z][A-Za-z.'-]+){1,3})\b/i)?.[1]?.trim() ??
+  null;
+
+const extractPlainEnglishContactRole = (message: string) =>
+  message.match(/\b(?:is|as)\s+(?:the\s+)?([A-Za-z][A-Za-z/&,\s-]{3,80}?)(?=,?\s+email\b|,?\s+at\b|,?\s+who\b|[.])/i)?.[1]?.trim() ??
+  null;
+
+const sanitizePlainEnglishContactName = (
+  candidate: string | null,
+  clientName: string | null,
+) => {
+  if (!candidate) {
+    return null;
+  }
+
+  let next = candidate.trim();
+
+  if (next.includes(".")) {
+    next = next.split(".").slice(-1)[0]?.trim() ?? next;
+  }
+
+  if (clientName) {
+    const escapedClientName = clientName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    next = next.replace(new RegExp(`^${escapedClientName}\\s+`, "i"), "").trim();
+  }
+
+  const normalizedWords = next
+    .split(/\s+/)
+    .map((word) => word.replace(/^[^A-Za-z]+|[^A-Za-z.'-]+$/g, ""))
+    .filter(Boolean);
+
+  if (normalizedWords.length < 2) {
+    return next || null;
+  }
+
+  return normalizedWords.slice(0, 4).join(" ");
+};
+
+const normalizeContactRole = (role: string | null) => {
+  if (!role) {
+    return null;
+  }
+
+  const normalized = role
+    .trim()
+    .replace(/\s+/g, " ")
+    .split(" ")
+    .map((word) => {
+      if (!word) {
+        return word;
+      }
+
+      if (word === "&" || word === "/") {
+        return word;
+      }
+
+      return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+    })
+    .join(" ");
+
+  return normalized || null;
+};
+
+const extractPlainEnglishWants = (message: string) => {
+  const raw =
+    message.match(/\b(?:they want|wants|needs|looking for|looking to|need)\s+([\s\S]+?)(?=[.](?:\s|$)|\b(?:offer value|worth|value|deadline|close date|by)\b)/i)?.[1]?.trim() ??
+    null;
+
+  if (!raw) {
+    return [];
+  }
+
+  return raw
+    .split(/,|;|\band\b/i)
+    .map((item) => item.replace(/^to\s+/i, "").trim())
+    .filter(Boolean);
+};
+
+const hasPlainEnglishSaleIntent = (message: string) =>
+  /\b(?:create|launch|open|set up|start|build|prepare)\b/i.test(message) &&
+  /\b(?:sale|deal|opportunity|proposal|client)\b/i.test(message);
+
 const parseAutonomousSaleRequest = (message: string): AutonomousSaleRequest | null => {
-  if (!/create a new sale/i.test(message)) {
+  const hasLegacyTrigger = /create a new sale/i.test(message);
+  const hasStructuredFields =
+    /\bclient(?: name)?\s*:/i.test(message) &&
+    /\bcontact\s*:/i.test(message) &&
+    /\bemail\s*:/i.test(message) &&
+    /\boffer value\s*:/i.test(message) &&
+    /\bdeadline\s*:/i.test(message);
+  const hasSpecTrigger =
+    /\b(?:sales spec|sale spec|sales brief|create sale from spec|launch sale from spec)\b/i.test(
+      message,
+    ) || hasStructuredFields;
+  const hasPlainEnglishTrigger =
+    hasPlainEnglishSaleIntent(message) &&
+    Boolean(extractEmailAddress(message)) &&
+    (Boolean(message.match(/\b(?:r|zar)\s*[:\-]?\s*\d/i)) ||
+      Boolean(message.match(/\b(?:worth|value)\s+(?:r|zar)?\s*\d/i))) &&
+    Boolean(
+      message.match(/\b(?:deadline|close date|target date|by)\s*(?:is|on|to)?\s*[:\-]?\s*(\d{4}-\d{2}-\d{2}|\d{1,2}\s+[a-z]+\s+(?:\d{4}|this year))/i),
+    );
+
+  if (!hasLegacyTrigger && !hasSpecTrigger && !hasPlainEnglishTrigger) {
     return null;
   }
 
   const clientName =
     message.match(/create a new sale for\s+(.+?)(?:\.|\n)/i)?.[1]?.trim() ??
-    message.match(/client(?: name)?:\s*(.+)/i)?.[1]?.trim();
-  const contactName = message.match(/contact:\s*(.+)/i)?.[1]?.trim();
-  const contactEmail = message.match(/email:\s*([^\s]+)/i)?.[1]?.trim();
-  const contactRole = message.match(/role:\s*(.+)/i)?.[1]?.trim();
-  const offerValueRaw = message.match(/offer value:\s*([\s\S]*?)deadline:/i)?.[1]?.trim();
-  const deadline = message.match(/deadline:\s*([\s\S]*?)(?:assign|return|$)/i)?.[1]
-    ?.match(/(\d{4}-\d{2}-\d{2})/)?.[1];
+    extractStructuredField(message, ["client(?: name)?"]) ??
+    extractPlainEnglishClientName(message);
+  const contactName = sanitizePlainEnglishContactName(
+    extractStructuredField(message, ["contact"]) ?? extractPlainEnglishContactName(message),
+    clientName,
+  );
+  const contactEmail = extractStructuredField(message, ["email"]) ?? extractEmailAddress(message);
+  const contactRole = normalizeContactRole(
+    extractStructuredField(message, ["role"]) ?? extractPlainEnglishContactRole(message),
+  );
+  const offerValueRaw = extractStructuredField(message, ["offer value", "deal value", "value"]);
+  const deadline = (() => {
+    const raw = extractStructuredField(message, ["deadline", "close date", "target date"]);
+    if (raw) {
+      return parseDateReference(raw);
+    }
+
+    const plainEnglishDate =
+      message.match(/\b(?:deadline|close date|target date|by)\s*(?:is|on|to)?\s*[:\-]?\s*([a-z0-9\s,-]+)/i)?.[1]?.trim() ??
+      null;
+
+    return plainEnglishDate ? parseDateReference(plainEnglishDate) : null;
+  })();
   const wantsBlock = message.match(/what they want:\s*([\s\S]*?)offer value:/i)?.[1] ?? "";
-  const wants = wantsBlock
-    .split(/\r?\n/)
+  const wantsFromField = extractStructuredField(message, ["what they want", "scope", "needs"]);
+  const wants = (wantsBlock || wantsFromField || "")
+    .split(/\r?\n|[,;]+/)
     .map((line) => line.replace(/^[-*]\s*/, "").trim())
     .filter(Boolean);
-  const offerValue = offerValueRaw ? parseCurrencyNumber(offerValueRaw) : 0;
+  const fallbackWants = wants.length > 0 ? wants : extractPlainEnglishWants(message);
+  const offerValue =
+    offerValueRaw
+      ? parseCurrencyNumber(offerValueRaw)
+      : extractOpportunityEstimatedValue(message) ?? 0;
 
   if (!clientName || !contactName || !contactEmail || !deadline || offerValue <= 0) {
     return null;
@@ -556,10 +814,10 @@ const parseAutonomousSaleRequest = (message: string): AutonomousSaleRequest | nu
     clientName,
     contactEmail,
     contactName,
-    contactRole,
+    contactRole: contactRole ?? undefined,
     deadline,
     offerValue,
-    wants,
+    wants: fallbackWants,
   };
 };
 
@@ -759,6 +1017,10 @@ const isProposalDraftIntent = (message: string) => {
     normalized.includes("create a draft proposal") ||
     normalized.includes("create draft proposal") ||
     normalized.includes("create a proposal") ||
+    normalized.includes("prepare a proposal") ||
+    normalized.includes("put together a proposal") ||
+    normalized.includes("draft a proposal") ||
+    normalized.includes("new proposal") ||
     normalized.includes("new draft proposal") ||
     normalized.includes("fresh draft proposal")
   );
@@ -782,11 +1044,13 @@ const extractProposalTitle = (message: string) =>
   message.match(/\btitle\s+(?:is|to)\s+["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim() ??
   message.match(/\b(?:rename|call)\s+(?:it|the proposal)\s+["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim() ??
   message.match(/\bdraft proposal titled\s+["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim() ??
+  message.match(/\bproposal(?: called| named| title is)?\s+["“]?(.+?)["”]?(?=\s+(?:for|with|valid until|expires|expiry|by)\b|$|\n)/i)?.[1]?.trim() ??
   null;
 
 const extractProposalValidUntil = (message: string) => {
   const raw =
     message.match(/\b(?:expire|expires|expiry|valid until)\s*(?:on)?\s*[:\-]?\s*([\s\S]+)$/i)?.[1]?.trim() ??
+    message.match(/\b(?:deadline|due|by)\s*(?:is|on|to)?\s*[:\-]?\s*([a-z0-9\s,-]+)/i)?.[1]?.trim() ??
     null;
 
   return raw ? parseDateReference(raw) : null;
@@ -800,7 +1064,118 @@ const isOpportunityCreateIntent = (message: string) => {
     normalized.includes("create new opportunity") ||
     normalized.includes("create an opportunity") ||
     normalized.includes("create opportunity") ||
+    normalized.includes("start a new opportunity") ||
+    normalized.includes("open a new opportunity") ||
+    normalized.includes("add a new opportunity") ||
+    normalized.includes("add opportunity") ||
+    normalized.includes("create a new deal") ||
+    normalized.includes("create new deal") ||
+    normalized.includes("set up a new deal") ||
+    normalized.includes("open a deal") ||
+    normalized.includes("set up a deal") ||
+    normalized.includes("start a new deal") ||
+    normalized.includes("start a deal") ||
     normalized.includes("new opportunity")
+  );
+};
+
+const isOpportunityEditIntent = (message: string) => {
+  const normalized = normalizeLookupValue(message);
+
+  return (
+    normalized.includes("rename opportunity") ||
+    normalized.includes("update opportunity") ||
+    normalized.includes("edit opportunity") ||
+    normalized.includes("change opportunity") ||
+    normalized.includes("change the opportunity") ||
+    normalized.includes("change the name of") ||
+    normalized.includes("rename it") ||
+    normalized.includes("change it to") ||
+    normalized.includes("name should be") ||
+    normalized.includes("must be changed to") ||
+    normalized.includes("should be changed to") ||
+    normalized.includes("name must be changed to") ||
+    normalized.includes("title should be") ||
+    normalized.includes("title must be")
+  );
+};
+
+const isClientRequestCreateIntent = (
+  message: string,
+  workspace: IAssistantWorkspace,
+) => {
+  const normalized = normalizeLookupValue(message);
+
+  if (!isClientScopedUser(workspace.clientIds)) {
+    return (
+      !isAdminRequestHandlingIntent(message) &&
+      !["review", "handle", "process", "assign", "triage"].some((token) =>
+        normalized.includes(token),
+      ) &&
+      ["submit", "log", "open", "create"].some((token) => normalized.includes(token)) &&
+      (normalized.includes("client request") || normalized.includes("service request"))
+    );
+  }
+
+  return (
+    normalized.includes("client request") ||
+    normalized.includes("service request") ||
+    normalized.includes("need help") ||
+    normalized.includes("need support") ||
+    normalized.includes("need a proposal") ||
+    normalized.includes("need pricing") ||
+    normalized.includes("looking for help") ||
+    normalized.includes("looking for support") ||
+    normalized.includes("please help us") ||
+    normalized.includes("we need")
+  );
+};
+
+const isAdminRequestHandlingIntent = (message: string) => {
+  const normalized = normalizeLookupValue(message);
+
+  return (
+    ["review", "handle", "process", "work on", "take care of", "triage"].some((token) =>
+      normalized.includes(token),
+    ) &&
+    ["request", "client request", "service request", "client needs", "client asked"].some(
+      (token) => normalized.includes(token),
+    )
+  );
+};
+
+const isExplicitStructuredMutationIntent = (message: string) => {
+  const normalized = normalizeLookupValue(message);
+
+  return (
+    isOpportunityCreateIntent(message) ||
+    normalized.includes("create activity") ||
+    normalized.includes("create follow-up") ||
+    normalized.includes("create follow up") ||
+    normalized.includes("add task") ||
+    normalized.includes("create task") ||
+    normalized.includes("create pricing request") ||
+    normalized.includes("add pricing request") ||
+    normalized.includes("new pricing request") ||
+    normalized.includes("create note") ||
+    normalized.includes("add note") ||
+    normalized.includes("record note") ||
+    normalized.includes("update activity") ||
+    normalized.includes("edit activity") ||
+    normalized.includes("update follow-up") ||
+    normalized.includes("edit follow-up") ||
+    normalized.includes("update pricing request") ||
+    normalized.includes("edit pricing request") ||
+    normalized.includes("update note") ||
+    normalized.includes("edit note") ||
+    normalized.includes("delete activity") ||
+    normalized.includes("remove activity") ||
+    normalized.includes("delete follow-up") ||
+    normalized.includes("remove follow-up") ||
+    normalized.includes("delete pricing request") ||
+    normalized.includes("remove pricing request") ||
+    normalized.includes("delete note") ||
+    normalized.includes("remove note")
   );
 };
 
@@ -870,12 +1245,6 @@ const extractOpportunityEstimatedValue = (message: string) => {
 };
 
 const extractOpportunityExpectedCloseDate = (message: string) => {
-  const isoMatch = message.match(/\b(\d{4}-\d{2}-\d{2})\b/);
-
-  if (isoMatch?.[1]) {
-    return isoMatch[1];
-  }
-
   const naturalMatch =
     message.match(/\b(\d{1,2}\s+[a-z]+\s+\d{4})\b/i)?.[1] ??
     message.match(/\b(\d{1,2}\s+[a-z]+\s+this year)\b/i)?.[1] ??
@@ -884,7 +1253,103 @@ const extractOpportunityExpectedCloseDate = (message: string) => {
     )?.[1] ??
     null;
 
-  return naturalMatch ? parseDateReference(naturalMatch) : null;
+  if (naturalMatch) {
+    return parseDateReference(naturalMatch);
+  }
+
+  const isoMatch = message.match(/\b(\d{4}-\d{2}-\d{2})\b/);
+
+  return isoMatch?.[1] ?? null;
+};
+
+const toTitleCase = (value: string) =>
+  value
+    .trim()
+    .replace(/\s+/g, " ")
+    .split(" ")
+    .map((word) => (word ? word.charAt(0).toUpperCase() + word.slice(1).toLowerCase() : word))
+    .join(" ");
+
+const extractServiceRequestPriority = (
+  message: string,
+): PendingServiceRequestCreateRequest["priority"] => {
+  const normalized = normalizeLookupValue(message);
+
+  if (normalized.includes("critical") || normalized.includes("urgent")) {
+    return "critical";
+  }
+
+  if (normalized.includes("high priority") || normalized.includes("high")) {
+    return "high";
+  }
+
+  if (normalized.includes("low priority") || normalized.includes("low")) {
+    return "low";
+  }
+
+  return "medium";
+};
+
+const extractServiceRequestTitle = (message: string, clientName: string | null) => {
+  const explicit =
+    message.match(/\b(?:request|service request)\s+title\s*(?:is|to)?\s*[:\-]?\s*["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim() ??
+    message.match(/\btitle\s*(?:is|to)?\s*[:\-]?\s*["“]?(.+?)["”]?(?=\s+(?:priority|request type|description)\b|$|\n)/i)?.[1]?.trim() ??
+    null;
+
+  if (explicit) {
+    return explicit.replace(/[.\s]+$/, "");
+  }
+
+  const wants = extractPlainEnglishWants(message);
+  const lead = wants[0] ?? null;
+
+  if (lead) {
+    return `${clientName ? `${clientName} ` : ""}${toTitleCase(lead)}`.trim();
+  }
+
+  if (/proposal|quote/i.test(message)) {
+    return `${clientName ? `${clientName} ` : ""}Proposal support`.trim();
+  }
+
+  if (/pricing|commercial/i.test(message)) {
+    return `${clientName ? `${clientName} ` : ""}Pricing support`.trim();
+  }
+
+  return `${clientName ? `${clientName} ` : ""}Support request`.trim();
+};
+
+const sanitizeWorkflowGeneratedTitle = (value: string | null) => {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim().replace(/[.\s]+$/, "");
+  const normalized = normalizeLookupValue(trimmed);
+
+  if (
+    trimmed.length > 90 ||
+    normalized.includes("please review") ||
+    normalized.includes("latest request") ||
+    normalized.includes("assign the best") ||
+    normalized.includes("create an opportunity") ||
+    normalized.includes("create opportunity") ||
+    normalized.includes("create proposal") ||
+    normalized.includes("proposal for it")
+  ) {
+    return null;
+  }
+
+  return trimmed;
+};
+
+const prefixClientNameOnce = (clientName: string | null, title: string) => {
+  if (!clientName) {
+    return title.trim();
+  }
+
+  return normalizeLookupValue(title).startsWith(normalizeLookupValue(clientName))
+    ? title.trim()
+    : `${clientName} ${title}`.trim();
 };
 
 const extractOpportunityStage = (message: string) => {
@@ -912,12 +1377,131 @@ const extractOpportunityStage = (message: string) => {
   return null;
 };
 
+const extractPriorityNumber = (message: string) => {
+  const normalized = normalizeLookupValue(message);
+  const explicit = message.match(/\bpriority\s*(?:is|to)?\s*(\d)\b/i)?.[1];
+
+  if (explicit) {
+    const parsed = Number(explicit);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  if (normalized.includes("critical") || normalized.includes("urgent") || normalized.includes("high priority")) {
+    return 1;
+  }
+
+  if (normalized.includes("low priority")) {
+    return 3;
+  }
+
+  if (normalized.includes("medium priority")) {
+    return 2;
+  }
+
+  return null;
+};
+
+const extractLabeledValue = (message: string, label: string) =>
+  message.match(new RegExp(`\\b${label}\\s*(?:is|to)?\\s*[:\\-]?\\s*["â€œ]?(.+?)["â€]?(?:$|\\n)`, "i"))?.[1]?.trim() ??
+  null;
+
+const extractIdentifierValue = (message: string, label: string) =>
+  message.match(new RegExp(`\\b${label}\\s*(?:is)?\\s*[:\\-]?\\s*([a-z0-9_-]+)`, "i"))?.[1]?.trim() ??
+  null;
+
+const extractGenericDueDate = (message: string) => {
+  const raw =
+    message.match(/\b(?:due|due date|required by|deadline)\s*(?:is|on|to)?\s*[:\-]?\s*([a-z0-9\s,-]+)/i)?.[1]?.trim() ??
+    null;
+
+  return raw ? parseDateReference(raw) : extractOpportunityExpectedCloseDate(message);
+};
+
+const extractNoteTitle = (message: string) =>
+  message.match(/\b(?:note title|title)\s*(?:is|to)?\s*[:\-]?\s*["â€œ]?(.+?)["â€]?(?=\s+(?:that says|saying|content(?: is| to)?)\b|$|\n)/i)?.[1]?.trim().replace(/[.\s]+$/, "") ??
+  null;
+
+const extractActivitySubject = (message: string) =>
+  message.match(/\b(?:subject|activity title|title|task)\s*(?:is|to)?\s*[:\-]?\s*["â€œ]?(.+?)["â€]?(?=\s+(?:opportunity title|due date|assignedtoid|assigned to|priority|description)\b|$|\n)/i)?.[1]?.trim().replace(/[.\s]+$/, "") ??
+  null;
+
+const extractPricingRequestTitle = (message: string) =>
+  message.match(/\b(?:pricing request title|title)\s*(?:is|to)?\s*[:\-]?\s*["â€œ]?(.+?)["â€]?(?=\s+(?:opportunity title|required by|assignedtoid|assigned to|priority|description)\b|$|\n)/i)?.[1]?.trim().replace(/[.\s]+$/, "") ??
+  null;
+
+const extractExplicitOpportunityTitle = (message: string) =>
+  message.match(/\b(?:opportunity|deal)(?:\s+for\s+[A-Z][A-Za-z0-9&.' -]{2,60}?)?\s+called\s+["“]?(.+?)["”]?(?=\s+(?:worth|close|closing|expected close date|date|stage|assign to|and assign|owner)\b|$|\n)/i)?.[1]?.trim().replace(/[.\s]+$/, "") ??
+  message.match(/\bcalled\s+["“]?(.+?)["”]?(?=\s+(?:worth|close|closing|expected close date|date|stage|assign to|and assign|owner)\b|$|\n)/i)?.[1]?.trim().replace(/[.\s]+$/, "") ??
+  message.match(/\bopportunity title\s*(?:is|to)?\s*[:\-]?\s*["“]?(.+?)["”]?(?=\s+(?:worth|close date|expected close date|date|stage|assign to|owner)\b|$|\n)/i)?.[1]?.trim().replace(/[.\s]+$/, "") ??
+  message.match(/\btitle\s*(?:is|to)\s*["“]?(.+?)["”]?(?=\s+(?:worth|close date|expected close date|date|stage|assign to|owner)\b|$|\n)/i)?.[1]?.trim().replace(/[.\s]+$/, "") ??
+  null;
+
+const extractOpportunityEditTitle = (message: string) =>
+  message.match(/\b(?:rename|change)\s+(?:it|this|the opportunity|opportunity\s+["“]?[A-Za-z0-9&.' -]+["”]?)\s+to\s+["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim().replace(/[.\s]+$/, "") ??
+  message.match(/\b(?:name|title)\s+(?:should be|must be(?: changed)? to|needs? to be|to)\s+["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim().replace(/[.\s]+$/, "") ??
+  message.match(/\b(?:name|title)\s+of\s+.+?\s+must\s+be\s+changed\s+to\s+["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim().replace(/[.\s]+$/, "") ??
+  message.match(/\b(?:name|title)\s+of\s+.+?\s+should\s+be\s+changed\s+to\s+["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim().replace(/[.\s]+$/, "") ??
+  message.match(/\bchange\s+the\s+name\s+of\s+.+?\s+to\s+["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim().replace(/[.\s]+$/, "") ??
+  null;
+
+const extractActivityType = (message: string) => {
+  const normalized = normalizeLookupValue(message);
+
+  if (normalized.includes("meeting")) {
+    return "Meeting";
+  }
+
+  if (normalized.includes("call")) {
+    return "Call";
+  }
+
+  if (normalized.includes("email")) {
+    return "Email";
+  }
+
+  return "Task";
+};
+
+const extractNoteContent = (message: string) =>
+  message.match(/\b(?:that says|saying|content is|content to)\s*[:\-]?\s*["â€œ]?(.+?)["â€]?(?:$|\n)/i)?.[1]?.trim() ??
+  message.match(/\bnote\s+(?:that|saying)\s+["â€œ]?(.+?)["â€]?(?:$|\n)/i)?.[1]?.trim() ??
+  null;
+
+const findMentionedNote = (workspace: IAssistantWorkspace, message: string) =>
+  workspace.notes.find((note) => normalizeLookupValue(message).includes(normalizeLookupValue(note.title))) ??
+  workspace.notes.find((note) => normalizeLookupValue(message).includes(normalizeLookupValue(note.id))) ??
+  null;
+
+const findMentionedPricingRequest = (workspace: IAssistantWorkspace, message: string) =>
+  workspace.pricingRequests.find((request) =>
+    normalizeLookupValue(message).includes(normalizeLookupValue(request.title)),
+  ) ??
+  workspace.pricingRequests.find((request) =>
+    normalizeLookupValue(message).includes(normalizeLookupValue(request.id)),
+  ) ??
+  null;
+
+const findMentionedActivity = (workspace: IAssistantWorkspace, message: string) =>
+  workspace.salesData.activities.find((activity) =>
+    normalizeLookupValue(message).includes(normalizeLookupValue(activity.subject)),
+  ) ??
+  workspace.salesData.activities.find((activity) =>
+    normalizeLookupValue(message).includes(normalizeLookupValue(activity.id)),
+  ) ??
+  null;
+
 const extractOpportunityTitle = (
   message: string,
   workspace: IAssistantWorkspace,
   clientName: string | null,
   ownerName: string | null,
 ) => {
+  const directTitle = extractExplicitOpportunityTitle(message);
+
+  if (directTitle) {
+    return directTitle;
+  }
+
   const explicit =
     message.match(/\bopportunity title\s*(?:is|to)?\s*[:\-]?\s*["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim() ??
     message.match(/\bdeal called\s*["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim() ??
@@ -1040,6 +1624,30 @@ const inferPendingProposalDraftRequest = (
     request.validUntil = extractProposalValidUntil(message.content) ?? request.validUntil;
     request.opportunityTitle =
       extractOpportunityReference(message.content, workspace) ?? request.opportunityTitle;
+
+    if (!request.opportunityTitle) {
+      const client =
+        findClientByReferenceInWorkspace(
+          workspace,
+          extractPlainEnglishClientName(message.content),
+        ) ??
+        workspace.salesData.clients.find((item) =>
+          normalizeLookupValue(message.content).includes(normalizeLookupValue(item.name)),
+        ) ??
+        null;
+
+      const latestOpenOpportunity =
+        workspace.salesData.opportunities
+          .filter((item) => (client ? item.clientId === client.id : true))
+          .filter((item) => isOpenOpportunityStage(String(item.stage)))
+          .sort((left, right) => right.createdDate.localeCompare(left.createdDate))[0] ?? null;
+
+      request.opportunityTitle = latestOpenOpportunity?.title ?? request.opportunityTitle;
+
+      if (!request.title && latestOpenOpportunity && client) {
+        request.title = `${client.name} proposal`;
+      }
+    }
   });
 
   const opportunity = findOpportunityByReferenceInWorkspace(workspace, request.opportunityTitle);
@@ -1146,15 +1754,130 @@ const getRecentPendingProposalEditRequest = (
   } satisfies PendingProposalEditRequest;
 };
 
+const inferPendingOpportunityEditRequest = (
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) => {
+  const recentUserMessages = getRecentUserMessages(messages)
+    .filter((message) => !isConfirmationMessage(message.content))
+    .slice(-6);
+  const recentAssistant = lastAssistantContent(messages);
+  const recentOpportunityMutation = [...messages]
+    .reverse()
+    .filter((message) => message.role === "assistant")
+    .flatMap((message) => message.mutations ?? [])
+    .find((mutation) => mutation.entityType === "opportunity" && mutation.operation === "create");
+  const hasEditIntent =
+    recentUserMessages.some((message) => isOpportunityEditIntent(message.content)) &&
+    (normalizeLookupValue(recentAssistant).includes("opportunity") || Boolean(recentOpportunityMutation));
+
+  if (!hasEditIntent) {
+    return null;
+  }
+
+  const request: PendingOpportunityEditRequest = {
+    estimatedValue: null,
+    expectedCloseDate: null,
+    opportunityId: null,
+    opportunityTitle: null,
+    ownerId: null,
+    ownerName: null,
+    stage: null,
+    title: null,
+  };
+
+  recentUserMessages.forEach((message) => {
+    const directOpportunity =
+      findOpportunityByReferenceInWorkspace(workspace, message.content) ??
+      null;
+    const owner =
+      findOwnerByReferenceInWorkspace(workspace, message.content) ??
+      null;
+
+    request.opportunityId = directOpportunity?.id ?? request.opportunityId;
+    request.opportunityTitle = directOpportunity?.title ?? request.opportunityTitle;
+    request.ownerId = owner?.id ?? request.ownerId;
+    request.ownerName = owner?.name ?? request.ownerName;
+    request.title = extractOpportunityEditTitle(message.content) ?? request.title;
+    request.estimatedValue =
+      extractOpportunityEstimatedValue(message.content) ?? request.estimatedValue;
+    request.expectedCloseDate =
+      extractOpportunityExpectedCloseDate(message.content) ?? request.expectedCloseDate;
+    request.stage = extractOpportunityStage(message.content) ?? request.stage;
+  });
+
+  if (!request.opportunityId) {
+    const recentOpportunityId =
+      typeof recentOpportunityMutation?.entityId === "string"
+        ? recentOpportunityMutation.entityId
+        : null;
+    const recentOpportunity =
+      findOpportunityByReferenceInWorkspace(workspace, recentOpportunityId) ??
+      workspace.salesData.opportunities.find((item) => item.id === recentOpportunityId) ??
+      null;
+
+    request.opportunityId = recentOpportunity?.id ?? request.opportunityId;
+    request.opportunityTitle = recentOpportunity?.title ?? request.opportunityTitle;
+  }
+
+  return request;
+};
+
+const getRecentPendingOpportunityEditRequest = (
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) => {
+  const traceStep = [...messages]
+    .reverse()
+    .filter((message) => message.role === "assistant")
+    .flatMap((message) => message.trace ?? [])
+    .find((step) => step.tool === "confirmation_required_opportunity_edit");
+
+  if (!traceStep) {
+    return inferPendingOpportunityEditRequest(messages, workspace);
+  }
+
+  return {
+    estimatedValue:
+      typeof traceStep.arguments.estimatedValue === "number"
+        ? traceStep.arguments.estimatedValue
+        : null,
+    expectedCloseDate:
+      typeof traceStep.arguments.expectedCloseDate === "string"
+        ? traceStep.arguments.expectedCloseDate
+        : null,
+    opportunityId:
+      typeof traceStep.arguments.opportunityId === "string"
+        ? traceStep.arguments.opportunityId
+        : null,
+    opportunityTitle:
+      typeof traceStep.arguments.opportunityTitle === "string"
+        ? traceStep.arguments.opportunityTitle
+        : null,
+    ownerId:
+      typeof traceStep.arguments.ownerId === "string" ? traceStep.arguments.ownerId : null,
+    ownerName:
+      typeof traceStep.arguments.ownerName === "string" ? traceStep.arguments.ownerName : null,
+    stage: typeof traceStep.arguments.stage === "string" ? traceStep.arguments.stage : null,
+    title: typeof traceStep.arguments.title === "string" ? traceStep.arguments.title : null,
+  } satisfies PendingOpportunityEditRequest;
+};
+
 const inferPendingOpportunityCreateRequest = (
   messages: AssistantMessage[],
   workspace: IAssistantWorkspace,
 ) => {
-  const recentUserMessages = getRecentUserMessages(messages).slice(-6);
+  const recentUserMessages = getRecentUserMessages(messages)
+    .filter((message) => !isConfirmationMessage(message.content))
+    .slice(-6);
+  const hasEditIntent = recentUserMessages.some((message) =>
+    isOpportunityEditIntent(message.content),
+  );
   const recentAssistant = lastAssistantContent(messages);
   const confirmedMutationRequest = getRecentConfirmedGenericMutationRequest(messages);
   const hasCreateIntent =
-    recentUserMessages.some((message) => isOpportunityCreateIntent(message.content)) ||
+    (!hasEditIntent &&
+      recentUserMessages.some((message) => isOpportunityCreateIntent(message.content))) ||
     (confirmedMutationRequest ? isOpportunityCreateIntent(confirmedMutationRequest) : false) ||
     normalizeLookupValue(recentAssistant).includes("create the opportunity");
 
@@ -1221,6 +1944,317 @@ const inferPendingOpportunityCreateRequest = (
   }
 
   return request;
+};
+
+const createOpportunityMissingFieldsMessage = (
+  request: PendingOpportunityCreateRequest,
+) => {
+  const missing: string[] = [];
+
+  if (!request.clientId && !request.clientName) {
+    missing.push("the client name or id");
+  }
+
+  if (!request.title) {
+    missing.push("the opportunity name");
+  }
+
+  if (!request.ownerId && !request.ownerName) {
+    missing.push("the owner name or id");
+  }
+
+  if (!request.estimatedValue) {
+    missing.push("the value");
+  }
+
+  if (!request.expectedCloseDate) {
+    missing.push("the expected close date");
+  }
+
+  if (missing.length === 0) {
+    return null;
+  }
+
+  if (missing.length === 1) {
+    return `I can create the opportunity, but I still need ${missing[0]}.`;
+  }
+
+  return `I can create the opportunity, but I still need ${missing.slice(0, -1).join(", ")} and ${missing.at(-1)}.`;
+};
+
+const inferPendingServiceRequestCreateRequest = (
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) => {
+  const recentUserMessages = getRecentUserMessages(messages)
+    .filter((message) => !isConfirmationMessage(message.content))
+    .slice(-6);
+  const hasCreateIntent = recentUserMessages.some((message) =>
+    isClientRequestCreateIntent(message.content, workspace),
+  );
+
+  if (!hasCreateIntent) {
+    return null;
+  }
+
+  const request: PendingServiceRequestCreateRequest = {
+    clientId: workspace.clientIds?.[0] ?? null,
+    clientName: null,
+    description: null,
+    priority: "medium",
+    requestType: "service_request",
+    title: null,
+  };
+
+  recentUserMessages.forEach((message) => {
+    const matchedClient =
+      findClientByReferenceInWorkspace(
+        workspace,
+        extractPlainEnglishClientName(message.content),
+      ) ??
+      workspace.salesData.clients.find((item) =>
+        normalizeLookupValue(message.content).includes(normalizeLookupValue(item.name)),
+      ) ??
+      null;
+
+    request.clientId = matchedClient?.id ?? request.clientId;
+    request.clientName = matchedClient?.name ?? request.clientName;
+    request.priority = extractServiceRequestPriority(message.content);
+    request.description = message.content.trim();
+    request.title =
+      extractServiceRequestTitle(message.content, request.clientName) ?? request.title;
+
+    if (/proposal|quote/i.test(message.content)) {
+      request.requestType = "proposal_support";
+    } else if (/pricing|commercial/i.test(message.content)) {
+      request.requestType = "pricing_support";
+    }
+  });
+
+  if (!request.clientName && request.clientId) {
+    request.clientName =
+      findClientByReferenceInWorkspace(workspace, request.clientId)?.name ?? null;
+  }
+
+  return request;
+};
+
+const getRecentPendingServiceRequestCreateRequest = (
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) => {
+  const traceStep = [...messages]
+    .reverse()
+    .filter((message) => message.role === "assistant")
+    .flatMap((message) => message.trace ?? [])
+    .find((step) => step.tool === "confirmation_required_service_request_create");
+
+  if (!traceStep) {
+    return inferPendingServiceRequestCreateRequest(messages, workspace);
+  }
+
+  return {
+    clientId: typeof traceStep.arguments.clientId === "string" ? traceStep.arguments.clientId : null,
+    clientName:
+      typeof traceStep.arguments.clientName === "string" ? traceStep.arguments.clientName : null,
+    description:
+      typeof traceStep.arguments.description === "string" ? traceStep.arguments.description : null,
+    priority:
+      traceStep.arguments.priority === "critical" ||
+      traceStep.arguments.priority === "high" ||
+      traceStep.arguments.priority === "low"
+        ? traceStep.arguments.priority
+        : "medium",
+    requestType:
+      typeof traceStep.arguments.requestType === "string" ? traceStep.arguments.requestType : null,
+    title: typeof traceStep.arguments.title === "string" ? traceStep.arguments.title : null,
+  } satisfies PendingServiceRequestCreateRequest;
+};
+
+const inferPendingAdminRequestHandlingRequest = (
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) => {
+  if (!isManagerRole(workspace.role) || isClientScopedUser(workspace.clientIds)) {
+    return null;
+  }
+
+  const recentUserMessages = getRecentUserMessages(messages)
+    .filter((message) => !isConfirmationMessage(message.content))
+    .slice(-6);
+  const hasIntent = recentUserMessages.some((message) => isAdminRequestHandlingIntent(message.content));
+
+  if (!hasIntent) {
+    return null;
+  }
+
+  const pendingRequests = getPendingAdminClientRequests(workspace);
+  const request: PendingAdminRequestHandlingRequest = {
+    clientId: null,
+    clientName: null,
+    createOpportunity: false,
+    createProposal: false,
+    estimatedValue: null,
+    expectedCloseDate: null,
+    opportunityTitle: null,
+    ownerId: null,
+    ownerName: null,
+    proposalTitle: null,
+    proposalValidUntil: null,
+    requestId: null,
+    requestTitle: null,
+    stage: null,
+  };
+
+  recentUserMessages.forEach((message) => {
+    const client =
+      findClientByReferenceInWorkspace(
+        workspace,
+        extractPlainEnglishClientName(message.content),
+      ) ??
+      workspace.salesData.clients.find((item) =>
+        normalizeLookupValue(message.content).includes(normalizeLookupValue(item.name)),
+      ) ??
+      null;
+
+    request.clientId = client?.id ?? request.clientId;
+    request.clientName = client?.name ?? request.clientName;
+    request.createOpportunity =
+      request.createOpportunity ||
+      /\b(?:opportunity|deal|sale|pipeline)\b/i.test(message.content);
+    request.createProposal =
+      request.createProposal || /\b(?:proposal|quote)\b/i.test(message.content);
+    request.estimatedValue =
+      extractOpportunityEstimatedValue(message.content) ?? request.estimatedValue;
+    request.expectedCloseDate =
+      extractOpportunityExpectedCloseDate(message.content) ?? request.expectedCloseDate;
+    request.ownerId =
+      findOwnerByReferenceInWorkspace(workspace, message.content)?.id ?? request.ownerId;
+    request.ownerName =
+      findOwnerByReferenceInWorkspace(workspace, message.content)?.name ?? request.ownerName;
+    request.stage = extractOpportunityStage(message.content) ?? request.stage;
+    request.opportunityTitle =
+      extractOpportunityTitle(
+        message.content,
+        workspace,
+        request.clientName,
+        request.ownerName,
+      ) ?? request.opportunityTitle;
+    request.proposalTitle = extractProposalTitle(message.content) ?? request.proposalTitle;
+    request.proposalValidUntil =
+      extractProposalValidUntil(message.content) ?? request.proposalValidUntil;
+
+    const matchedRequest =
+      pendingRequests.find((item) =>
+        request.clientId ? item.clientId === request.clientId : false,
+      ) ??
+      pendingRequests.find((item) =>
+        normalizeLookupValue(message.content).includes(normalizeLookupValue(item.title)),
+      ) ??
+      pendingRequests[0] ??
+      null;
+
+    request.requestId = matchedRequest?.id ?? request.requestId;
+    request.requestTitle = matchedRequest?.title ?? request.requestTitle;
+    request.clientId = matchedRequest?.clientId ?? request.clientId;
+  });
+
+  if (!request.requestId) {
+    return null;
+  }
+
+  const targetRequest = workspace.serviceRequests.find((item) => item.id === request.requestId) ?? null;
+  const targetClient =
+    findClientByReferenceInWorkspace(workspace, request.clientId ?? request.clientName) ?? null;
+  const defaultValue = request.estimatedValue ?? 250_000;
+  const defaultDeadline =
+    request.expectedCloseDate ?? addDays(new Date(), 14).toISOString().split("T")[0];
+  const owner =
+    findOwnerByReferenceInWorkspace(workspace, request.ownerId ?? request.ownerName) ??
+    (targetClient
+      ? getBestOwner(workspace.salesData, defaultValue, targetClient.industry ?? "General", {
+          pricingRequests: workspace.pricingRequests,
+        })
+      : null);
+
+  return {
+    ...request,
+    clientId: targetRequest?.clientId ?? request.clientId,
+    clientName: targetClient?.name ?? request.clientName,
+    createOpportunity: request.createOpportunity,
+    createProposal: request.createProposal,
+    estimatedValue: defaultValue,
+    expectedCloseDate: defaultDeadline,
+    opportunityTitle:
+      sanitizeWorkflowGeneratedTitle(request.opportunityTitle) ??
+      (targetClient
+        ? prefixClientNameOnce(targetClient.name, targetRequest?.title ?? "Support opportunity")
+        : null),
+    ownerId: owner?.id ?? request.ownerId,
+    ownerName: owner?.name ?? request.ownerName,
+    proposalTitle:
+      sanitizeWorkflowGeneratedTitle(request.proposalTitle) ??
+      (targetClient
+        ? `${prefixClientNameOnce(targetClient.name, targetRequest?.title ?? "Support")} proposal`
+        : null),
+    proposalValidUntil: request.proposalValidUntil ?? defaultDeadline,
+    requestId: targetRequest?.id ?? request.requestId,
+    requestTitle: targetRequest?.title ?? request.requestTitle,
+    stage: request.stage ?? OpportunityStage.New,
+  } satisfies PendingAdminRequestHandlingRequest;
+};
+
+const getRecentPendingAdminRequestHandlingRequest = (
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) => {
+  const traceStep = [...messages]
+    .reverse()
+    .filter((message) => message.role === "assistant")
+    .flatMap((message) => message.trace ?? [])
+    .find((step) => step.tool === "confirmation_required_admin_request_workflow");
+
+  if (!traceStep) {
+    return inferPendingAdminRequestHandlingRequest(messages, workspace);
+  }
+
+  return {
+    clientId: typeof traceStep.arguments.clientId === "string" ? traceStep.arguments.clientId : null,
+    clientName:
+      typeof traceStep.arguments.clientName === "string" ? traceStep.arguments.clientName : null,
+    createOpportunity: Boolean(traceStep.arguments.createOpportunity),
+    createProposal: Boolean(traceStep.arguments.createProposal),
+    estimatedValue:
+      typeof traceStep.arguments.estimatedValue === "number"
+        ? traceStep.arguments.estimatedValue
+        : null,
+    expectedCloseDate:
+      typeof traceStep.arguments.expectedCloseDate === "string"
+        ? traceStep.arguments.expectedCloseDate
+        : null,
+    opportunityTitle:
+      typeof traceStep.arguments.opportunityTitle === "string"
+        ? traceStep.arguments.opportunityTitle
+        : null,
+    ownerId: typeof traceStep.arguments.ownerId === "string" ? traceStep.arguments.ownerId : null,
+    ownerName:
+      typeof traceStep.arguments.ownerName === "string" ? traceStep.arguments.ownerName : null,
+    proposalTitle:
+      typeof traceStep.arguments.proposalTitle === "string"
+        ? traceStep.arguments.proposalTitle
+        : null,
+    proposalValidUntil:
+      typeof traceStep.arguments.proposalValidUntil === "string"
+        ? traceStep.arguments.proposalValidUntil
+        : null,
+    requestId:
+      typeof traceStep.arguments.requestId === "string" ? traceStep.arguments.requestId : null,
+    requestTitle:
+      typeof traceStep.arguments.requestTitle === "string"
+        ? traceStep.arguments.requestTitle
+        : null,
+    stage: typeof traceStep.arguments.stage === "string" ? traceStep.arguments.stage : null,
+  } satisfies PendingAdminRequestHandlingRequest;
 };
 
 const CLIENT_REQUEST_ASSIGNMENT_CONFIRMATION_TOOL =
@@ -1333,6 +2367,10 @@ const isClientRequestSummaryIntent = (message: string) => {
         normalized.includes("waiting") ||
         normalized.includes("review") ||
         normalized.includes("notification"))) ||
+    normalized.includes("what needs review") ||
+    normalized.includes("what should i review") ||
+    normalized.includes("what is waiting for review") ||
+    normalized.includes("any new client requests") ||
     (normalized.includes("notification") &&
       (normalized.includes("admin") || normalized.includes("client"))) ||
     normalized.includes("what client requests are waiting") ||
@@ -2038,6 +3076,63 @@ const createMutationConfirmationReply = async (
     );
   }
 
+  const adminRequestHandlingRequest = inferPendingAdminRequestHandlingRequest(messages, workspace);
+
+  if (adminRequestHandlingRequest) {
+    const planParts = [
+      `review ${adminRequestHandlingRequest.requestTitle ?? "the latest client request"}`,
+      adminRequestHandlingRequest.createOpportunity
+        ? `create opportunity ${adminRequestHandlingRequest.opportunityTitle ?? "for the request"}`
+        : null,
+      adminRequestHandlingRequest.createProposal
+        ? `create proposal ${adminRequestHandlingRequest.proposalTitle ?? "for the request"}`
+        : null,
+      "assign the best available representatives",
+    ].filter(Boolean);
+
+    return createConfirmationResult(
+      `I can ${planParts.join(", ")} for ${adminRequestHandlingRequest.clientName ?? "that client"}. Reply confirm to proceed.`,
+      adminRequestHandlingRequest,
+      "confirmation_required_admin_request_workflow",
+    );
+  }
+
+  const serviceRequestCreateRequest = inferPendingServiceRequestCreateRequest(messages, workspace);
+
+  if (serviceRequestCreateRequest) {
+    if (!serviceRequestCreateRequest.clientId && !serviceRequestCreateRequest.clientName) {
+      return createLocalAssistantResult({
+        arguments: {
+          missing: "client",
+        },
+        message: "I can submit the request, but I still need the client name or id.",
+        output: serviceRequestCreateRequest,
+        reason: "Service request creation is missing the target client.",
+        tool: "service_request_missing_client",
+      });
+    }
+
+    if (!serviceRequestCreateRequest.title || !serviceRequestCreateRequest.description) {
+      return createLocalAssistantResult({
+        arguments: {
+          missingDescription: !serviceRequestCreateRequest.description,
+          missingTitle: !serviceRequestCreateRequest.title,
+        },
+        message:
+          "I can submit the request, but I still need a clear request title and summary.",
+        output: serviceRequestCreateRequest,
+        reason: "Service request creation is missing required details.",
+        tool: "service_request_missing_details",
+      });
+    }
+
+    return createConfirmationResult(
+      `I can submit ${serviceRequestCreateRequest.title} for ${serviceRequestCreateRequest.clientName ?? "that client"} as a ${serviceRequestCreateRequest.priority} priority request. Reply confirm to proceed.`,
+      serviceRequestCreateRequest,
+      "confirmation_required_service_request_create",
+    );
+  }
+
   if (
     normalized.includes("proceed with the proposal") ||
     normalized.includes("proposal accepted") ||
@@ -2106,6 +3201,52 @@ const createMutationConfirmationReply = async (
       }. Reply confirm to proceed.`,
       proposalEditRequest,
       PROPOSAL_EDIT_CONFIRMATION_TOOL,
+    );
+  }
+
+  const opportunityEditRequest = inferPendingOpportunityEditRequest(messages, workspace);
+
+  if (opportunityEditRequest?.opportunityId && opportunityEditRequest.title) {
+    return createConfirmationResult(
+      `I can rename ${opportunityEditRequest.opportunityTitle ?? "that opportunity"} to ${opportunityEditRequest.title}. Reply confirm to proceed.`,
+      opportunityEditRequest,
+      "confirmation_required_opportunity_edit",
+    );
+  }
+
+  const opportunityCreateRequest = inferPendingOpportunityCreateRequest(messages, workspace);
+
+  if (opportunityCreateRequest) {
+    const missingOpportunityFieldsMessage =
+      createOpportunityMissingFieldsMessage(opportunityCreateRequest);
+
+    if (missingOpportunityFieldsMessage) {
+      return createLocalAssistantResult({
+        arguments: {
+          clientId: opportunityCreateRequest.clientId,
+          clientName: opportunityCreateRequest.clientName,
+          estimatedValue: opportunityCreateRequest.estimatedValue,
+          expectedCloseDate: opportunityCreateRequest.expectedCloseDate,
+          ownerId: opportunityCreateRequest.ownerId,
+          ownerName: opportunityCreateRequest.ownerName,
+          stage: opportunityCreateRequest.stage,
+          title: opportunityCreateRequest.title,
+        },
+        message: missingOpportunityFieldsMessage,
+        output: opportunityCreateRequest,
+        reason: "Opportunity create request is still missing required details.",
+        tool: "opportunity_create_missing_details",
+      });
+    }
+
+    return createConfirmationResult(
+      `I can create opportunity ${opportunityCreateRequest.title}` +
+        `${opportunityCreateRequest.clientName ? ` for ${opportunityCreateRequest.clientName}` : ""}` +
+        `${opportunityCreateRequest.estimatedValue ? ` worth ${formatCurrency(opportunityCreateRequest.estimatedValue)}` : ""}` +
+        `${opportunityCreateRequest.expectedCloseDate ? ` closing on ${opportunityCreateRequest.expectedCloseDate}` : ""}` +
+        `${opportunityCreateRequest.ownerName ? ` and assign it to ${opportunityCreateRequest.ownerName}` : ""}. Reply confirm to proceed.`,
+      opportunityCreateRequest,
+      "confirmation_required_opportunity_create",
     );
   }
 
@@ -2551,7 +3692,7 @@ const shouldRunConfirmedOpportunityCreateWorkflow = (
     isConfirmationMessage(message.content),
   );
 
-  return hasUserConfirmation && !isConfirmationMessage(latestUserMessage);
+  return hasUserConfirmation && isConfirmationMessage(latestUserMessage);
 };
 
 const createConfirmedOpportunityCreateResult = async (
@@ -2648,6 +3789,354 @@ const createConfirmedOpportunityCreateResult = async (
   };
 };
 
+const shouldRunConfirmedOpportunityEditWorkflow = (
+  latestUserMessage: string,
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) =>
+  !isClientScopedUser(workspace.clientIds) &&
+  isConfirmationMessage(latestUserMessage) &&
+  Boolean(getRecentPendingOpportunityEditRequest(messages, workspace)?.opportunityId);
+
+const createConfirmedOpportunityEditResult = async (
+  workspace: IAssistantWorkspace,
+  messages: AssistantMessage[],
+) => {
+  const request = getRecentPendingOpportunityEditRequest(messages, workspace);
+
+  if (!request?.opportunityId) {
+    return null;
+  }
+
+  const existingOpportunity =
+    findOpportunityByReferenceInWorkspace(
+      workspace,
+      request.opportunityId ?? request.opportunityTitle,
+    ) ?? null;
+
+  if (!existingOpportunity) {
+    return null;
+  }
+
+  const owner =
+    findOwnerByReferenceInWorkspace(workspace, request.ownerId ?? request.ownerName) ?? null;
+
+  const updatedOpportunity =
+    workspace.isLiveBackend && workspace.sessionToken
+      ? await updateLiveOpportunity(workspace.sessionToken, {
+          ...existingOpportunity,
+          estimatedValue: request.estimatedValue ?? existingOpportunity.estimatedValue,
+          expectedCloseDate: request.expectedCloseDate ?? existingOpportunity.expectedCloseDate,
+          ownerId: owner?.id ?? existingOpportunity.ownerId,
+          stage: request.stage ?? existingOpportunity.stage,
+          title: request.title ?? existingOpportunity.title,
+          value:
+            request.estimatedValue ??
+            existingOpportunity.value ??
+            existingOpportunity.estimatedValue,
+        })
+      : updateMockOpportunity(workspace.tenantId, existingOpportunity.id, {
+          estimatedValue: request.estimatedValue ?? undefined,
+          expectedCloseDate: request.expectedCloseDate ?? undefined,
+          ownerId: owner?.id ?? undefined,
+          stage: request.stage ?? undefined,
+          title: request.title ?? undefined,
+          value: request.estimatedValue ?? undefined,
+        });
+
+  if (!updatedOpportunity) {
+    return null;
+  }
+
+  const finalOpportunityTitle =
+    updatedOpportunity.title ?? request.title ?? existingOpportunity.title;
+
+  if (!updatedOpportunity.title && finalOpportunityTitle) {
+    updatedOpportunity.title = finalOpportunityTitle;
+  }
+
+  upsertById(workspace.salesData.opportunities, updatedOpportunity);
+
+  return {
+    message: `Updated opportunity ${finalOpportunityTitle}.`,
+    mode: "workflow" as const,
+    model: "local-opportunity-edit-workflow",
+    reason: "Confirmed opportunity edit executed locally from recent assistant context.",
+    mutations: [
+      {
+        entityId: updatedOpportunity.id,
+        entityType: "opportunity" as const,
+        operation: "update" as const,
+        record: updatedOpportunity as unknown as Record<string, unknown>,
+        title: finalOpportunityTitle,
+      },
+    ] satisfies AssistantMutation[],
+    trace: [
+      {
+        arguments: {
+          estimatedValue: updatedOpportunity.value ?? updatedOpportunity.estimatedValue,
+          expectedCloseDate: updatedOpportunity.expectedCloseDate,
+          opportunityId: updatedOpportunity.id,
+          ownerId: updatedOpportunity.ownerId ?? null,
+          stage: updatedOpportunity.stage,
+          title: finalOpportunityTitle,
+        },
+        outputPreview: createTracePreview({
+          opportunity: finalOpportunityTitle,
+        }),
+        tool: "confirmed_opportunity_edit_workflow",
+      },
+    ] satisfies AssistantTraceStep[],
+  };
+};
+
+const shouldRunConfirmedServiceRequestCreateWorkflow = (
+  latestUserMessage: string,
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) =>
+  isConfirmationMessage(latestUserMessage) &&
+  Boolean(getRecentPendingServiceRequestCreateRequest(messages, workspace)?.title);
+
+const createConfirmedServiceRequestCreateResult = async (
+  workspace: IAssistantWorkspace,
+  messages: AssistantMessage[],
+) => {
+  const request = getRecentPendingServiceRequestCreateRequest(messages, workspace);
+
+  if (!request?.clientId || !request.title || !request.description) {
+    return null;
+  }
+
+  const client = findClientByReferenceInWorkspace(
+    workspace,
+    request.clientId ?? request.clientName,
+  );
+
+  if (!client) {
+    return null;
+  }
+
+  const createdRequest = await createServiceRequestForWorkspace(workspace, {
+    clientId: client.id,
+    description: request.description,
+    priority: request.priority,
+    requestType: request.requestType ?? "service_request",
+    source: isClientScopedUser(workspace.clientIds) ? "client_portal" : "assistant",
+    title: request.title,
+  });
+
+  workspace.serviceRequests.unshift(createdRequest);
+
+  return {
+    message:
+      `Submitted ${createdRequest.title} for ${client.name} as a ${createdRequest.priority} priority client request.` +
+      ` Next best action: ask an admin to review and assign it.`,
+    mode: "workflow" as const,
+    model: "local-service-request-create-workflow",
+    reason: "Confirmed service request creation executed from recent assistant context.",
+    mutations: [
+      {
+        entityId: createdRequest.id,
+        entityType: "note" as const,
+        operation: "create" as const,
+        record: createdRequest as unknown as Record<string, unknown>,
+        title: createdRequest.title,
+      },
+    ] satisfies AssistantMutation[],
+    trace: [
+      {
+        arguments: {
+          clientId: client.id,
+          priority: createdRequest.priority,
+          requestType: createdRequest.requestType,
+          title: createdRequest.title,
+        },
+        outputPreview: createTracePreview({
+          client: client.name,
+          request: createdRequest.title,
+        }),
+        tool: "confirmed_service_request_create_workflow",
+      },
+    ] satisfies AssistantTraceStep[],
+  };
+};
+
+const shouldRunConfirmedAdminRequestHandlingWorkflow = (
+  latestUserMessage: string,
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) =>
+  isManagerRole(workspace.role) &&
+  !isClientScopedUser(workspace.clientIds) &&
+  isConfirmationMessage(latestUserMessage) &&
+  Boolean(getRecentPendingAdminRequestHandlingRequest(messages, workspace)?.requestId);
+
+const createConfirmedAdminRequestHandlingResult = async (
+  workspace: IAssistantWorkspace,
+  messages: AssistantMessage[],
+) => {
+  const request = getRecentPendingAdminRequestHandlingRequest(messages, workspace);
+
+  if (!request?.requestId) {
+    return null;
+  }
+
+  const serviceRequest = workspace.serviceRequests.find((item) => item.id === request.requestId);
+
+  if (!serviceRequest) {
+    return null;
+  }
+
+  const client =
+    findClientByReferenceInWorkspace(workspace, serviceRequest.clientId ?? request.clientId) ?? null;
+  const representativePlan = pickRepresentativesForClientRequest(workspace, serviceRequest);
+
+  if (!representativePlan || representativePlan.representatives.length === 0) {
+    return null;
+  }
+
+  let updatedRequest = serviceRequest;
+  const mutations: AssistantMutation[] = [];
+  let createdOpportunity: IAssistantWorkspace["salesData"]["opportunities"][number] | null = null;
+  let createdProposal: IAssistantWorkspace["salesData"]["proposals"][number] | null = null;
+
+  if (serviceRequest.status === "submitted") {
+    updatedRequest = await markServiceRequestUnderReviewForWorkspace(workspace, serviceRequest.id);
+    workspace.serviceRequests = workspace.serviceRequests.map((item) =>
+      item.id === updatedRequest.id ? updatedRequest : item,
+    );
+  }
+
+  if (request.createOpportunity && !updatedRequest.opportunityId) {
+    const opportunityResult = await attachOpportunityToServiceRequestForWorkspace(
+      workspace,
+      updatedRequest.id,
+      {
+        estimatedValue: request.estimatedValue ?? 250_000,
+        expectedCloseDate:
+          request.expectedCloseDate ?? addDays(new Date(), 14).toISOString().split("T")[0],
+        mode: "create",
+        ownerId: request.ownerId ?? undefined,
+        stage: request.stage ?? OpportunityStage.New,
+        title: request.opportunityTitle ?? `${client?.name ?? "Client"} support opportunity`,
+      },
+    );
+
+    updatedRequest = opportunityResult.request;
+    createdOpportunity = opportunityResult.opportunity as
+      | IAssistantWorkspace["salesData"]["opportunities"][number]
+      | null;
+
+    if (createdOpportunity) {
+      upsertById(workspace.salesData.opportunities, createdOpportunity);
+      mutations.push({
+        entityId: createdOpportunity.id,
+        entityType: "opportunity",
+        operation: "create",
+        record: createdOpportunity as unknown as Record<string, unknown>,
+        title: createdOpportunity.title,
+      });
+    }
+  }
+
+  if (request.createProposal && !updatedRequest.proposalId) {
+    const proposalResult = await attachProposalToServiceRequestForWorkspace(
+      workspace,
+      updatedRequest.id,
+      {
+        currency: "ZAR",
+        description: updatedRequest.description,
+        mode: "create",
+        title: request.proposalTitle ?? `${client?.name ?? "Client"} support proposal`,
+        validUntil:
+          request.proposalValidUntil ??
+          request.expectedCloseDate ??
+          addDays(new Date(), 14).toISOString().split("T")[0],
+      },
+    );
+
+    updatedRequest = proposalResult.request;
+    createdProposal = proposalResult.proposal as
+      | IAssistantWorkspace["salesData"]["proposals"][number]
+      | null;
+
+    if (createdProposal) {
+      upsertById(workspace.salesData.proposals, createdProposal);
+      mutations.push({
+        entityId: createdProposal.id,
+        entityType: "proposal",
+        operation: "create",
+        record: createdProposal as unknown as Record<string, unknown>,
+        title: createdProposal.title,
+      });
+    }
+  }
+
+  const createdAssignments = await createServiceRequestAssignmentsForWorkspace(
+    workspace,
+    updatedRequest.id,
+    {
+      note:
+        createdOpportunity?.title
+          ? `Linked to ${createdOpportunity.title}.`
+          : "Follow up on the requested support.",
+      representativeUserIds: representativePlan.representatives.map((member) => member.id),
+    },
+  );
+
+  updatedRequest = createdAssignments.request;
+  workspace.serviceRequests = workspace.serviceRequests.map((item) =>
+    item.id === updatedRequest.id ? updatedRequest : item,
+  );
+
+  mutations.push(
+    ...createdAssignments.assignments.map((assignment) => ({
+      entityId: assignment.id,
+      entityType: "note" as const,
+      operation: "create" as const,
+      record: assignment as unknown as Record<string, unknown>,
+      title: `Assigned ${assignment.representativeName} to ${updatedRequest.title}`,
+    })),
+    {
+      entityId: updatedRequest.id,
+      entityType: "note" as const,
+      operation: "update" as const,
+      record: updatedRequest as unknown as Record<string, unknown>,
+      title: updatedRequest.title,
+    },
+  );
+
+  return {
+    message:
+      `Reviewed ${updatedRequest.title}${client ? ` for ${client.name}` : ""},` +
+      `${createdOpportunity ? ` created opportunity ${createdOpportunity.title},` : ""}` +
+      `${createdProposal ? ` created proposal ${createdProposal.title},` : ""}` +
+      ` and assigned ${representativePlan.representatives.map((member) => member.name).join(" and ")}.`,
+    mode: "workflow" as const,
+    model: "local-admin-request-workflow",
+    reason: "Confirmed admin request handling executed from recent assistant context.",
+    mutations,
+    trace: [
+      {
+        arguments: {
+          createOpportunity: request.createOpportunity,
+          createProposal: request.createProposal,
+          requestId: updatedRequest.id,
+          requestTitle: updatedRequest.title,
+        },
+        outputPreview: createTracePreview({
+          assignments: representativePlan.representatives.map((member) => member.name),
+          opportunity: createdOpportunity?.title ?? null,
+          proposal: createdProposal?.title ?? null,
+          request: updatedRequest.title,
+        }),
+        tool: "confirmed_admin_request_workflow",
+      },
+    ] satisfies AssistantTraceStep[],
+  };
+};
+
 const shouldRunConfirmedClientAssignmentDecisionWorkflow = (
   latestUserMessage: string,
   messages: AssistantMessage[],
@@ -2717,6 +4206,13 @@ const shouldRunConfirmedRepresentativeDecisionWorkflow = (
 ) =>
   isConfirmationMessage(latestUserMessage) &&
   Boolean(getRecentPendingRepresentativeDecisionRequest(messages));
+
+const shouldRunConfirmedGenericMutationWorkflow = (
+  latestUserMessage: string,
+  messages: AssistantMessage[],
+) =>
+  isConfirmationMessage(latestUserMessage) &&
+  Boolean(getRecentConfirmedGenericMutationRequest(messages));
 
 const createConfirmedRepresentativeDecisionResult = async (
   workspace: IAssistantWorkspace,
@@ -2879,6 +4375,243 @@ const getRecentConfirmedGenericMutationRequest = (messages: AssistantMessage[]) 
   return latestUserMessage ?? priorUserRequest ?? null;
 };
 
+type ConfirmedGenericToolRequest = {
+  args: Record<string, unknown>;
+  toolName:
+    | "create_activity"
+    | "update_activity"
+    | "delete_activity"
+    | "create_pricing_request"
+    | "update_pricing_request"
+    | "delete_pricing_request"
+    | "create_note"
+    | "update_note"
+    | "delete_note";
+};
+
+const inferConfirmedGenericToolRequest = (
+  workspace: IAssistantWorkspace,
+  request: string,
+): ConfirmedGenericToolRequest | null => {
+  const normalized = normalizeLookupValue(request);
+  const mentionedOpportunity = extractOpportunityReference(request, workspace);
+  const opportunity = findOpportunityByReferenceInWorkspace(workspace, mentionedOpportunity);
+  const explicitAssignedToId =
+    extractIdentifierValue(request, "assignedtoid") ??
+    extractIdentifierValue(request, "assigned_to_id") ??
+    extractIdentifierValue(request, "assigneeid");
+  const mentionedOwner =
+    (explicitAssignedToId
+      ? findOwnerByReferenceInWorkspace(workspace, explicitAssignedToId)
+      : null) ??
+    workspace.salesData.teamMembers.find((item) =>
+      normalized.includes(normalizeLookupValue(item.name)),
+    ) ?? null;
+
+  if (
+    normalized.includes("create note") ||
+    normalized.includes("add note") ||
+    normalized.includes("record note")
+  ) {
+    const title =
+      extractNoteTitle(request) ??
+      `Assistant note ${new Date().toISOString().split("T")[0]}`;
+    const content = extractNoteContent(request);
+
+    if (!content) {
+      return null;
+    }
+
+    return {
+      args: {
+        category: extractLabeledValue(request, "category") ?? "General",
+        clientId:
+          findClientByReferenceInWorkspace(
+            workspace,
+            workspace.salesData.clients.find((item) =>
+              normalized.includes(normalizeLookupValue(item.name)),
+            )?.id ?? null,
+          )?.id ?? undefined,
+        content,
+        title,
+      },
+      toolName: "create_note",
+    };
+  }
+
+  if (normalized.includes("update note") || normalized.includes("edit note") || normalized.includes("change note")) {
+    const note = findMentionedNote(workspace, request);
+
+    if (!note) {
+      return null;
+    }
+
+    return {
+      args: {
+        category: extractLabeledValue(request, "category") ?? undefined,
+        content: extractNoteContent(request) ?? undefined,
+        noteId: note.id,
+        title: extractLabeledValue(request, "title") ?? undefined,
+      },
+      toolName: "update_note",
+    };
+  }
+
+  if (normalized.includes("delete note") || normalized.includes("remove note")) {
+    const note = findMentionedNote(workspace, request);
+
+    return note
+      ? {
+          args: {
+            noteId: note.id,
+          },
+          toolName: "delete_note",
+        }
+      : null;
+  }
+
+  if (
+    normalized.includes("create pricing request") ||
+    normalized.includes("add pricing request") ||
+    normalized.includes("new pricing request")
+  ) {
+    if (!opportunity) {
+      return null;
+    }
+
+    return {
+      args: {
+        assignedToId: mentionedOwner?.id ?? opportunity.ownerId ?? undefined,
+        description:
+          extractLabeledValue(request, "description") ??
+          `Assistant-created pricing request for ${opportunity.title}.`,
+        opportunityId: opportunity.id,
+        priority: extractPriorityNumber(request) ?? 2,
+        requiredByDate: extractGenericDueDate(request) ?? undefined,
+        title:
+          extractPricingRequestTitle(request) ?? `Pricing request for ${opportunity.title}`,
+      },
+      toolName: "create_pricing_request",
+    };
+  }
+
+  if (
+    normalized.includes("update pricing request") ||
+    normalized.includes("edit pricing request") ||
+    normalized.includes("change pricing request")
+  ) {
+    const pricingRequest = findMentionedPricingRequest(workspace, request);
+
+    return pricingRequest
+      ? {
+          args: {
+            assignedToId: mentionedOwner?.id ?? undefined,
+            description: extractLabeledValue(request, "description") ?? undefined,
+            pricingRequestId: pricingRequest.id,
+            priority: extractPriorityNumber(request) ?? undefined,
+            requiredByDate: extractGenericDueDate(request) ?? undefined,
+            status: extractLabeledValue(request, "status") ?? undefined,
+            title: extractLabeledValue(request, "title") ?? undefined,
+          },
+          toolName: "update_pricing_request",
+        }
+      : null;
+  }
+
+  if (normalized.includes("delete pricing request") || normalized.includes("remove pricing request")) {
+    const pricingRequest = findMentionedPricingRequest(workspace, request);
+
+    return pricingRequest
+      ? {
+          args: {
+            pricingRequestId: pricingRequest.id,
+          },
+          toolName: "delete_pricing_request",
+        }
+      : null;
+  }
+
+  if (
+    normalized.includes("create activity") ||
+    normalized.includes("create follow-up") ||
+    normalized.includes("create follow up") ||
+    normalized.includes("add task") ||
+    normalized.includes("create task")
+  ) {
+    const subject =
+      extractActivitySubject(request) ??
+      null;
+
+    if (!subject) {
+      return null;
+    }
+
+    return {
+      args: {
+        activityType: extractActivityType(request),
+        assignedToId: mentionedOwner?.id ?? opportunity?.ownerId ?? undefined,
+        dueDate: extractGenericDueDate(request) ?? undefined,
+        opportunityId: opportunity?.id ?? undefined,
+        priority: extractPriorityNumber(request) ?? 2,
+        subject,
+        title: subject,
+      },
+      toolName: "create_activity",
+    };
+  }
+
+  if (
+    normalized.includes("update activity") ||
+    normalized.includes("edit activity") ||
+    normalized.includes("change activity") ||
+    normalized.includes("update follow-up") ||
+    normalized.includes("edit follow-up")
+  ) {
+    const activity = findMentionedActivity(workspace, request);
+
+    return activity
+      ? {
+          args: {
+            activityId: activity.id,
+            assignedToId: mentionedOwner?.id ?? undefined,
+            dueDate: extractGenericDueDate(request) ?? undefined,
+            priority: extractPriorityNumber(request) ?? undefined,
+            status: extractLabeledValue(request, "status") ?? undefined,
+            subject:
+              extractLabeledValue(request, "subject") ??
+              extractLabeledValue(request, "title") ??
+              undefined,
+            title:
+              extractLabeledValue(request, "subject") ??
+              extractLabeledValue(request, "title") ??
+              undefined,
+          },
+          toolName: "update_activity",
+        }
+      : null;
+  }
+
+  if (
+    normalized.includes("delete activity") ||
+    normalized.includes("remove activity") ||
+    normalized.includes("delete follow-up") ||
+    normalized.includes("remove follow-up")
+  ) {
+    const activity = findMentionedActivity(workspace, request);
+
+    return activity
+      ? {
+          args: {
+            activityId: activity.id,
+          },
+          toolName: "delete_activity",
+        }
+      : null;
+  }
+
+  return null;
+};
+
 const getDefaultOpportunityForOwner = (
   workspace: IAssistantWorkspace,
   ownerId: string,
@@ -3014,12 +4747,15 @@ const shouldRunWorkloadBoostWorkflow = (
   messages: AssistantMessage[],
   workspace: IAssistantWorkspace,
 ) =>
-  isWorkloadBoostIntent(latestUserMessage) ||
+  (!isExplicitStructuredMutationIntent(latestUserMessage) &&
+    isWorkloadBoostIntent(latestUserMessage)) ||
   (isConfirmationMessage(latestUserMessage) &&
     Boolean(
       (() => {
         const recentRequest = findRecentNonConfirmationUserMessage(messages);
-        return recentRequest ? createWorkloadBoostPlan(recentRequest.content, workspace, messages) : null;
+        return recentRequest && !isExplicitStructuredMutationIntent(recentRequest.content)
+          ? createWorkloadBoostPlan(recentRequest.content, workspace, messages)
+          : null;
       })(),
     ));
 
@@ -3143,6 +4879,19 @@ const inferAdvisorAssignmentRequest = (
   workspace: IAssistantWorkspace,
 ): AdvisorAssignmentRequest | null => {
   if (!isManagerRole(workspace.role)) {
+    return null;
+  }
+
+  if (isExplicitStructuredMutationIntent(message)) {
+    return null;
+  }
+
+  const pendingOpportunityCreateRequest = inferPendingOpportunityCreateRequest(
+    messages,
+    workspace,
+  );
+
+  if (pendingOpportunityCreateRequest) {
     return null;
   }
 
@@ -3943,6 +5692,10 @@ const shouldRunReassignmentWorkflow = (
   latestUserMessage: string,
   messages: AssistantMessage[],
 ) => {
+  if (isExplicitStructuredMutationIntent(latestUserMessage)) {
+    return false;
+  }
+
   const normalized = normalizeLookupValue(latestUserMessage);
   const recentAssistant = normalizeLookupValue(lastAssistantContent(messages));
   const isBulkClarification =
@@ -6490,6 +8243,77 @@ const createToolset = (workspace: IAssistantWorkspace, messages: AssistantMessag
   return { runTool, toolDefinitions: visibleToolDefinitions };
 };
 
+async function createConfirmedGenericMutationLocalResult(
+  workspace: IAssistantWorkspace,
+  messages: AssistantMessage[],
+) {
+  const confirmedRequest = getRecentConfirmedGenericMutationRequest(messages);
+
+  if (!confirmedRequest) {
+    return null;
+  }
+
+  const localRequest = inferConfirmedGenericToolRequest(workspace, confirmedRequest);
+
+  if (!localRequest) {
+    return null;
+  }
+
+  const { runTool } = createToolset(workspace, messages);
+  const output = await runTool(localRequest.toolName, JSON.stringify(localRequest.args));
+
+  if (!output || typeof output !== "object" || !("mutation" in output)) {
+    return null;
+  }
+
+  const mutation = output.mutation as AssistantMutation | undefined;
+
+  if (!mutation) {
+    return null;
+  }
+
+  const resultRecord = output as Record<string, unknown>;
+  const responseMessage = (() => {
+    switch (localRequest.toolName) {
+      case "create_note":
+        return `Created note ${String(mutation.title ?? "Untitled note")}.`;
+      case "update_note":
+        return `Updated note ${String(mutation.title ?? "Untitled note")}.`;
+      case "delete_note":
+        return `Deleted note ${String(mutation.title ?? "Untitled note")}.`;
+      case "create_pricing_request":
+        return `Created pricing request ${String(mutation.title ?? "Untitled pricing request")}.`;
+      case "update_pricing_request":
+        return `Updated pricing request ${String(mutation.title ?? "Untitled pricing request")}.`;
+      case "delete_pricing_request":
+        return `Deleted pricing request ${String(mutation.title ?? "Untitled pricing request")}.`;
+      case "create_activity":
+        return `Created follow-up ${String(mutation.title ?? "Untitled activity")}.`;
+      case "update_activity":
+        return `Updated follow-up ${String(mutation.title ?? "Untitled activity")}.`;
+      case "delete_activity":
+        return `Deleted follow-up ${String(mutation.title ?? "Untitled activity")}.`;
+      default:
+        return "Completed the requested workspace change.";
+    }
+  })();
+
+  return {
+    message: responseMessage,
+    mode: "workflow" as const,
+    model: "local-generic-mutation-workflow",
+    reason: "Confirmed generic workspace mutation executed locally without provider access.",
+    mutations: [mutation],
+    trace: [
+      {
+        arguments: localRequest.args,
+        outputPreview: createTracePreview(resultRecord),
+        tool: `confirmed_${localRequest.toolName}_workflow`,
+      },
+    ] satisfies AssistantTraceStep[],
+  };
+}
+
 const createTracePreview = (value: unknown) => {
   try {
     const serialized = JSON.stringify(value, null, 2);
@@ -7455,6 +9279,30 @@ export const runSecureAssistant = async ({
     return mutationConfirmationResult;
   }
 
+  const confirmedServiceRequestCreateResult = shouldRunConfirmedServiceRequestCreateWorkflow(
+    latestUserMessage,
+    messages,
+    workspace,
+  )
+    ? await createConfirmedServiceRequestCreateResult(workspace, messages)
+    : null;
+
+  if (confirmedServiceRequestCreateResult) {
+    return confirmedServiceRequestCreateResult;
+  }
+
+  const confirmedAdminRequestHandlingResult = shouldRunConfirmedAdminRequestHandlingWorkflow(
+    latestUserMessage,
+    messages,
+    workspace,
+  )
+    ? await createConfirmedAdminRequestHandlingResult(workspace, messages)
+    : null;
+
+  if (confirmedAdminRequestHandlingResult) {
+    return confirmedAdminRequestHandlingResult;
+  }
+
   const confirmedMessageSendResult = shouldRunConfirmedMessageSendWorkflow(
     latestUserMessage,
     messages,
@@ -7489,6 +9337,18 @@ export const runSecureAssistant = async ({
 
   if (confirmedProposalEditResult) {
     return confirmedProposalEditResult;
+  }
+
+  const confirmedOpportunityEditResult = shouldRunConfirmedOpportunityEditWorkflow(
+    latestUserMessage,
+    messages,
+    workspace,
+  )
+    ? await createConfirmedOpportunityEditResult(workspace, messages)
+    : null;
+
+  if (confirmedOpportunityEditResult) {
+    return confirmedOpportunityEditResult;
   }
 
   const confirmedOpportunityCreateResult = shouldRunConfirmedOpportunityCreateWorkflow(
@@ -7531,6 +9391,17 @@ export const runSecureAssistant = async ({
 
   if (confirmedRepresentativeDecisionResult) {
     return confirmedRepresentativeDecisionResult;
+  }
+
+  const confirmedGenericMutationLocalResult = shouldRunConfirmedGenericMutationWorkflow(
+    latestUserMessage,
+    messages,
+  )
+    ? await createConfirmedGenericMutationLocalResult(workspace, messages)
+    : null;
+
+  if (confirmedGenericMutationLocalResult) {
+    return confirmedGenericMutationLocalResult;
   }
 
   const clientRequestNotificationSummaryReply = createClientRequestNotificationSummaryReply(

--- a/lib/server/assistant-openai.ts
+++ b/lib/server/assistant-openai.ts
@@ -48,6 +48,13 @@ import {
   updateMockPricingRequest,
   updateMockProposal,
 } from "@/lib/server/mock-workspace-store";
+import {
+  applyServiceRequestClientDecision,
+  applyServiceRequestRepDecision,
+  createServiceRequestAssignments,
+  getServiceRequestDetail,
+  markServiceRequestUnderReview,
+} from "@/lib/server/service-request-store";
 
 export type AssistantMessage = {
   content: string;
@@ -163,12 +170,13 @@ type AssistantChatMessage =
     };
 
 type AssistantActor = {
+  clientIds?: string[];
   email: string;
   firstName: string;
   id: string;
   lastName: string;
   password: string;
-  role: IAssistantWorkspace["role"];
+  role: "Admin" | "BusinessDevelopmentManager" | "Client" | "SalesManager" | "SalesRep";
   tenantId: string;
   tenantName: string;
 };
@@ -259,7 +267,22 @@ type ClientRequestAssignmentPlan = {
   client: IAssistantWorkspace["salesData"]["clients"][number];
   opportunity: IAssistantWorkspace["salesData"]["opportunities"][number] | null;
   representatives: IAssistantWorkspace["salesData"]["teamMembers"];
-  request: IAssistantWorkspace["notes"][number];
+  request: IAssistantWorkspace["serviceRequests"][number];
+};
+
+type PendingClientAssignmentDecisionRequest = {
+  assignmentIds: string[];
+  decision: "approve" | "reject";
+  requestId: string | null;
+  requestTitle: string | null;
+};
+
+type PendingRepresentativeDecisionRequest = {
+  assignmentId: string | null;
+  decision: "accept" | "reject";
+  representativeName: string | null;
+  requestId: string | null;
+  requestTitle: string | null;
 };
 
 class AssistantProviderRequestError extends Error {
@@ -361,12 +384,13 @@ const upsertById = <T extends { id: string }>(items: T[], nextItem: T) => {
 };
 
 const createAssistantActor = (workspace: IAssistantWorkspace): AssistantActor => ({
+  clientIds: workspace.clientIds ?? undefined,
   email: workspace.userEmail ?? "",
   firstName: workspace.userDisplayName.split(" ")[0] ?? "Assistant",
   id: workspace.userId ?? workspace.userDisplayName,
   lastName: workspace.userDisplayName.split(" ").slice(1).join(" "),
   password: "",
-  role: workspace.role,
+  role: isClientScopedUser(workspace.clientIds) ? "Client" : workspace.role,
   tenantId: workspace.tenantId,
   tenantName: workspace.scopeLabel,
 });
@@ -1134,18 +1158,17 @@ const isClientFacingRepresentative = (
   ].some((token) => normalizeLookupValue(member.role).includes(token));
 
 const getPendingAdminClientRequests = (workspace: IAssistantWorkspace) =>
-  workspace.notes
+  workspace.serviceRequests
     .filter(
-      (note) =>
-        note.requestType === "client_request" &&
-        note.status === "Pending admin review" &&
-        Boolean(note.clientId),
+      (request) =>
+        request.status === "submitted" &&
+        Boolean(request.clientId),
     )
-    .sort((left, right) => right.createdDate.localeCompare(left.createdDate));
+    .sort((left, right) => right.createdAt.localeCompare(left.createdAt));
 
 const getClientRequestOpportunity = (
   workspace: IAssistantWorkspace,
-  request: IAssistantWorkspace["notes"][number],
+  request: IAssistantWorkspace["serviceRequests"][number],
 ) =>
   workspace.salesData.opportunities
     .filter(
@@ -1165,7 +1188,7 @@ const getClientRequestOpportunity = (
 
 const pickRepresentativesForClientRequest = (
   workspace: IAssistantWorkspace,
-  request: IAssistantWorkspace["notes"][number],
+  request: IAssistantWorkspace["serviceRequests"][number],
 ) => {
   const opportunity = getClientRequestOpportunity(workspace, request);
   const client = workspace.salesData.clients.find((item) => item.id === request.clientId);
@@ -1273,8 +1296,236 @@ const getRecentClientRequestAssignmentPlan = (
     return null;
   }
 
-  const request = workspace.notes.find((note) => note.id === requestId);
+  const request = workspace.serviceRequests.find((item) => item.id === requestId);
   return request ? pickRepresentativesForClientRequest(workspace, request) : null;
+};
+
+const getLatestClientAssignmentReviewRequest = (workspace: IAssistantWorkspace) =>
+  workspace.serviceRequests
+    .filter((request) => request.status === "awaiting_client_assignment_approval")
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0] ?? null;
+
+const getLatestRepresentativeReviewRequest = (workspace: IAssistantWorkspace) =>
+  workspace.serviceRequests
+    .filter((request) => request.status === "awaiting_rep_acceptance")
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0] ?? null;
+
+const isClientAssignmentDecisionIntent = (message: string) => {
+  const normalized = normalizeLookupValue(message);
+
+  const decision =
+    normalized.includes("accept") || normalized.includes("approve")
+      ? "approve"
+      : normalized.includes("reject") || normalized.includes("decline")
+        ? "reject"
+        : null;
+
+  if (!decision) {
+    return null;
+  }
+
+  if (
+    normalized.includes("assignment") ||
+    normalized.includes("representative") ||
+    normalized.includes("sales rep") ||
+    normalized.includes("rep")
+  ) {
+    return decision;
+  }
+
+  return null;
+};
+
+const isRepresentativeDecisionIntent = (message: string) => {
+  const normalized = normalizeLookupValue(message);
+
+  const decision =
+    normalized.includes("accept")
+      ? "accept"
+      : normalized.includes("reject") || normalized.includes("decline")
+        ? "reject"
+        : null;
+
+  if (!decision) {
+    return null;
+  }
+
+  if (
+    normalized.includes("assignment") ||
+    normalized.includes("request") ||
+    normalized.includes("take this") ||
+    normalized.includes("i ll take") ||
+    normalized.includes("i will take")
+  ) {
+    return decision;
+  }
+
+  return null;
+};
+
+const createClientAssignmentDecisionConfirmationReply = (
+  latestUserMessage: string,
+  workspace: IAssistantWorkspace,
+) => {
+  if (isConfirmationMessage(latestUserMessage) || !isClientScopedUser(workspace.clientIds)) {
+    return null;
+  }
+
+  const decision = isClientAssignmentDecisionIntent(latestUserMessage);
+
+  if (!decision) {
+    return null;
+  }
+
+  const request = getLatestClientAssignmentReviewRequest(workspace);
+
+  if (!request) {
+    return null;
+  }
+
+  const detail = getServiceRequestDetail(createAssistantActor(workspace), request.id);
+  const assignmentIds = detail.assignments.map((assignment) => assignment.id);
+
+  if (assignmentIds.length === 0) {
+    return null;
+  }
+
+  return createConfirmationResult(
+    `I can ${decision === "approve" ? "approve" : "reject"} the assigned representatives for ${request.title}. Reply confirm to proceed.`,
+    {
+      assignmentIds,
+      decision,
+      requestId: request.id,
+      requestTitle: request.title,
+    },
+    `confirmation_required_client_assignment_${decision}`,
+  );
+};
+
+const getRecentPendingClientAssignmentDecisionRequest = (
+  messages: AssistantMessage[],
+): PendingClientAssignmentDecisionRequest | null => {
+  const traceStep = [...messages]
+    .reverse()
+    .filter((message) => message.role === "assistant")
+    .flatMap((message) => message.trace ?? [])
+    .find((step) => step.tool.startsWith("confirmation_required_client_assignment_"));
+
+  if (!traceStep) {
+    return null;
+  }
+
+  const assignmentIds = Array.isArray(traceStep.arguments.assignmentIds)
+    ? traceStep.arguments.assignmentIds.filter(
+        (value): value is string => typeof value === "string",
+      )
+    : [];
+  const decision =
+    traceStep.arguments.decision === "approve" || traceStep.arguments.decision === "reject"
+      ? traceStep.arguments.decision
+      : null;
+
+  if (!decision || assignmentIds.length === 0) {
+    return null;
+  }
+
+  return {
+    assignmentIds,
+    decision,
+    requestId:
+      typeof traceStep.arguments.requestId === "string" ? traceStep.arguments.requestId : null,
+    requestTitle:
+      typeof traceStep.arguments.requestTitle === "string"
+        ? traceStep.arguments.requestTitle
+        : null,
+  };
+};
+
+const createRepresentativeDecisionConfirmationReply = (
+  latestUserMessage: string,
+  workspace: IAssistantWorkspace,
+) => {
+  if (isConfirmationMessage(latestUserMessage) || workspace.role !== "SalesRep") {
+    return null;
+  }
+
+  const decision = isRepresentativeDecisionIntent(latestUserMessage);
+
+  if (!decision) {
+    return null;
+  }
+
+  const request = getLatestRepresentativeReviewRequest(workspace);
+
+  if (!request || !workspace.userId) {
+    return null;
+  }
+
+  const detail = getServiceRequestDetail(createAssistantActor(workspace), request.id);
+  const assignment =
+    detail.assignments.find(
+      (item) =>
+        item.representativeUserId === workspace.userId &&
+        item.status === "pending_rep_response",
+    ) ?? null;
+
+  if (!assignment) {
+    return null;
+  }
+
+  return createConfirmationResult(
+    `I can ${decision} the assignment for ${request.title}. Reply confirm to proceed.`,
+    {
+      assignmentId: assignment.id,
+      decision,
+      requestId: request.id,
+      requestTitle: request.title,
+      representativeName: workspace.userDisplayName,
+    },
+    `confirmation_required_representative_assignment_${decision}`,
+  );
+};
+
+const getRecentPendingRepresentativeDecisionRequest = (
+  messages: AssistantMessage[],
+): PendingRepresentativeDecisionRequest | null => {
+  const traceStep = [...messages]
+    .reverse()
+    .filter((message) => message.role === "assistant")
+    .flatMap((message) => message.trace ?? [])
+    .find((step) => step.tool.startsWith("confirmation_required_representative_assignment_"));
+
+  if (!traceStep) {
+    return null;
+  }
+
+  const decision =
+    traceStep.arguments.decision === "accept" || traceStep.arguments.decision === "reject"
+      ? traceStep.arguments.decision
+      : null;
+  const assignmentId =
+    typeof traceStep.arguments.assignmentId === "string"
+      ? traceStep.arguments.assignmentId
+      : null;
+
+  if (!decision || !assignmentId) {
+    return null;
+  }
+
+  return {
+    assignmentId,
+    decision,
+    representativeName:
+      typeof traceStep.arguments.representativeName === "string"
+        ? traceStep.arguments.representativeName
+        : null,
+    requestId:
+      typeof traceStep.arguments.requestId === "string" ? traceStep.arguments.requestId : null,
+    requestTitle:
+      typeof traceStep.arguments.requestTitle === "string"
+        ? traceStep.arguments.requestTitle
+        : null,
+  };
 };
 
 const parseExplicitMessageSendRequest = (
@@ -1805,6 +2056,20 @@ const createMutationConfirmationReply = (
     return clientRequestAssignmentConfirmationResult;
   }
 
+  const clientAssignmentDecisionConfirmationResult =
+    createClientAssignmentDecisionConfirmationReply(latestUserMessage, workspace);
+
+  if (clientAssignmentDecisionConfirmationResult) {
+    return clientAssignmentDecisionConfirmationResult;
+  }
+
+  const representativeDecisionConfirmationResult =
+    createRepresentativeDecisionConfirmationReply(latestUserMessage, workspace);
+
+  if (representativeDecisionConfirmationResult) {
+    return representativeDecisionConfirmationResult;
+  }
+
   const advisorAssignmentConfirmationResult = createAdvisorAssignmentConfirmationReply(
     latestUserMessage,
     workspace,
@@ -1877,7 +2142,7 @@ const createClientRequestNotificationSummaryReply = (
       const client =
         workspace.salesData.clients.find((item) => item.id === request.clientId) ?? null;
 
-      return `${index + 1}. ${client?.name ?? "Unlinked client"}: ${request.title} (${request.createdDate})`;
+      return `${index + 1}. ${client?.name ?? "Unlinked client"}: ${request.title} (${request.createdAt.split("T")[0]})`;
     })
     .join("\n");
 
@@ -1891,7 +2156,7 @@ const createClientRequestNotificationSummaryReply = (
     output: {
       pendingRequests: pendingRequests.map((request) => ({
         clientId: request.clientId ?? null,
-        createdDate: request.createdDate,
+        createdDate: request.createdAt.split("T")[0],
         id: request.id,
         title: request.title,
       })),
@@ -1960,34 +2225,20 @@ const createClientRequestAssignmentResult = (
   }
 
   const actor = createAssistantActor(workspace);
-  const assignedByUserName =
-    `${workspace.userDisplayName}`.trim() || workspace.userEmail || "workspace admin";
-  const createdAssignments = plan.representatives.map((representative) =>
-    createMockNote(actor, {
-      assignedByUserId: workspace.userId ?? undefined,
-      assignedByUserName,
-      category: "Client Message",
-      clientId: plan.client.id,
-      content:
-        `We reviewed your request "${plan.request.title}" and assigned ${representative.name} to help. ` +
-        `${plan.opportunity ? `This is linked to ${plan.opportunity.title}.` : "They will follow up on the requested support."}`,
-      createdDate: new Date().toISOString(),
-      kind: "team_assignment",
-      linkedRequestId: plan.request.id,
-      representativeId: representative.id,
-      representativeName: representative.name,
-      requestType: "team_assignment",
-      source: "assistant",
-      status: "Pending client response",
-      submittedBy: workspace.userEmail ?? undefined,
-      title: `Assigned ${representative.name} to ${plan.request.title}`,
-    }),
-  );
-  const updatedRequest = updateMockNote(workspace.tenantId, plan.request.id, {
-    status: "Acknowledged",
+  const reviewedRequest = markServiceRequestUnderReview(actor, plan.request.id);
+  const createdAssignments = createServiceRequestAssignments(actor, plan.request.id, {
+    note:
+      plan.opportunity
+        ? `Linked to ${plan.opportunity.title}.`
+        : "Follow up on the requested support.",
+    representativeUserIds: plan.representatives.map((member) => member.id),
   });
-
-  workspace.notes = listMockNotes(workspace.tenantId);
+  workspace.serviceRequests = workspace.serviceRequests.map((request) =>
+    request.id === reviewedRequest.id ? reviewedRequest : request,
+  );
+  workspace.serviceRequests = workspace.serviceRequests.map((request) =>
+    request.id === createdAssignments.request.id ? createdAssignments.request : request,
+  );
 
   return {
     message:
@@ -1997,20 +2248,20 @@ const createClientRequestAssignmentResult = (
     model: "local-client-request-workflow",
     reason: "Confirmed client-request assignment workflow executed from authorized admin notifications.",
     mutations: [
-      ...createdAssignments.map((assignment) => ({
+      ...createdAssignments.assignments.map((assignment) => ({
         entityId: assignment.id,
         entityType: "note" as const,
         operation: "create" as const,
         record: assignment as unknown as Record<string, unknown>,
-        title: assignment.title,
+        title: `Assigned ${assignment.representativeName} to ${plan.request.title}`,
       })),
-      updatedRequest
+      createdAssignments.request
         ? {
-            entityId: updatedRequest.id,
+            entityId: createdAssignments.request.id,
             entityType: "note" as const,
             operation: "update" as const,
-            record: updatedRequest as unknown as Record<string, unknown>,
-            title: updatedRequest.title,
+            record: createdAssignments.request as unknown as Record<string, unknown>,
+            title: createdAssignments.request.title,
           }
         : null,
     ].filter(Boolean) as AssistantMutation[],
@@ -2302,6 +2553,141 @@ const createConfirmedOpportunityCreateResult = async (
           owner: owner?.name ?? null,
         }),
         tool: "confirmed_opportunity_create_workflow",
+      },
+    ] satisfies AssistantTraceStep[],
+  };
+};
+
+const shouldRunConfirmedClientAssignmentDecisionWorkflow = (
+  latestUserMessage: string,
+  messages: AssistantMessage[],
+) =>
+  isConfirmationMessage(latestUserMessage) &&
+  Boolean(getRecentPendingClientAssignmentDecisionRequest(messages));
+
+const createConfirmedClientAssignmentDecisionResult = (
+  workspace: IAssistantWorkspace,
+  messages: AssistantMessage[],
+) => {
+  const request = getRecentPendingClientAssignmentDecisionRequest(messages);
+
+  if (!request?.requestId) {
+    return null;
+  }
+
+  const updated = applyServiceRequestClientDecision(
+    createAssistantActor(workspace),
+    request.requestId,
+    {
+      assignmentIds: request.assignmentIds,
+      decision: request.decision,
+    },
+  );
+
+  workspace.serviceRequests = workspace.serviceRequests.map((item) =>
+    item.id === updated.id ? updated : item,
+  );
+
+  return {
+    message:
+      `${request.decision === "approve" ? "Approved" : "Rejected"} the assigned representatives for ${request.requestTitle ?? "the request"}.` +
+      ` Next best action: ${
+        request.decision === "approve"
+          ? "wait for the representative response."
+          : "ask admin to review and assign a different team."
+      }`,
+    mode: "workflow" as const,
+    model: "local-client-assignment-decision-workflow",
+    reason: "Confirmed client assignment decision executed against the workflow store.",
+    mutations: [
+      {
+        entityId: updated.id,
+        entityType: "note" as const,
+        operation: "update" as const,
+        record: updated as unknown as Record<string, unknown>,
+        title: updated.title,
+      },
+    ] satisfies AssistantMutation[],
+    trace: [
+      {
+        arguments: {
+          assignmentIds: request.assignmentIds,
+          decision: request.decision,
+          requestId: request.requestId,
+        },
+        outputPreview: createTracePreview({
+          requestTitle: request.requestTitle,
+          status: updated.status,
+        }),
+        tool: "client_assignment_decision_workflow",
+      },
+    ] satisfies AssistantTraceStep[],
+  };
+};
+
+const shouldRunConfirmedRepresentativeDecisionWorkflow = (
+  latestUserMessage: string,
+  messages: AssistantMessage[],
+) =>
+  isConfirmationMessage(latestUserMessage) &&
+  Boolean(getRecentPendingRepresentativeDecisionRequest(messages));
+
+const createConfirmedRepresentativeDecisionResult = (
+  workspace: IAssistantWorkspace,
+  messages: AssistantMessage[],
+) => {
+  const request = getRecentPendingRepresentativeDecisionRequest(messages);
+
+  if (!request?.requestId || !request.assignmentId) {
+    return null;
+  }
+
+  const updated = applyServiceRequestRepDecision(
+    createAssistantActor(workspace),
+    request.requestId,
+    {
+      assignmentId: request.assignmentId,
+      decision: request.decision,
+    },
+  );
+
+  workspace.serviceRequests = workspace.serviceRequests.map((item) =>
+    item.id === updated.id ? updated : item,
+  );
+
+  return {
+    message:
+      `${request.decision === "accept" ? "Accepted" : "Rejected"} the assignment for ${request.requestTitle ?? "the request"}.` +
+      ` Next best action: ${
+        request.decision === "accept"
+          ? "begin the client follow-up and delivery work."
+          : "notify admin to reassign the request."
+      }`,
+    mode: "workflow" as const,
+    model: "local-representative-decision-workflow",
+    reason: "Confirmed representative assignment decision executed against the workflow store.",
+    mutations: [
+      {
+        entityId: updated.id,
+        entityType: "note" as const,
+        operation: "update" as const,
+        record: updated as unknown as Record<string, unknown>,
+        title: updated.title,
+      },
+    ] satisfies AssistantMutation[],
+    trace: [
+      {
+        arguments: {
+          assignmentId: request.assignmentId,
+          decision: request.decision,
+          requestId: request.requestId,
+        },
+        outputPreview: createTracePreview({
+          representative: request.representativeName,
+          requestTitle: request.requestTitle,
+          status: updated.status,
+        }),
+        tool: "representative_assignment_decision_workflow",
       },
     ] satisfies AssistantTraceStep[],
   };
@@ -7041,6 +7427,24 @@ export const runSecureAssistant = async ({
 
   if (confirmedClientRequestAssignmentResult) {
     return confirmedClientRequestAssignmentResult;
+  }
+
+  const confirmedClientAssignmentDecisionResult =
+    shouldRunConfirmedClientAssignmentDecisionWorkflow(latestUserMessage, messages)
+      ? createConfirmedClientAssignmentDecisionResult(workspace, messages)
+      : null;
+
+  if (confirmedClientAssignmentDecisionResult) {
+    return confirmedClientAssignmentDecisionResult;
+  }
+
+  const confirmedRepresentativeDecisionResult =
+    shouldRunConfirmedRepresentativeDecisionWorkflow(latestUserMessage, messages)
+      ? createConfirmedRepresentativeDecisionResult(workspace, messages)
+      : null;
+
+  if (confirmedRepresentativeDecisionResult) {
+    return confirmedRepresentativeDecisionResult;
   }
 
   const clientRequestNotificationSummaryReply = createClientRequestNotificationSummaryReply(

--- a/lib/server/assistant-openai.ts
+++ b/lib/server/assistant-openai.ts
@@ -9,6 +9,7 @@ import {
   getOpportunityInsights,
   getTeamCapacity,
 } from "@/providers/salesSelectors";
+import { OpportunityStage, ProposalStatus } from "@/providers/salesTypes";
 
 import {
   getAssistantServerConfig,
@@ -19,21 +20,28 @@ import type { IAssistantWorkspace } from "./assistant-workspace";
 import { isClientScopedUser } from "@/lib/auth/dashboard-access";
 import { isManagerRole } from "@/lib/auth/roles";
 import {
+  createLiveOpportunity,
+  createLiveProposal,
+  deleteLiveOpportunity,
+  deleteLiveProposal,
+  updateLiveProposal,
+} from "@/lib/server/assistant-backend";
+import {
   createMockActivity,
   createMockClient,
   createMockContact,
   createMockNote,
-  listMockNotes,
-  listMockPricingRequests,
-  deleteMockClient,
-  deleteMockOpportunity,
-  deleteMockProposal,
   deleteMockActivity,
+  deleteMockClient,
   deleteMockNote,
+  deleteMockOpportunity,
   deleteMockPricingRequest,
+  deleteMockProposal,
   createMockOpportunity,
   createMockPricingRequest,
   createMockProposal,
+  listMockNotes,
+  listMockPricingRequests,
   updateMockActivity,
   updateMockNote,
   updateMockOpportunity,
@@ -83,6 +91,31 @@ type ProviderResponse = {
   output_text?: string;
 };
 
+type ChatCompletionToolCall = {
+  id?: string;
+  function?: {
+    arguments?: string;
+    name?: string;
+  };
+  type?: string;
+};
+
+type ChatCompletionMessage = {
+  content?: string | null;
+  role?: string;
+  tool_calls?: ChatCompletionToolCall[];
+};
+
+type ChatCompletionChoice = {
+  finish_reason?: string | null;
+  message?: ChatCompletionMessage | null;
+};
+
+type ChatCompletionResponse = {
+  choices?: ChatCompletionChoice[] | null;
+  id?: string;
+};
+
 type AssistantInputMessage = {
   content: string;
   role: "assistant" | "user";
@@ -105,6 +138,29 @@ type AssistantResponseInput =
   | AssistantFunctionCallInput
   | AssistantFunctionOutputInput
   | AssistantInputMessage;
+
+type AssistantChatMessage =
+  | {
+      content: string;
+      role: "assistant" | "system" | "user";
+    }
+  | {
+      content?: string | null;
+      role: "assistant";
+      tool_calls: Array<{
+        id: string;
+        function: {
+          arguments: string;
+          name: string;
+        };
+        type: "function";
+      }>;
+    }
+  | {
+      content: string;
+      role: "tool";
+      tool_call_id: string;
+    };
 
 type AssistantActor = {
   email: string;
@@ -148,6 +204,32 @@ type PendingMessageSendRequest = {
   recipientId: string | null;
   recipientName: string | null;
   subject: string | null;
+};
+
+type PendingProposalDraftRequest = {
+  description: string | null;
+  opportunityId: string | null;
+  opportunityTitle: string | null;
+  title: string | null;
+  validUntil: string | null;
+};
+
+type PendingProposalEditRequest = {
+  proposalId: string | null;
+  proposalTitle: string | null;
+  title: string | null;
+  validUntil: string | null;
+};
+
+type PendingOpportunityCreateRequest = {
+  clientId: string | null;
+  clientName: string | null;
+  estimatedValue: number | null;
+  expectedCloseDate: string | null;
+  ownerId: string | null;
+  ownerName: string | null;
+  stage: string | null;
+  title: string | null;
 };
 
 type WorkloadBoostPlan = {
@@ -541,6 +623,497 @@ const resolveMessageRecipientReference = (
 
 const buildMessageSubject = (recipientName: string | null) =>
   recipientName ? `Message to ${recipientName}` : "Workspace message";
+
+const PROPOSAL_DRAFT_CONFIRMATION_TOOL = "confirmation_required_proposal_draft_create";
+const PROPOSAL_EDIT_CONFIRMATION_TOOL = "confirmation_required_proposal_edit";
+
+const parseDateReference = (value: string) => {
+  const isoMatch = value.match(/(\d{4}-\d{2}-\d{2})/);
+
+  if (isoMatch?.[1]) {
+    return isoMatch[1];
+  }
+
+  const normalized = value.replace(/\b(expire|expires|expiry|on|until|valid|date)\b/gi, " ").trim();
+  const parsed = new Date(normalized);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return parsed.toISOString().split("T")[0];
+};
+
+const isProposalDraftIntent = (message: string) => {
+  const normalized = normalizeLookupValue(message);
+
+  return (
+    normalized.includes("create a draft proposal") ||
+    normalized.includes("create draft proposal") ||
+    normalized.includes("create a proposal") ||
+    normalized.includes("new draft proposal") ||
+    normalized.includes("fresh draft proposal")
+  );
+};
+
+const isProposalEditIntent = (message: string) => {
+  const normalized = normalizeLookupValue(message);
+
+  return (
+    normalized.includes("change it") ||
+    normalized.includes("edit it") ||
+    normalized.includes("update it") ||
+    normalized.includes("rename it") ||
+    normalized.includes("change proposal") ||
+    normalized.includes("edit proposal") ||
+    normalized.includes("update proposal")
+  );
+};
+
+const extractProposalTitle = (message: string) =>
+  message.match(/\btitle\s+(?:is|to)\s+["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim() ??
+  message.match(/\b(?:rename|call)\s+(?:it|the proposal)\s+["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim() ??
+  message.match(/\bdraft proposal titled\s+["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim() ??
+  null;
+
+const extractProposalValidUntil = (message: string) => {
+  const raw =
+    message.match(/\b(?:expire|expires|expiry|valid until)\s*(?:on)?\s*[:\-]?\s*([\s\S]+)$/i)?.[1]?.trim() ??
+    null;
+
+  return raw ? parseDateReference(raw) : null;
+};
+
+const isOpportunityCreateIntent = (message: string) => {
+  const normalized = normalizeLookupValue(message);
+
+  return (
+    normalized.includes("create a new opportunity") ||
+    normalized.includes("create new opportunity") ||
+    normalized.includes("create an opportunity") ||
+    normalized.includes("create opportunity") ||
+    normalized.includes("new opportunity")
+  );
+};
+
+const findClientByReferenceInWorkspace = (
+  workspace: IAssistantWorkspace,
+  reference: string | null,
+) => {
+  if (!reference) {
+    return null;
+  }
+
+  const normalizedReference = normalizeLookupValue(reference);
+
+  return (
+    workspace.salesData.clients.find(
+      (client) => normalizeLookupValue(client.id) === normalizedReference,
+    ) ??
+    workspace.salesData.clients.find(
+      (client) => normalizeLookupValue(client.name) === normalizedReference,
+    ) ??
+    workspace.salesData.clients.find((client) =>
+      normalizeLookupValue(client.name).includes(normalizedReference),
+    ) ??
+    null
+  );
+};
+
+const findOwnerByReferenceInWorkspace = (
+  workspace: IAssistantWorkspace,
+  reference: string | null,
+) => {
+  if (!reference) {
+    return null;
+  }
+
+  const normalizedReference = normalizeLookupValue(reference);
+
+  return (
+    workspace.salesData.teamMembers.find(
+      (member) => normalizeLookupValue(member.id) === normalizedReference,
+    ) ??
+    workspace.salesData.teamMembers.find(
+      (member) => normalizeLookupValue(member.name) === normalizedReference,
+    ) ??
+    workspace.salesData.teamMembers.find((member) =>
+      normalizeLookupValue(member.name).includes(normalizedReference),
+    ) ??
+    null
+  );
+};
+
+const extractOpportunityEstimatedValue = (message: string) => {
+  const sanitizedMessage = message
+    .replace(/\b\d{4}-\d{2}-\d{2}\b/g, " ")
+    .replace(/\b\d{1,2}\s+[a-z]+\s+(?:\d{4}|this year)\b/gi, " ");
+  const currencyMatch =
+    sanitizedMessage.match(/\b(?:r|zar)\s*[:\-]?\s*(\d+(?:[ ,]\d{3})*(?:\.\d+)?|\d+(?:\.\d+)?)/i)?.[0] ??
+    sanitizedMessage.match(/\bworth\s+(?:r|zar)?\s*(\d+(?:[ ,]\d{3})*(?:\.\d+)?|\d+(?:\.\d+)?)/i)?.[0] ??
+    null;
+
+  if (!currencyMatch) {
+    return null;
+  }
+
+  const value = parseCurrencyNumber(currencyMatch);
+  return value > 0 ? value : null;
+};
+
+const extractOpportunityExpectedCloseDate = (message: string) => {
+  const isoMatch = message.match(/\b(\d{4}-\d{2}-\d{2})\b/);
+
+  if (isoMatch?.[1]) {
+    return isoMatch[1];
+  }
+
+  const naturalMatch =
+    message.match(/\b(\d{1,2}\s+[a-z]+\s+\d{4})\b/i)?.[1] ??
+    message.match(/\b(\d{1,2}\s+[a-z]+\s+this year)\b/i)?.[1] ??
+    message.match(
+      /\b(?:close date|expected close date|date)\s*(?:is|on|to)?\s*[:\-]?\s*([a-z0-9\s,-]+)/i,
+    )?.[1] ??
+    null;
+
+  return naturalMatch ? parseDateReference(naturalMatch) : null;
+};
+
+const extractOpportunityStage = (message: string) => {
+  const normalized = normalizeLookupValue(message);
+
+  if (normalized.includes("negotiation") || normalized.includes("negotiating")) {
+    return OpportunityStage.Negotiating;
+  }
+  if (normalized.includes("proposal sent") || normalized.includes("proposal")) {
+    return OpportunityStage.ProposalSent;
+  }
+  if (normalized.includes("qualified")) {
+    return OpportunityStage.Qualified;
+  }
+  if (normalized.includes("won")) {
+    return OpportunityStage.Won;
+  }
+  if (normalized.includes("lost")) {
+    return OpportunityStage.Lost;
+  }
+  if (normalized.includes("new")) {
+    return OpportunityStage.New;
+  }
+
+  return null;
+};
+
+const extractOpportunityTitle = (
+  message: string,
+  workspace: IAssistantWorkspace,
+  clientName: string | null,
+  ownerName: string | null,
+) => {
+  const explicit =
+    message.match(/\bopportunity title\s*(?:is|to)?\s*[:\-]?\s*["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim() ??
+    message.match(/\bdeal called\s*["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim() ??
+    message.match(/\btitle\s*(?:is|to)\s*["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim() ??
+    null;
+
+  if (explicit) {
+    return explicit;
+  }
+
+  let remainder = ` ${message} `;
+
+  if (clientName) {
+    remainder = remainder.replace(new RegExp(clientName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"), " ");
+  }
+
+  if (ownerName) {
+    remainder = remainder.replace(new RegExp(ownerName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"), " ");
+    const firstName = ownerName.split(" ")[0];
+    if (firstName) {
+      remainder = remainder.replace(new RegExp(firstName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"), " ");
+    }
+  }
+
+  workspace.salesData.teamMembers.forEach((member) => {
+    const firstName = member.name.split(" ")[0];
+    if (firstName && normalizeLookupValue(message).includes(normalizeLookupValue(firstName))) {
+      remainder = remainder.replace(new RegExp(firstName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"), " ");
+    }
+  });
+
+  remainder = remainder
+    .replace(/\b\d{4}-\d{2}-\d{2}\b/g, " ")
+    .replace(/\b\d{1,2}\s+[a-z]+\s+(?:\d{4}|this year)\b/gi, " ")
+    .replace(/\b(?:r|zar)\s*[:\-]?\s*[\d][\d\s,]*(?:\.\d+)?\b/gi, " ")
+    .replace(/\b(?:close date|expected close date|date|owner|stage|client|assign to|worth)\b/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return remainder.length > 0 ? remainder : null;
+};
+
+const findOpportunityByReferenceInWorkspace = (
+  workspace: IAssistantWorkspace,
+  reference: string | null,
+) => {
+  if (!reference) {
+    return null;
+  }
+
+  const normalizedReference = normalizeLookupValue(reference);
+
+  return (
+    workspace.salesData.opportunities.find(
+      (opportunity) => normalizeLookupValue(opportunity.id) === normalizedReference,
+    ) ??
+    workspace.salesData.opportunities.find(
+      (opportunity) => normalizeLookupValue(opportunity.title) === normalizedReference,
+    ) ??
+    workspace.salesData.opportunities.find((opportunity) =>
+      normalizeLookupValue(opportunity.title).includes(normalizedReference),
+    ) ??
+    null
+  );
+};
+
+const findProposalByReferenceInWorkspace = (
+  workspace: IAssistantWorkspace,
+  reference: string | null,
+) => {
+  if (!reference) {
+    return null;
+  }
+
+  const normalizedReference = normalizeLookupValue(reference);
+
+  return (
+    workspace.salesData.proposals.find(
+      (proposal) => normalizeLookupValue(proposal.id) === normalizedReference,
+    ) ??
+    workspace.salesData.proposals.find(
+      (proposal) => normalizeLookupValue(proposal.title) === normalizedReference,
+    ) ??
+    workspace.salesData.proposals.find((proposal) =>
+      normalizeLookupValue(proposal.title).includes(normalizedReference),
+    ) ??
+    null
+  );
+};
+
+const extractOpportunityReference = (
+  message: string,
+  workspace: IAssistantWorkspace,
+) =>
+  workspace.salesData.opportunities.find((opportunity) =>
+    normalizeLookupValue(message).includes(normalizeLookupValue(opportunity.title)),
+  )?.title ?? null;
+
+const inferPendingProposalDraftRequest = (
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) => {
+  const recentUserMessages = getRecentUserMessages(messages).slice(-6);
+  const hasDraftIntent = recentUserMessages.some((message) => isProposalDraftIntent(message.content));
+
+  if (!hasDraftIntent) {
+    return null;
+  }
+
+  const request: PendingProposalDraftRequest = {
+    description: null,
+    opportunityId: null,
+    opportunityTitle: null,
+    title: null,
+    validUntil: null,
+  };
+
+  recentUserMessages.forEach((message) => {
+    request.title = extractProposalTitle(message.content) ?? request.title;
+    request.validUntil = extractProposalValidUntil(message.content) ?? request.validUntil;
+    request.opportunityTitle =
+      extractOpportunityReference(message.content, workspace) ?? request.opportunityTitle;
+  });
+
+  const opportunity = findOpportunityByReferenceInWorkspace(workspace, request.opportunityTitle);
+  request.opportunityId = opportunity?.id ?? null;
+
+  return request;
+};
+
+const inferPendingProposalEditRequest = (
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) => {
+  const recentUserMessages = getRecentUserMessages(messages).slice(-6);
+  const recentAssistant = lastAssistantContent(messages);
+  const hasEditIntent =
+    recentUserMessages.some((message) => isProposalEditIntent(message.content)) &&
+    normalizeLookupValue(recentAssistant).includes("proposal");
+
+  if (!hasEditIntent) {
+    return null;
+  }
+
+  const request: PendingProposalEditRequest = {
+    proposalId: null,
+    proposalTitle: null,
+    title: null,
+    validUntil: null,
+  };
+
+  recentUserMessages.forEach((message) => {
+    request.title = extractProposalTitle(message.content) ?? request.title;
+    request.validUntil = extractProposalValidUntil(message.content) ?? request.validUntil;
+    request.proposalTitle =
+      request.proposalTitle ??
+      findProposalByReferenceInWorkspace(workspace, message.content)?.title ??
+      null;
+  });
+
+  request.proposalTitle =
+    request.proposalTitle ??
+    recentAssistant.match(/proposal(?: is| titled)?\s+["“]?(.+?)["”]?(?:,| currently|\.)/i)?.[1]?.trim() ??
+    workspace.salesData.proposals[0]?.title ??
+    null;
+
+  const proposal = findProposalByReferenceInWorkspace(workspace, request.proposalTitle);
+  request.proposalId = proposal?.id ?? null;
+
+  return request;
+};
+
+const getRecentPendingProposalDraftRequest = (
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) => {
+  const traceStep = [...messages]
+    .reverse()
+    .filter((message) => message.role === "assistant")
+    .flatMap((message) => message.trace ?? [])
+    .find((step) => step.tool === PROPOSAL_DRAFT_CONFIRMATION_TOOL);
+
+  if (!traceStep) {
+    return inferPendingProposalDraftRequest(messages, workspace);
+  }
+
+  return {
+    description:
+      typeof traceStep.arguments.description === "string" ? traceStep.arguments.description : null,
+    opportunityId:
+      typeof traceStep.arguments.opportunityId === "string" ? traceStep.arguments.opportunityId : null,
+    opportunityTitle:
+      typeof traceStep.arguments.opportunityTitle === "string"
+        ? traceStep.arguments.opportunityTitle
+        : null,
+    title: typeof traceStep.arguments.title === "string" ? traceStep.arguments.title : null,
+    validUntil:
+      typeof traceStep.arguments.validUntil === "string" ? traceStep.arguments.validUntil : null,
+  } satisfies PendingProposalDraftRequest;
+};
+
+const getRecentPendingProposalEditRequest = (
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) => {
+  const traceStep = [...messages]
+    .reverse()
+    .filter((message) => message.role === "assistant")
+    .flatMap((message) => message.trace ?? [])
+    .find((step) => step.tool === PROPOSAL_EDIT_CONFIRMATION_TOOL);
+
+  if (!traceStep) {
+    return inferPendingProposalEditRequest(messages, workspace);
+  }
+
+  return {
+    proposalId:
+      typeof traceStep.arguments.proposalId === "string" ? traceStep.arguments.proposalId : null,
+    proposalTitle:
+      typeof traceStep.arguments.proposalTitle === "string"
+        ? traceStep.arguments.proposalTitle
+        : null,
+    title: typeof traceStep.arguments.title === "string" ? traceStep.arguments.title : null,
+    validUntil:
+      typeof traceStep.arguments.validUntil === "string" ? traceStep.arguments.validUntil : null,
+  } satisfies PendingProposalEditRequest;
+};
+
+const inferPendingOpportunityCreateRequest = (
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) => {
+  const recentUserMessages = getRecentUserMessages(messages).slice(-6);
+  const recentAssistant = lastAssistantContent(messages);
+  const confirmedMutationRequest = getRecentConfirmedGenericMutationRequest(messages);
+  const hasCreateIntent =
+    recentUserMessages.some((message) => isOpportunityCreateIntent(message.content)) ||
+    (confirmedMutationRequest ? isOpportunityCreateIntent(confirmedMutationRequest) : false) ||
+    normalizeLookupValue(recentAssistant).includes("create the opportunity");
+
+  if (!hasCreateIntent) {
+    return null;
+  }
+
+  const request: PendingOpportunityCreateRequest = {
+    clientId: null,
+    clientName: null,
+    estimatedValue: null,
+    expectedCloseDate: null,
+    ownerId: null,
+    ownerName: null,
+    stage: null,
+    title: null,
+  };
+
+  recentUserMessages.forEach((message) => {
+    const client =
+      workspace.salesData.clients.find((item) =>
+        normalizeLookupValue(message.content).includes(normalizeLookupValue(item.name)),
+      ) ??
+      workspace.salesData.clients.find((item) =>
+        normalizeLookupValue(message.content).includes(normalizeLookupValue(item.id)),
+      ) ??
+      null;
+    const owner =
+      workspace.salesData.teamMembers.find((item) =>
+        normalizeLookupValue(message.content).includes(normalizeLookupValue(item.name)),
+      ) ??
+      workspace.salesData.teamMembers.find((item) =>
+        normalizeLookupValue(message.content).includes(normalizeLookupValue(item.name.split(" ")[0] ?? "")),
+      ) ??
+      workspace.salesData.teamMembers.find((item) =>
+        normalizeLookupValue(message.content).includes(normalizeLookupValue(item.id)),
+      ) ??
+      null;
+
+    request.clientId = client?.id ?? request.clientId;
+    request.clientName = client?.name ?? request.clientName;
+    request.ownerId = owner?.id ?? request.ownerId;
+    request.ownerName = owner?.name ?? request.ownerName;
+    request.estimatedValue =
+      extractOpportunityEstimatedValue(message.content) ?? request.estimatedValue;
+    request.expectedCloseDate =
+      extractOpportunityExpectedCloseDate(message.content) ?? request.expectedCloseDate;
+    request.stage = extractOpportunityStage(message.content) ?? request.stage;
+    request.title =
+      extractOpportunityTitle(
+        message.content,
+        workspace,
+        request.clientName,
+        request.ownerName,
+      ) ?? request.title;
+  });
+
+  if (request.clientName && !request.clientId) {
+    request.clientId = findClientByReferenceInWorkspace(workspace, request.clientName)?.id ?? null;
+  }
+
+  if (request.ownerName && !request.ownerId) {
+    request.ownerId = findOwnerByReferenceInWorkspace(workspace, request.ownerName)?.id ?? null;
+  }
+
+  return request;
+};
 
 const CLIENT_REQUEST_ASSIGNMENT_CONFIRMATION_TOOL =
   "confirmation_required_client_request_assignment";
@@ -1150,6 +1723,57 @@ const createMutationConfirmationReply = (
     );
   }
 
+  const proposalDraftRequest = inferPendingProposalDraftRequest(messages, workspace);
+
+  if (proposalDraftRequest) {
+    if (!proposalDraftRequest.opportunityId && !proposalDraftRequest.opportunityTitle) {
+      return createLocalAssistantResult({
+        arguments: {
+          missing: "opportunity",
+        },
+        message:
+          "I can create the draft proposal, but I still need the opportunity title or id so I can attach it to the right deal.",
+        output: proposalDraftRequest,
+        reason: "Proposal draft request is missing the target opportunity.",
+        tool: "proposal_draft_missing_opportunity",
+      });
+    }
+
+    if (!proposalDraftRequest.title || !proposalDraftRequest.validUntil) {
+      return createLocalAssistantResult({
+        arguments: {
+          missingTitle: !proposalDraftRequest.title,
+          missingValidUntil: !proposalDraftRequest.validUntil,
+        },
+        message:
+          "I can create the draft proposal, but I still need the proposal title and expiry date.",
+        output: proposalDraftRequest,
+        reason: "Proposal draft request is missing required proposal details.",
+        tool: "proposal_draft_missing_details",
+      });
+    }
+
+    return createConfirmationResult(
+      `I can create draft proposal ${proposalDraftRequest.title} with expiry ${proposalDraftRequest.validUntil}. Reply confirm to proceed.`,
+      proposalDraftRequest,
+      PROPOSAL_DRAFT_CONFIRMATION_TOOL,
+    );
+  }
+
+  const proposalEditRequest = inferPendingProposalEditRequest(messages, workspace);
+
+  if (proposalEditRequest?.proposalId && (proposalEditRequest.title || proposalEditRequest.validUntil)) {
+    return createConfirmationResult(
+      `I can update ${proposalEditRequest.proposalTitle ?? "that proposal"}${
+        proposalEditRequest.title ? ` with title ${proposalEditRequest.title}` : ""
+      }${
+        proposalEditRequest.validUntil ? ` and expiry ${proposalEditRequest.validUntil}` : ""
+      }. Reply confirm to proceed.`,
+      proposalEditRequest,
+      PROPOSAL_EDIT_CONFIRMATION_TOOL,
+    );
+  }
+
   if (isMessageDraftIntent(latestUserMessage)) {
     return createDraftMessageReply(latestUserMessage);
   }
@@ -1403,6 +2027,281 @@ const createClientRequestAssignmentResult = (
           request: plan.request.title,
         }),
         tool: CLIENT_REQUEST_ASSIGNMENT_TOOL,
+      },
+    ] satisfies AssistantTraceStep[],
+  };
+};
+
+const shouldRunConfirmedProposalDraftWorkflow = (
+  latestUserMessage: string,
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) =>
+  isConfirmationMessage(latestUserMessage) &&
+  Boolean(getRecentPendingProposalDraftRequest(messages, workspace)?.title);
+
+const createConfirmedProposalDraftResult = async (
+  workspace: IAssistantWorkspace,
+  messages: AssistantMessage[],
+) => {
+  const request = getRecentPendingProposalDraftRequest(messages, workspace);
+
+  if (!request?.title || !request.validUntil) {
+    return null;
+  }
+
+  const opportunity =
+    findOpportunityByReferenceInWorkspace(workspace, request.opportunityId ?? request.opportunityTitle) ??
+    null;
+
+  if (!opportunity) {
+    return null;
+  }
+
+  const proposal = workspace.isLiveBackend && workspace.sessionToken
+    ? await createLiveProposal(workspace.sessionToken, {
+        clientId: opportunity.clientId,
+        currency: "ZAR",
+        description:
+          request.description ??
+          `Generated from assistant draft proposal request for ${request.title}.`,
+        id: "",
+        opportunityId: opportunity.id,
+        status: ProposalStatus.Draft,
+        title: request.title,
+        validUntil: request.validUntil,
+      })
+    : createMockProposal(createAssistantActor(workspace), {
+        currency: "ZAR",
+        description:
+          request.description ??
+          `Generated from assistant draft proposal request for ${request.title}.`,
+        opportunityId: opportunity.id,
+        title: request.title,
+        validUntil: request.validUntil,
+      });
+  upsertById(workspace.salesData.proposals, proposal);
+
+  return {
+    message:
+      `Created draft proposal ${proposal.title} for ${opportunity.title}, valid until ${proposal.validUntil}.`,
+    mode: "workflow" as const,
+    model: "local-proposal-draft-workflow",
+    reason: "Confirmed draft proposal executed locally from recent assistant context.",
+    mutations: [
+      {
+        entityId: proposal.id,
+        entityType: "proposal" as const,
+        operation: "create" as const,
+        record: proposal as unknown as Record<string, unknown>,
+        title: proposal.title,
+      },
+    ] satisfies AssistantMutation[],
+    trace: [
+      {
+        arguments: {
+          opportunityId: opportunity.id,
+          title: proposal.title,
+          validUntil: proposal.validUntil,
+        },
+        outputPreview: createTracePreview({
+          opportunity: opportunity.title,
+          proposal: proposal.title,
+          validUntil: proposal.validUntil,
+        }),
+        tool: "confirmed_proposal_draft_workflow",
+      },
+    ] satisfies AssistantTraceStep[],
+  };
+};
+
+const shouldRunConfirmedProposalEditWorkflow = (
+  latestUserMessage: string,
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) =>
+  isConfirmationMessage(latestUserMessage) &&
+  Boolean(getRecentPendingProposalEditRequest(messages, workspace)?.proposalId);
+
+const createConfirmedProposalEditResult = async (
+  workspace: IAssistantWorkspace,
+  messages: AssistantMessage[],
+) => {
+  const request = getRecentPendingProposalEditRequest(messages, workspace);
+
+  if (!request?.proposalId) {
+    return null;
+  }
+
+  const existingProposal =
+    findProposalByReferenceInWorkspace(workspace, request.proposalId ?? request.proposalTitle) ??
+    null;
+
+  if (!existingProposal) {
+    return null;
+  }
+
+  const updatedProposal =
+    workspace.isLiveBackend && workspace.sessionToken
+      ? await updateLiveProposal(workspace.sessionToken, {
+          ...existingProposal,
+          title: request.title ?? existingProposal.title,
+          validUntil: request.validUntil ?? existingProposal.validUntil,
+        })
+      : updateMockProposal(workspace.tenantId, existingProposal.id, {
+          title: request.title ?? existingProposal.title,
+          validUntil: request.validUntil ?? existingProposal.validUntil,
+        });
+
+  if (!updatedProposal) {
+    return null;
+  }
+
+  upsertById(workspace.salesData.proposals, updatedProposal);
+
+  return {
+    message:
+      `Updated proposal ${updatedProposal.title}. It is now valid until ${updatedProposal.validUntil}.`,
+    mode: "workflow" as const,
+    model: "local-proposal-edit-workflow",
+    reason: "Confirmed proposal edit executed locally from recent assistant context.",
+    mutations: [
+      {
+        entityId: updatedProposal.id,
+        entityType: "proposal" as const,
+        operation: "update" as const,
+        record: updatedProposal as unknown as Record<string, unknown>,
+        title: updatedProposal.title,
+      },
+    ] satisfies AssistantMutation[],
+    trace: [
+      {
+        arguments: {
+          proposalId: updatedProposal.id,
+          title: updatedProposal.title,
+          validUntil: updatedProposal.validUntil,
+        },
+        outputPreview: createTracePreview({
+          proposal: updatedProposal.title,
+          validUntil: updatedProposal.validUntil,
+        }),
+        tool: "confirmed_proposal_edit_workflow",
+      },
+    ] satisfies AssistantTraceStep[],
+  };
+};
+
+const shouldRunConfirmedOpportunityCreateWorkflow = (
+  latestUserMessage: string,
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) => {
+  if (isClientScopedUser(workspace.clientIds)) {
+    return false;
+  }
+
+  const request = inferPendingOpportunityCreateRequest(messages, workspace);
+
+  if (!request?.clientId || !request.title || !request.estimatedValue || !request.expectedCloseDate) {
+    return false;
+  }
+
+  const hasUserConfirmation = getRecentUserMessages(messages).some((message) =>
+    isConfirmationMessage(message.content),
+  );
+
+  return hasUserConfirmation && !isConfirmationMessage(latestUserMessage);
+};
+
+const createConfirmedOpportunityCreateResult = async (
+  workspace: IAssistantWorkspace,
+  messages: AssistantMessage[],
+) => {
+  const request = inferPendingOpportunityCreateRequest(messages, workspace);
+
+  if (
+    !request?.clientId ||
+    !request.title ||
+    !request.estimatedValue ||
+    !request.expectedCloseDate
+  ) {
+    return null;
+  }
+
+  const client = findClientByReferenceInWorkspace(
+    workspace,
+    request.clientId ?? request.clientName,
+  );
+
+  if (!client) {
+    return null;
+  }
+
+  const owner =
+    findOwnerByReferenceInWorkspace(workspace, request.ownerId ?? request.ownerName) ??
+    null;
+
+  const opportunity =
+    workspace.isLiveBackend && workspace.sessionToken
+      ? await createLiveOpportunity(workspace.sessionToken, {
+          clientId: client.id,
+          createdDate: new Date().toISOString().split("T")[0],
+          currency: "ZAR",
+          estimatedValue: request.estimatedValue,
+          expectedCloseDate: request.expectedCloseDate,
+          id: "",
+          ownerId: owner?.id,
+          probability: 50,
+          source: 1,
+          stage: request.stage ?? OpportunityStage.New,
+          title: request.title,
+          value: request.estimatedValue,
+        })
+      : createMockOpportunity(createAssistantActor(workspace), {
+          clientId: client.id,
+          estimatedValue: request.estimatedValue,
+          expectedCloseDate: request.expectedCloseDate,
+          ownerId: owner?.id,
+          stage: request.stage ?? OpportunityStage.New,
+          title: request.title,
+        });
+
+  upsertById(workspace.salesData.opportunities, opportunity);
+
+  return {
+    message:
+      `Created opportunity ${opportunity.title} for ${client.name}` +
+      ` worth ${formatCurrency(opportunity.value ?? opportunity.estimatedValue)}` +
+      ` closing on ${opportunity.expectedCloseDate}` +
+      `${owner ? ` and assigned it to ${owner.name}.` : "."}`,
+    mode: "workflow" as const,
+    model: "local-opportunity-create-workflow",
+    reason: "Confirmed opportunity creation executed locally from recent assistant context.",
+    mutations: [
+      {
+        entityId: opportunity.id,
+        entityType: "opportunity" as const,
+        operation: "create" as const,
+        record: opportunity as unknown as Record<string, unknown>,
+        title: opportunity.title,
+      },
+    ] satisfies AssistantMutation[],
+    trace: [
+      {
+        arguments: {
+          clientId: client.id,
+          estimatedValue: opportunity.value ?? opportunity.estimatedValue,
+          expectedCloseDate: opportunity.expectedCloseDate,
+          ownerId: owner?.id ?? null,
+          stage: opportunity.stage,
+          title: opportunity.title,
+        },
+        outputPreview: createTracePreview({
+          client: client.name,
+          opportunity: opportunity.title,
+          owner: owner?.name ?? null,
+        }),
+        tool: "confirmed_opportunity_create_workflow",
       },
     ] satisfies AssistantTraceStep[],
   };
@@ -4179,7 +5078,7 @@ const createToolset = (workspace: IAssistantWorkspace, messages: AssistantMessag
     },
   ];
 
-  const runTool = (name: string, rawArguments: string) => {
+  const runTool = async (name: string, rawArguments: string) => {
     const args = rawArguments ? JSON.parse(rawArguments) as Record<string, unknown> : {};
     const internalMutationTools = new Set([
       "create_client",
@@ -4452,16 +5351,33 @@ const createToolset = (workspace: IAssistantWorkspace, messages: AssistantMessag
       }
       case "create_opportunity": {
         const client = resolveClient(args, { allowRecentFallback: true });
-        const opportunity = createMockOpportunity(actor, {
-          clientId: client.id,
-          description: typeof args.description === "string" ? args.description : undefined,
-          estimatedValue: Number(args.estimatedValue ?? 0),
-          expectedCloseDate: String(args.expectedCloseDate ?? ""),
-          ownerId: typeof args.ownerId === "string" ? args.ownerId : undefined,
-          probability: Number(args.probability ?? 50),
-          stage: typeof args.stage === "string" ? args.stage : undefined,
-          title: String(args.title ?? "Untitled opportunity"),
-        });
+        const opportunity =
+          workspace.isLiveBackend && workspace.sessionToken
+            ? await createLiveOpportunity(workspace.sessionToken, {
+                clientId: client.id,
+                createdDate: new Date().toISOString().split("T")[0],
+                currency: "ZAR",
+                description: typeof args.description === "string" ? args.description : undefined,
+                estimatedValue: Number(args.estimatedValue ?? 0),
+                expectedCloseDate: String(args.expectedCloseDate ?? ""),
+                id: "",
+                ownerId: typeof args.ownerId === "string" ? args.ownerId : undefined,
+                probability: Number(args.probability ?? 50),
+                source: 1,
+                stage: typeof args.stage === "string" ? args.stage : OpportunityStage.New,
+                title: String(args.title ?? "Untitled opportunity"),
+                value: Number(args.estimatedValue ?? 0),
+              })
+            : createMockOpportunity(actor, {
+                clientId: client.id,
+                description: typeof args.description === "string" ? args.description : undefined,
+                estimatedValue: Number(args.estimatedValue ?? 0),
+                expectedCloseDate: String(args.expectedCloseDate ?? ""),
+                ownerId: typeof args.ownerId === "string" ? args.ownerId : undefined,
+                probability: Number(args.probability ?? 50),
+                stage: typeof args.stage === "string" ? args.stage : undefined,
+                title: String(args.title ?? "Untitled opportunity"),
+              });
 
         upsertById(workspace.salesData.opportunities, opportunity);
 
@@ -4481,25 +5397,39 @@ const createToolset = (workspace: IAssistantWorkspace, messages: AssistantMessag
       }
       case "create_proposal": {
         const opportunity = resolveOpportunity(args, { allowRecentFallback: true });
-        const proposal = createMockProposal(actor, {
-          currency: typeof args.currency === "string" ? args.currency : "ZAR",
-          description: typeof args.description === "string" ? args.description : undefined,
-          lineItems: Array.isArray(args.lineItems)
-            ? args.lineItems
-                .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === "object")
-                .map((item) => ({
-                  description: typeof item.description === "string" ? item.description : undefined,
-                  discount: Number(item.discount ?? 0),
-                  productServiceName: String(item.productServiceName ?? ""),
-                  quantity: Number(item.quantity ?? 1),
-                  taxRate: Number(item.taxRate ?? 0),
-                  unitPrice: Number(item.unitPrice ?? 0),
-                }))
-            : [],
-          opportunityId: opportunity.id,
-          title: String(args.title ?? "Untitled proposal"),
-          validUntil: String(args.validUntil ?? ""),
-        });
+        const lineItems = Array.isArray(args.lineItems)
+          ? args.lineItems
+              .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === "object")
+              .map((item) => ({
+                description: typeof item.description === "string" ? item.description : undefined,
+                discount: Number(item.discount ?? 0),
+                productServiceName: String(item.productServiceName ?? ""),
+                quantity: Number(item.quantity ?? 1),
+                taxRate: Number(item.taxRate ?? 0),
+                unitPrice: Number(item.unitPrice ?? 0),
+              }))
+          : [];
+        const proposal =
+          workspace.isLiveBackend && workspace.sessionToken
+            ? await createLiveProposal(workspace.sessionToken, {
+                clientId: opportunity.clientId,
+                currency: typeof args.currency === "string" ? args.currency : "ZAR",
+                description: typeof args.description === "string" ? args.description : undefined,
+                id: "",
+                lineItems,
+                opportunityId: opportunity.id,
+                status: ProposalStatus.Draft,
+                title: String(args.title ?? "Untitled proposal"),
+                validUntil: String(args.validUntil ?? ""),
+              })
+            : createMockProposal(actor, {
+                currency: typeof args.currency === "string" ? args.currency : "ZAR",
+                description: typeof args.description === "string" ? args.description : undefined,
+                lineItems,
+                opportunityId: opportunity.id,
+                title: String(args.title ?? "Untitled proposal"),
+                validUntil: String(args.validUntil ?? ""),
+              });
 
         upsertById(workspace.salesData.proposals, proposal);
 
@@ -4902,7 +5832,11 @@ const createToolset = (workspace: IAssistantWorkspace, messages: AssistantMessag
           allowRecentFallback: true,
         });
 
-        deleteMockOpportunity(workspace.tenantId, opportunity.id);
+        if (workspace.isLiveBackend && workspace.sessionToken) {
+          await deleteLiveOpportunity(workspace.sessionToken, opportunity.id);
+        } else {
+          deleteMockOpportunity(workspace.tenantId, opportunity.id);
+        }
         workspace.salesData.opportunities = workspace.salesData.opportunities.filter(
           (item) => item.id !== opportunity.id,
         );
@@ -4926,7 +5860,11 @@ const createToolset = (workspace: IAssistantWorkspace, messages: AssistantMessag
       case "delete_proposal": {
         const proposal = resolveProposal(args, { allowRecentFallback: true });
 
-        deleteMockProposal(workspace.tenantId, proposal.id);
+        if (workspace.isLiveBackend && workspace.sessionToken) {
+          await deleteLiveProposal(workspace.sessionToken, proposal.id);
+        } else {
+          deleteMockProposal(workspace.tenantId, proposal.id);
+        }
         workspace.salesData.proposals = workspace.salesData.proposals.filter(
           (item) => item.id !== proposal.id,
         );
@@ -5117,6 +6055,8 @@ const extractFunctionCalls = (response: ProviderResponse) =>
   (response.output ?? []).filter((item) => item.type === "function_call");
 
 const createResponsesUrl = (baseUrl: string) => `${baseUrl.replace(/\/$/, "")}/responses`;
+const createChatCompletionsUrl = (baseUrl: string) =>
+  `${baseUrl.replace(/\/$/, "")}/chat/completions`;
 
 const parseProviderError = async (response: Response) => {
   const raw = await response.text();
@@ -5200,6 +6140,46 @@ const callResponsesApi = async (
   return response.json() as Promise<ProviderResponse>;
 };
 
+const callChatCompletionsApi = async (
+  config: AssistantServerConfig,
+  body: Record<string, unknown>,
+): Promise<ChatCompletionResponse> => {
+  let response: Response;
+
+  try {
+    response = await fetch(createChatCompletionsUrl(config.baseUrl), {
+      body: JSON.stringify(body),
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+  } catch (error) {
+    throw new AssistantProviderRequestError(
+      error instanceof Error
+        ? error.message
+        : "The live assistant provider could not be reached.",
+      { status: 0 },
+    );
+  }
+
+  if (!response.ok) {
+    if (response.status === 429) {
+      logProviderRateLimit(config, response);
+    }
+
+    const providerError = await parseProviderError(response);
+
+    throw new AssistantProviderRequestError(providerError.message, {
+      code: providerError.code,
+      status: response.status,
+    });
+  }
+
+  return response.json() as Promise<ChatCompletionResponse>;
+};
+
 const createToolMetadata = (toolDefinitions: ToolDefinition[]) =>
   toolDefinitions.map((tool) => ({
     description: tool.description,
@@ -5207,6 +6187,101 @@ const createToolMetadata = (toolDefinitions: ToolDefinition[]) =>
     parameters: tool.parameters,
     type: "function",
   }));
+
+const createChatCompletionToolMetadata = (toolDefinitions: ToolDefinition[]) =>
+  toolDefinitions.map((tool) => ({
+    function: {
+      description: tool.description,
+      name: tool.name,
+      parameters: tool.parameters,
+    },
+    type: "function",
+  }));
+
+const filterGeminiToolDefinitions = (
+  toolDefinitions: ToolDefinition[],
+  latestUserMessage: string,
+) => {
+  const normalized = normalizeLookupValue(latestUserMessage);
+  const selected = new Set<string>([
+    "get_scope_overview",
+    "list_opportunities",
+    "list_proposals",
+    "list_follow_ups",
+    "search_workspace_records",
+  ]);
+
+  if (
+    normalized.includes("message") ||
+    normalized.includes("email") ||
+    normalized.includes("send ")
+  ) {
+    selected.add("create_message");
+  }
+
+  if (
+    normalized.includes("opportunity") ||
+    normalized.includes("deal") ||
+    normalized.includes("pipeline")
+  ) {
+    selected.add("create_opportunity");
+    selected.add("delete_opportunity");
+  }
+
+  if (normalized.includes("proposal")) {
+    selected.add("create_proposal");
+    selected.add("delete_proposal");
+  }
+
+  if (
+    normalized.includes("pricing") ||
+    normalized.includes("commercial") ||
+    normalized.includes("deal desk")
+  ) {
+    selected.add("create_pricing_request");
+    selected.add("delete_pricing_request");
+  }
+
+  if (
+    normalized.includes("follow up") ||
+    normalized.includes("follow-up") ||
+    normalized.includes("task") ||
+    normalized.includes("activity") ||
+    normalized.includes("meeting") ||
+    normalized.includes("call")
+  ) {
+    selected.add("create_activity");
+    selected.add("delete_activity");
+  }
+
+  if (
+    normalized.includes("note") ||
+    normalized.includes("record this") ||
+    normalized.includes("log this")
+  ) {
+    selected.add("create_note");
+    selected.add("delete_note");
+  }
+
+  if (
+    normalized.includes("client") ||
+    normalized.includes("account") ||
+    normalized.includes("organization")
+  ) {
+    selected.add("create_client");
+    selected.add("delete_client");
+  }
+
+  if (
+    normalized.includes("reassign") ||
+    normalized.includes("rebalance") ||
+    normalized.includes("redistribute")
+  ) {
+    selected.add("rebalance_responsibilities");
+  }
+
+  return toolDefinitions.filter((tool) => selected.has(tool.name));
+};
 
 const mapMessagesToInput = (messages: AssistantMessage[]): AssistantInputMessage[] =>
   messages.map((message) => ({
@@ -5240,6 +6315,21 @@ const mapMessagesToProviderInput = (
     },
   ];
 };
+
+const mapMessagesToChatInput = (
+  systemPrompt: string,
+  messages: AssistantMessage[],
+  confirmedGenericMutationRequest?: string | null,
+): AssistantChatMessage[] => [
+  {
+    content: systemPrompt,
+    role: "system",
+  },
+  ...mapMessagesToProviderInput(messages, confirmedGenericMutationRequest).map((message) => ({
+    content: message.content,
+    role: message.role,
+  })),
+];
 
 const serializeFunctionCallsForInput = (
   calls: ResponseOutputItem[],
@@ -5289,6 +6379,114 @@ const createOfflineAssistantResult = ({
     ] satisfies AssistantTraceStep[],
     mutations: [] satisfies AssistantMutation[],
   };
+};
+
+const runGeminiWithTools = async ({
+  config,
+  messages,
+  runTool,
+  systemPrompt,
+  toolMetadata,
+  trace,
+  mutations,
+}: {
+  config: AssistantServerConfig;
+  messages: AssistantMessage[];
+  mutations: AssistantMutation[];
+  runTool: ReturnType<typeof createToolset>["runTool"];
+  systemPrompt: string;
+  toolMetadata: ReturnType<typeof createChatCompletionToolMetadata>;
+  trace: AssistantTraceStep[];
+}) => {
+  const chatMessages = mapMessagesToChatInput(systemPrompt, messages);
+
+  for (let round = 0; round < MAX_TOOL_ROUNDS; round += 1) {
+    const response = await callChatCompletionsApi(config, {
+      messages: chatMessages,
+      model: config.model,
+      tool_choice: "auto",
+      tools: toolMetadata,
+    });
+
+    const choice = response.choices?.[0]?.message ?? null;
+    const toolCalls = choice?.tool_calls ?? [];
+
+    if (toolCalls.length === 0) {
+      return {
+        message:
+          choice?.content?.trim() ||
+          "The assistant could not produce a final response from the authorized data.",
+        mode: config.provider,
+        model: config.model,
+        reason: null,
+        mutations,
+        trace,
+      };
+    }
+
+    const normalizedToolCalls = toolCalls.flatMap((call) => {
+      const callId = call.id?.trim();
+      const name = call.function?.name?.trim();
+
+      if (!callId || !name) {
+        return [];
+      }
+
+      return [
+        {
+          arguments: call.function?.arguments ?? "{}",
+          id: callId,
+          name,
+        },
+      ];
+    });
+
+    if (normalizedToolCalls.length === 0) {
+      throw new Error("The assistant returned an invalid tool call.");
+    }
+
+    chatMessages.push({
+      content: choice?.content ?? null,
+      role: "assistant",
+      tool_calls: normalizedToolCalls.map((call) => ({
+        id: call.id,
+        function: {
+          arguments: call.arguments,
+          name: call.name,
+        },
+        type: "function",
+      })),
+    });
+
+    for (const call of normalizedToolCalls) {
+      const parsedArguments = call.arguments
+        ? (JSON.parse(call.arguments) as Record<string, unknown>)
+        : {};
+      const output = await runTool(call.name, call.arguments);
+      const mutation =
+        output && typeof output === "object" && "mutation" in output
+          ? (output as { mutation?: AssistantMutation }).mutation
+          : undefined;
+
+      if (mutation) {
+        mutations.push(mutation);
+      }
+
+      trace.push({
+        arguments: parsedArguments,
+        outputPreview: createTracePreview(output),
+        tool: call.name,
+      });
+
+      chatMessages.push({
+        content: JSON.stringify(output),
+        role: "tool",
+        tool_call_id: call.id,
+      });
+    }
+  }
+
+  throw new Error("The assistant exceeded the maximum number of tool rounds.");
 };
 
 const createConfirmedGenericMutationUnavailableResult = ({
@@ -5797,6 +6995,42 @@ export const runSecureAssistant = async ({
     return confirmedMessageSendResult;
   }
 
+  const confirmedProposalDraftResult = shouldRunConfirmedProposalDraftWorkflow(
+    latestUserMessage,
+    messages,
+    workspace,
+  )
+    ? await createConfirmedProposalDraftResult(workspace, messages)
+    : null;
+
+  if (confirmedProposalDraftResult) {
+    return confirmedProposalDraftResult;
+  }
+
+  const confirmedProposalEditResult = shouldRunConfirmedProposalEditWorkflow(
+    latestUserMessage,
+    messages,
+    workspace,
+  )
+    ? await createConfirmedProposalEditResult(workspace, messages)
+    : null;
+
+  if (confirmedProposalEditResult) {
+    return confirmedProposalEditResult;
+  }
+
+  const confirmedOpportunityCreateResult = shouldRunConfirmedOpportunityCreateWorkflow(
+    latestUserMessage,
+    messages,
+    workspace,
+  )
+    ? await createConfirmedOpportunityCreateResult(workspace, messages)
+    : null;
+
+  if (confirmedOpportunityCreateResult) {
+    return confirmedOpportunityCreateResult;
+  }
+
   const confirmedClientRequestAssignmentResult = shouldRunClientRequestAssignmentWorkflow(
     latestUserMessage,
     messages,
@@ -5926,21 +7160,37 @@ export const runSecureAssistant = async ({
   }
 
   const { runTool, toolDefinitions } = createToolset(workspace, messages);
-  const toolMetadata = createToolMetadata(toolDefinitions);
   const trace: AssistantTraceStep[] = [];
   const mutations: AssistantMutation[] = [];
   const initialInput = mapMessagesToProviderInput(messages, confirmedGenericMutationRequest);
   const providerErrors: AssistantProviderRequestError[] = [];
+  const systemPrompt = createSystemPrompt(workspace);
 
   for (const config of configuredProviders) {
-    let statelessInput: AssistantResponseInput[] = [...initialInput];
     const localTraceStart = trace.length;
     const localMutationStart = mutations.length;
 
     try {
+      if (config.provider === "gemini") {
+        const geminiToolMetadata = createChatCompletionToolMetadata(
+          filterGeminiToolDefinitions(toolDefinitions, latestUserMessage),
+        );
+        return await runGeminiWithTools({
+          config,
+          messages,
+          mutations,
+          runTool,
+          systemPrompt,
+          toolMetadata: geminiToolMetadata,
+          trace,
+        });
+      }
+
+      const toolMetadata = createToolMetadata(toolDefinitions);
+      let statelessInput: AssistantResponseInput[] = [...initialInput];
       let response = await callResponsesApi(config, {
         input: initialInput,
-        instructions: createSystemPrompt(workspace),
+        instructions: systemPrompt,
         model: config.model,
         reasoning: { effort: isManagerRole(workspace.role) ? "medium" : "low" },
         tool_choice: "auto",
@@ -5965,7 +7215,9 @@ export const runSecureAssistant = async ({
           };
         }
 
-        const toolOutputs: AssistantFunctionOutputInput[] = functionCalls.map((call) => {
+        const toolOutputs: AssistantFunctionOutputInput[] = [];
+
+        for (const call of functionCalls) {
           if (!call.call_id || !call.name) {
             throw new Error("The assistant returned an invalid tool call.");
           }
@@ -5973,7 +7225,7 @@ export const runSecureAssistant = async ({
           const parsedArguments = call.arguments
             ? (JSON.parse(call.arguments) as Record<string, unknown>)
             : {};
-          const output = runTool(call.name, call.arguments ?? "{}");
+          const output = await runTool(call.name, call.arguments ?? "{}");
           const mutation =
             output && typeof output === "object" && "mutation" in output
               ? (output as { mutation?: AssistantMutation }).mutation
@@ -5989,12 +7241,12 @@ export const runSecureAssistant = async ({
             tool: call.name,
           });
 
-          return {
+          toolOutputs.push({
             call_id: call.call_id,
             output: JSON.stringify(output),
             type: "function_call_output",
-          };
-        });
+          });
+        }
 
         if (config.supportsPreviousResponseId && response.id) {
           response = await callResponsesApi(config, {
@@ -6016,7 +7268,7 @@ export const runSecureAssistant = async ({
 
         response = await callResponsesApi(config, {
           input: statelessInput,
-          instructions: createSystemPrompt(workspace),
+          instructions: systemPrompt,
           model: config.model,
           reasoning: { effort: isManagerRole(workspace.role) ? "medium" : "low" },
           tool_choice: "auto",
@@ -6038,14 +7290,22 @@ export const runSecureAssistant = async ({
   }
 
   const hasRateLimit = providerErrors.some((error) => error.code === "rate_limit_exceeded");
+  const attemptedProviders = configuredProviders
+    .map((provider) => provider.provider[0].toUpperCase() + provider.provider.slice(1))
+    .join(", then ");
+  const firstProviderError = providerErrors[0];
+  const providerErrorSuffix =
+    firstProviderError?.message && process.env.NODE_ENV !== "production"
+      ? ` First provider error: ${firstProviderError.message}`
+      : "";
   const reason =
     configuredProviders.length > 1
       ? hasRateLimit
-        ? "The live assistant providers are temporarily rate-limited. Tried Groq, then OpenAI, and fell back to offline workspace guidance."
-        : "The live assistant providers are temporarily unavailable. Tried Groq, then OpenAI, and fell back to offline workspace guidance."
+        ? `The live assistant providers are temporarily rate-limited. Tried ${attemptedProviders}, and fell back to offline workspace guidance.${providerErrorSuffix}`
+        : `The live assistant providers are temporarily unavailable. Tried ${attemptedProviders}, and fell back to offline workspace guidance.${providerErrorSuffix}`
       : hasRateLimit
-        ? "The live assistant is temporarily rate-limited. Using offline workspace guidance."
-        : "The live assistant is temporarily unavailable. Using offline workspace guidance.";
+        ? `The live assistant is temporarily rate-limited. Using offline workspace guidance.${providerErrorSuffix}`
+        : `The live assistant is temporarily unavailable. Using offline workspace guidance.${providerErrorSuffix}`;
 
   if (confirmedGenericMutationRequest) {
     return createConfirmedGenericMutationUnavailableResult({

--- a/lib/server/assistant-openai.ts
+++ b/lib/server/assistant-openai.ts
@@ -868,6 +868,31 @@ const findRecentNonConfirmationUserMessage = (messages: AssistantMessage[]) =>
     .reverse()
     .find((message) => !isConfirmationMessage(message.content)) ?? null;
 
+const getLatestActiveConfirmationTraceStep = (
+  messages: AssistantMessage[],
+  pendingTool: string,
+  completedTools: string[] = [],
+) => {
+  for (const message of [...messages].reverse()) {
+    if (message.role !== "assistant") {
+      continue;
+    }
+
+    const trace = message.trace ?? [];
+
+    if (completedTools.some((tool) => trace.some((step) => step.tool === tool))) {
+      return null;
+    }
+
+    const pendingStep = trace.find((step) => step.tool === pendingTool);
+    if (pendingStep) {
+      return pendingStep;
+    }
+  }
+
+  return null;
+};
+
 const MESSAGE_SEND_CONFIRMATION_TOOL = "confirmation_required_message_send";
 const PENDING_MESSAGE_SEND_TOOLS = new Set([
   MESSAGE_SEND_CONFIRMATION_TOOL,
@@ -1702,11 +1727,9 @@ const getRecentPendingProposalDraftRequest = (
   messages: AssistantMessage[],
   workspace: IAssistantWorkspace,
 ) => {
-  const traceStep = [...messages]
-    .reverse()
-    .filter((message) => message.role === "assistant")
-    .flatMap((message) => message.trace ?? [])
-    .find((step) => step.tool === PROPOSAL_DRAFT_CONFIRMATION_TOOL);
+  const traceStep = getLatestActiveConfirmationTraceStep(messages, PROPOSAL_DRAFT_CONFIRMATION_TOOL, [
+    "confirmed_proposal_draft_workflow",
+  ]);
 
   if (!traceStep) {
     return inferPendingProposalDraftRequest(messages, workspace);
@@ -1731,11 +1754,9 @@ const getRecentPendingProposalEditRequest = (
   messages: AssistantMessage[],
   workspace: IAssistantWorkspace,
 ) => {
-  const traceStep = [...messages]
-    .reverse()
-    .filter((message) => message.role === "assistant")
-    .flatMap((message) => message.trace ?? [])
-    .find((step) => step.tool === PROPOSAL_EDIT_CONFIRMATION_TOOL);
+  const traceStep = getLatestActiveConfirmationTraceStep(messages, PROPOSAL_EDIT_CONFIRMATION_TOOL, [
+    "confirmed_proposal_edit_workflow",
+  ]);
 
   if (!traceStep) {
     return inferPendingProposalEditRequest(messages, workspace);
@@ -1827,11 +1848,11 @@ const getRecentPendingOpportunityEditRequest = (
   messages: AssistantMessage[],
   workspace: IAssistantWorkspace,
 ) => {
-  const traceStep = [...messages]
-    .reverse()
-    .filter((message) => message.role === "assistant")
-    .flatMap((message) => message.trace ?? [])
-    .find((step) => step.tool === "confirmation_required_opportunity_edit");
+  const traceStep = getLatestActiveConfirmationTraceStep(
+    messages,
+    "confirmation_required_opportunity_edit",
+    ["confirmed_opportunity_edit_workflow"],
+  );
 
   if (!traceStep) {
     return inferPendingOpportunityEditRequest(messages, workspace);
@@ -1982,6 +2003,40 @@ const createOpportunityMissingFieldsMessage = (
   return `I can create the opportunity, but I still need ${missing.slice(0, -1).join(", ")} and ${missing.at(-1)}.`;
 };
 
+const getRecentPendingOpportunityCreateRequest = (
+  messages: AssistantMessage[],
+  workspace: IAssistantWorkspace,
+) => {
+  const traceStep = getLatestActiveConfirmationTraceStep(
+    messages,
+    "confirmation_required_opportunity_create",
+    ["confirmed_opportunity_create_workflow"],
+  );
+
+  if (!traceStep) {
+    return inferPendingOpportunityCreateRequest(messages, workspace);
+  }
+
+  return {
+    clientId: typeof traceStep.arguments.clientId === "string" ? traceStep.arguments.clientId : null,
+    clientName:
+      typeof traceStep.arguments.clientName === "string" ? traceStep.arguments.clientName : null,
+    estimatedValue:
+      typeof traceStep.arguments.estimatedValue === "number"
+        ? traceStep.arguments.estimatedValue
+        : null,
+    expectedCloseDate:
+      typeof traceStep.arguments.expectedCloseDate === "string"
+        ? traceStep.arguments.expectedCloseDate
+        : null,
+    ownerId: typeof traceStep.arguments.ownerId === "string" ? traceStep.arguments.ownerId : null,
+    ownerName:
+      typeof traceStep.arguments.ownerName === "string" ? traceStep.arguments.ownerName : null,
+    stage: typeof traceStep.arguments.stage === "string" ? traceStep.arguments.stage : null,
+    title: typeof traceStep.arguments.title === "string" ? traceStep.arguments.title : null,
+  } satisfies PendingOpportunityCreateRequest;
+};
+
 const inferPendingServiceRequestCreateRequest = (
   messages: AssistantMessage[],
   workspace: IAssistantWorkspace,
@@ -2043,11 +2098,11 @@ const getRecentPendingServiceRequestCreateRequest = (
   messages: AssistantMessage[],
   workspace: IAssistantWorkspace,
 ) => {
-  const traceStep = [...messages]
-    .reverse()
-    .filter((message) => message.role === "assistant")
-    .flatMap((message) => message.trace ?? [])
-    .find((step) => step.tool === "confirmation_required_service_request_create");
+  const traceStep = getLatestActiveConfirmationTraceStep(
+    messages,
+    "confirmation_required_service_request_create",
+    ["confirmed_service_request_create_workflow"],
+  );
 
   if (!traceStep) {
     return inferPendingServiceRequestCreateRequest(messages, workspace);
@@ -2208,11 +2263,11 @@ const getRecentPendingAdminRequestHandlingRequest = (
   messages: AssistantMessage[],
   workspace: IAssistantWorkspace,
 ) => {
-  const traceStep = [...messages]
-    .reverse()
-    .filter((message) => message.role === "assistant")
-    .flatMap((message) => message.trace ?? [])
-    .find((step) => step.tool === "confirmation_required_admin_request_workflow");
+  const traceStep = getLatestActiveConfirmationTraceStep(
+    messages,
+    "confirmation_required_admin_request_workflow",
+    ["confirmed_admin_request_workflow"],
+  );
 
   if (!traceStep) {
     return inferPendingAdminRequestHandlingRequest(messages, workspace);
@@ -2677,10 +2732,11 @@ const getRecentPendingMessageSendRequest = (
   messages: AssistantMessage[],
   workspace: IAssistantWorkspace,
 ): PendingMessageSendRequest | null => {
-  const traceStep = [...messages]
-    .reverse()
-    .find((message) => message.role === "assistant")
-    ?.trace?.find((step) => PENDING_MESSAGE_SEND_TOOLS.has(step.tool));
+  const traceStep = [...PENDING_MESSAGE_SEND_TOOLS]
+    .map((tool) =>
+      getLatestActiveConfirmationTraceStep(messages, tool, ["confirmed_message_send_workflow"]),
+    )
+    .find((step) => Boolean(step));
 
   if (!traceStep) {
     return null;
@@ -3682,7 +3738,7 @@ const shouldRunConfirmedOpportunityCreateWorkflow = (
     return false;
   }
 
-  const request = inferPendingOpportunityCreateRequest(messages, workspace);
+  const request = getRecentPendingOpportunityCreateRequest(messages, workspace);
 
   if (!request?.clientId || !request.title || !request.estimatedValue || !request.expectedCloseDate) {
     return false;
@@ -3699,7 +3755,7 @@ const createConfirmedOpportunityCreateResult = async (
   workspace: IAssistantWorkspace,
   messages: AssistantMessage[],
 ) => {
-  const request = inferPendingOpportunityCreateRequest(messages, workspace);
+  const request = getRecentPendingOpportunityCreateRequest(messages, workspace);
 
   if (
     !request?.clientId ||
@@ -4353,11 +4409,21 @@ const getRecentDraftFollowUpProposal = (messages: AssistantMessage[]) => {
 };
 
 const getRecentConfirmedGenericMutationRequest = (messages: AssistantMessage[]) => {
-  const confirmationStep = [...messages]
-    .reverse()
-    .filter((message) => message.role === "assistant")
-    .flatMap((message) => message.trace ?? [])
-    .find((step) => step.tool === "confirmation_required_generic_mutation");
+  const confirmationStep = getLatestActiveConfirmationTraceStep(
+    messages,
+    "confirmation_required_generic_mutation",
+    [
+      "confirmed_create_note_workflow",
+      "confirmed_update_note_workflow",
+      "confirmed_delete_note_workflow",
+      "confirmed_create_pricing_request_workflow",
+      "confirmed_update_pricing_request_workflow",
+      "confirmed_delete_pricing_request_workflow",
+      "confirmed_create_activity_workflow",
+      "confirmed_update_activity_workflow",
+      "confirmed_delete_activity_workflow",
+    ],
+  );
 
   if (!confirmationStep) {
     return null;

--- a/lib/server/assistant-openai.ts
+++ b/lib/server/assistant-openai.ts
@@ -266,6 +266,8 @@ type PendingOpportunityEditRequest = {
   title: string | null;
 };
 
+type OpportunityCreateSlotUpdate = Partial<PendingOpportunityCreateRequest>;
+
 type PendingServiceRequestCreateRequest = {
   clientId: string | null;
   clientName: string | null;
@@ -1522,6 +1524,125 @@ const extractOpportunityEditTitle = (message: string) =>
   message.match(/\bchange\s+the\s+name\s+of\s+.+?\s+to\s+["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim().replace(/[.\s]+$/, "") ??
   null;
 
+const isBestFitOwnerInstruction = (message: string) => {
+  const normalized = normalizeLookupValue(message);
+
+  return [
+    "assign the best",
+    "assign best",
+    "assign any",
+    "assign a reasonable owner",
+    "assign reasonable owner",
+    "assign the right owner",
+    "assign a suitable owner",
+    "assign the most reliable owner",
+    "pick the best one",
+    "pick best one",
+    "lowest current workload",
+    "most reliable owner",
+    "reasonable owner",
+    "suitable owner",
+    "right owner",
+    "best fit",
+    "best fits",
+    "who best fits",
+    "best person",
+    "best owner",
+    "best rep",
+    "best advisor",
+  ].some((token) => normalized.includes(token));
+};
+
+const isOpportunityCreateFieldRefinementOnly = (message: string) => {
+  const normalized = normalizeLookupValue(message);
+
+  if (
+    /\b(?:opportunity title|deal called|called|title is|title to|name the opportunity|name the deal|call the opportunity|call the deal|call it)\b/i.test(
+      message,
+    )
+  ) {
+    return false;
+  }
+
+  return (
+    normalized.includes("client is") ||
+    normalized.includes("client name") ||
+    normalized.includes("valued at") ||
+    normalized.includes("worth") ||
+    normalized.includes("close date") ||
+    normalized.includes("expected close date") ||
+    normalized.includes("closes") ||
+    normalized.includes("closing") ||
+    normalized.includes("assign ") ||
+    normalized.includes("pick ") ||
+    normalized.includes("choose ") ||
+    normalized.includes("owner") ||
+    normalized.includes("stage")
+  );
+};
+
+const parseOpportunityCreateTurn = (
+  message: string,
+  workspace: IAssistantWorkspace,
+  current: PendingOpportunityCreateRequest,
+): OpportunityCreateSlotUpdate => {
+  const normalized = normalizeLookupValue(message);
+  const client =
+    workspace.salesData.clients.find((item) =>
+      normalized.includes(normalizeLookupValue(item.name)),
+    ) ??
+    workspace.salesData.clients.find((item) =>
+      normalized.includes(normalizeLookupValue(item.id)),
+    ) ??
+    findClientByReferenceInWorkspace(workspace, extractPlainEnglishClientName(message)) ??
+    null;
+  const owner =
+    workspace.salesData.teamMembers.find((item) =>
+      normalized.includes(normalizeLookupValue(item.name)),
+    ) ??
+    workspace.salesData.teamMembers.find((item) =>
+      normalized.includes(normalizeLookupValue(item.name.split(" ")[0] ?? "")),
+    ) ??
+    workspace.salesData.teamMembers.find((item) =>
+      normalized.includes(normalizeLookupValue(item.id)),
+    ) ??
+    null;
+  const explicitOpportunityName =
+    message.match(/\b(?:opp|opportunity|deal)\s+name\s+(?:should be|must be|is|to)\s+["“]?(.+?)["”]?(?:$|\n)/i)?.[1]?.trim() ??
+    null;
+  const extractedTitle = sanitizeWorkflowGeneratedTitle(
+    explicitOpportunityName ??
+      extractOpportunityTitle(
+        message,
+        workspace,
+        current.clientName ?? client?.name ?? null,
+        current.ownerName ?? owner?.name ?? null,
+      ),
+  );
+  const hasExplicitTitleRefinement =
+    /\b(?:opportunity title|deal called|called|title is|title to|name the opportunity|name the deal|call the opportunity|call the deal|call it)\b/i.test(
+      message,
+    );
+
+  return {
+    autoAssignBestOwner: isBestFitOwnerInstruction(message) || current.autoAssignBestOwner,
+    clientId: client?.id ?? current.clientId,
+    clientName: client?.name ?? current.clientName,
+    estimatedValue: extractOpportunityEstimatedValue(message) ?? current.estimatedValue,
+    expectedCloseDate:
+      extractOpportunityExpectedCloseDate(message) ?? current.expectedCloseDate,
+    ownerId: owner?.id ?? current.ownerId,
+    ownerName: owner?.name ?? current.ownerName,
+    stage: extractOpportunityStage(message) ?? current.stage,
+    title:
+      extractedTitle &&
+      !isOpportunityCreateFieldRefinementOnly(message) &&
+      (!current.title || hasExplicitTitleRefinement)
+        ? extractedTitle
+        : current.title,
+  };
+};
+
 const extractActivityType = (message: string) => {
   const normalized = normalizeLookupValue(message);
 
@@ -1984,61 +2105,10 @@ const inferPendingOpportunityCreateRequest = (
   };
 
   recentUserMessages.forEach((message) => {
-    const client =
-      workspace.salesData.clients.find((item) =>
-        normalizeLookupValue(message.content).includes(normalizeLookupValue(item.name)),
-      ) ??
-      workspace.salesData.clients.find((item) =>
-        normalizeLookupValue(message.content).includes(normalizeLookupValue(item.id)),
-      ) ??
-      null;
-    const owner =
-      workspace.salesData.teamMembers.find((item) =>
-        normalizeLookupValue(message.content).includes(normalizeLookupValue(item.name)),
-      ) ??
-      workspace.salesData.teamMembers.find((item) =>
-        normalizeLookupValue(message.content).includes(normalizeLookupValue(item.name.split(" ")[0] ?? "")),
-      ) ??
-      workspace.salesData.teamMembers.find((item) =>
-        normalizeLookupValue(message.content).includes(normalizeLookupValue(item.id)),
-      ) ??
-      null;
-
-    request.clientId = client?.id ?? request.clientId;
-    request.clientName = client?.name ?? request.clientName;
-    request.ownerId = owner?.id ?? request.ownerId;
-    request.ownerName = owner?.name ?? request.ownerName;
-    request.estimatedValue =
-      extractOpportunityEstimatedValue(message.content) ?? request.estimatedValue;
-    request.expectedCloseDate =
-      extractOpportunityExpectedCloseDate(message.content) ?? request.expectedCloseDate;
-    request.stage = extractOpportunityStage(message.content) ?? request.stage;
-    if (
-      /\b(?:assign|pick|choose)\b[\s\S]*\b(?:best|best fit|best fits|best person|best owner|best rep|best advisor|who best fits|most reliable owner|reasonable owner|right owner|suitable owner|any)\b/i.test(
-        message.content,
-      )
-    ) {
-      request.autoAssignBestOwner = true;
-    }
-    const extractedTitle = sanitizeWorkflowGeneratedTitle(
-      extractOpportunityTitle(
-        message.content,
-        workspace,
-        request.clientName,
-        request.ownerName,
-      ),
+    Object.assign(
+      request,
+      parseOpportunityCreateTurn(message.content, workspace, request),
     );
-    const hasExplicitTitleRefinement =
-      /\b(?:opportunity title|deal called|called|title is|title to|name the opportunity|name the deal|call the opportunity|call the deal|call it)\b/i.test(
-        message.content,
-      );
-
-    if (
-      extractedTitle &&
-      (!request.title || isOpportunityCreateIntent(message.content) || hasExplicitTitleRefinement)
-    ) {
-      request.title = extractedTitle;
-    }
   });
 
   if (request.clientName && !request.clientId) {
@@ -2109,11 +2179,30 @@ const getRecentPendingOpportunityCreateRequest = (
   messages: AssistantMessage[],
   workspace: IAssistantWorkspace,
 ) => {
-  const traceStep = getLatestActiveConfirmationTraceStep(
-    messages,
-    "confirmation_required_opportunity_create",
-    ["confirmed_opportunity_create_workflow"],
-  );
+  let traceStep: AssistantTraceStep | null = null;
+
+  for (const message of [...messages].reverse()) {
+    if (message.role !== "assistant") {
+      continue;
+    }
+
+    const trace = message.trace ?? [];
+
+    if (trace.some((step) => step.tool === "confirmed_opportunity_create_workflow")) {
+      break;
+    }
+
+    traceStep =
+      trace.find((step) =>
+        ["confirmation_required_opportunity_create", "opportunity_create_missing_details"].includes(
+          step.tool,
+        ),
+      ) ?? null;
+
+    if (traceStep) {
+      break;
+    }
+  }
 
   if (!traceStep) {
     return inferPendingOpportunityCreateRequest(messages, workspace);

--- a/lib/server/assistant-openai.ts
+++ b/lib/server/assistant-openai.ts
@@ -244,6 +244,7 @@ type PendingProposalEditRequest = {
 };
 
 type PendingOpportunityCreateRequest = {
+  autoAssignBestOwner?: boolean;
   clientId: string | null;
   clientName: string | null;
   estimatedValue: number | null;
@@ -873,7 +874,9 @@ const getLatestActiveConfirmationTraceStep = (
   pendingTool: string,
   completedTools: string[] = [],
 ) => {
-  for (const message of [...messages].reverse()) {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+
     if (message.role !== "assistant") {
       continue;
     }
@@ -886,6 +889,19 @@ const getLatestActiveConfirmationTraceStep = (
 
     const pendingStep = trace.find((step) => step.tool === pendingTool);
     if (pendingStep) {
+      const hasLaterNonConfirmationUserMessage = messages
+        .slice(index + 1)
+        .some(
+          (laterMessage) =>
+            laterMessage.role === "user" &&
+            !isConfirmationMessage(laterMessage.content) &&
+            !isAcknowledgementMessage(laterMessage.content),
+        );
+
+      if (hasLaterNonConfirmationUserMessage) {
+        return null;
+      }
+
       return pendingStep;
     }
   }
@@ -1160,13 +1176,39 @@ const isAdminRequestHandlingIntent = (message: string) => {
   const normalized = normalizeLookupValue(message);
 
   return (
-    ["review", "handle", "process", "work on", "take care of", "triage"].some((token) =>
-      normalized.includes(token),
-    ) &&
+    [
+      "review",
+      "handle",
+      "process",
+      "work on",
+      "take care of",
+      "triage",
+      "sort it out",
+      "deal with",
+      "do whatever needs doing",
+      "do what needs doing",
+    ].some((token) => normalized.includes(token)) &&
     ["request", "client request", "service request", "client needs", "client asked"].some(
       (token) => normalized.includes(token),
     )
   );
+};
+
+const isAdminRequestFullWorkflowIntent = (message: string) => {
+  const normalized = normalizeLookupValue(message);
+
+  return [
+    "sort it out",
+    "deal with this",
+    "deal with it",
+    "do whatever needs doing",
+    "do what needs doing",
+    "take care of this",
+    "take care of it",
+    "handle this one",
+    "handle it",
+    "sort this out",
+  ].some((token) => normalized.includes(token));
 };
 
 const isExplicitStructuredMutationIntent = (message: string) => {
@@ -1258,6 +1300,7 @@ const extractOpportunityEstimatedValue = (message: string) => {
     .replace(/\b\d{1,2}\s+[a-z]+\s+(?:\d{4}|this year)\b/gi, " ");
   const currencyMatch =
     sanitizedMessage.match(/\b(?:r|zar)\s*[:\-]?\s*(\d+(?:[ ,]\d{3})*(?:\.\d+)?|\d+(?:\.\d+)?)/i)?.[0] ??
+    sanitizedMessage.match(/\bvalued?\s+at\s+(?:r|zar)?\s*(\d+(?:[ ,]\d{3})*(?:\.\d+)?|\d+(?:\.\d+)?)/i)?.[0] ??
     sanitizedMessage.match(/\bworth\s+(?:r|zar)?\s*(\d+(?:[ ,]\d{3})*(?:\.\d+)?|\d+(?:\.\d+)?)/i)?.[0] ??
     null;
 
@@ -1353,8 +1396,18 @@ const sanitizeWorkflowGeneratedTitle = (value: string | null) => {
 
   if (
     trimmed.length > 90 ||
+    normalized.includes("create a new opportunity") ||
+    normalized.includes("existing client") ||
     normalized.includes("please review") ||
+    normalized.includes("review the client request") ||
     normalized.includes("latest request") ||
+    normalized.includes("sort it out") ||
+    normalized.includes("do whatever needs doing") ||
+    normalized.includes("do what needs doing") ||
+    normalized.includes("handle this one") ||
+    normalized.includes("handle this request") ||
+    normalized.includes("take care of this request") ||
+    normalized.includes("take care of this") ||
     normalized.includes("assign the best") ||
     normalized.includes("create an opportunity") ||
     normalized.includes("create opportunity") ||
@@ -1525,6 +1578,18 @@ const extractOpportunityTitle = (
 
   if (directTitle) {
     return directTitle;
+  }
+
+  const refinementTitle =
+    message.match(/\bname\s+(?:the\s+)?(?:opportunity|deal)\s+["“]?(.+?)["”]?(?=\s+(?:worth|close|closing|expected close date|date|stage|assign to|and assign|owner)\b|$|\n)/i)?.[1]?.trim() ??
+    message.match(/\bcall\s+(?:the\s+)?(?:opportunity|deal)\s+["“]?(.+?)["”]?(?=\s+(?:worth|close|closing|expected close date|date|stage|assign to|and assign|owner)\b|$|\n)/i)?.[1]?.trim() ??
+    message.match(/\bcall\s+it\s+["“]?(.+?)["”]?(?=\s+(?:worth|close|closing|expected close date|date|stage|assign to|and assign|owner)\b|$|\n)/i)?.[1]?.trim() ??
+    null;
+
+  if (refinementTitle) {
+    return refinementTitle
+      .replace(/^(?:it will be|it should be|it is|it'll be)\s+/i, "")
+      .replace(/[.\s]+$/, "");
   }
 
   const explicit =
@@ -1907,6 +1972,7 @@ const inferPendingOpportunityCreateRequest = (
   }
 
   const request: PendingOpportunityCreateRequest = {
+    autoAssignBestOwner: false,
     clientId: null,
     clientName: null,
     estimatedValue: null,
@@ -1947,13 +2013,32 @@ const inferPendingOpportunityCreateRequest = (
     request.expectedCloseDate =
       extractOpportunityExpectedCloseDate(message.content) ?? request.expectedCloseDate;
     request.stage = extractOpportunityStage(message.content) ?? request.stage;
-    request.title =
+    if (
+      /\b(?:assign|pick|choose)\b[\s\S]*\b(?:best|best fit|best fits|best person|best owner|best rep|best advisor|who best fits|most reliable owner|reasonable owner|right owner|suitable owner|any)\b/i.test(
+        message.content,
+      )
+    ) {
+      request.autoAssignBestOwner = true;
+    }
+    const extractedTitle = sanitizeWorkflowGeneratedTitle(
       extractOpportunityTitle(
         message.content,
         workspace,
         request.clientName,
         request.ownerName,
-      ) ?? request.title;
+      ),
+    );
+    const hasExplicitTitleRefinement =
+      /\b(?:opportunity title|deal called|called|title is|title to|name the opportunity|name the deal|call the opportunity|call the deal|call it)\b/i.test(
+        message.content,
+      );
+
+    if (
+      extractedTitle &&
+      (!request.title || isOpportunityCreateIntent(message.content) || hasExplicitTitleRefinement)
+    ) {
+      request.title = extractedTitle;
+    }
   });
 
   if (request.clientName && !request.clientId) {
@@ -1962,6 +2047,23 @@ const inferPendingOpportunityCreateRequest = (
 
   if (request.ownerName && !request.ownerId) {
     request.ownerId = findOwnerByReferenceInWorkspace(workspace, request.ownerName)?.id ?? null;
+  }
+
+  if (
+    request.autoAssignBestOwner &&
+    !request.ownerId &&
+    request.clientId &&
+    request.estimatedValue
+  ) {
+    const client = findClientByReferenceInWorkspace(workspace, request.clientId);
+    const bestOwner = client
+      ? getBestOwner(workspace.salesData, request.estimatedValue, client.industry ?? "General", {
+          pricingRequests: workspace.pricingRequests,
+        })
+      : null;
+
+    request.ownerId = bestOwner?.id ?? request.ownerId;
+    request.ownerName = bestOwner?.name ?? request.ownerName;
   }
 
   return request;
@@ -1980,7 +2082,7 @@ const createOpportunityMissingFieldsMessage = (
     missing.push("the opportunity name");
   }
 
-  if (!request.ownerId && !request.ownerName) {
+  if (!request.ownerId && !request.ownerName && !request.autoAssignBestOwner) {
     missing.push("the owner name or id");
   }
 
@@ -2018,6 +2120,10 @@ const getRecentPendingOpportunityCreateRequest = (
   }
 
   return {
+    autoAssignBestOwner:
+      typeof traceStep.arguments.autoAssignBestOwner === "boolean"
+        ? traceStep.arguments.autoAssignBestOwner
+        : false,
     clientId: typeof traceStep.arguments.clientId === "string" ? traceStep.arguments.clientId : null,
     clientName:
       typeof traceStep.arguments.clientName === "string" ? traceStep.arguments.clientName : null,
@@ -2176,7 +2282,7 @@ const inferPendingAdminRequestHandlingRequest = (
     request.clientName = client?.name ?? request.clientName;
     request.createOpportunity =
       request.createOpportunity ||
-      /\b(?:opportunity|deal|sale|pipeline)\b/i.test(message.content);
+      /\b(?:opportunity|opp|deal|sale|pipeline)\b/i.test(message.content);
     request.createProposal =
       request.createProposal || /\b(?:proposal|quote)\b/i.test(message.content);
     request.estimatedValue =
@@ -2189,13 +2295,17 @@ const inferPendingAdminRequestHandlingRequest = (
       findOwnerByReferenceInWorkspace(workspace, message.content)?.name ?? request.ownerName;
     request.stage = extractOpportunityStage(message.content) ?? request.stage;
     request.opportunityTitle =
-      extractOpportunityTitle(
-        message.content,
-        workspace,
-        request.clientName,
-        request.ownerName,
+      sanitizeWorkflowGeneratedTitle(
+        extractOpportunityTitle(
+          message.content,
+          workspace,
+          request.clientName,
+          request.ownerName,
+        ),
       ) ?? request.opportunityTitle;
-    request.proposalTitle = extractProposalTitle(message.content) ?? request.proposalTitle;
+    request.proposalTitle =
+      sanitizeWorkflowGeneratedTitle(extractProposalTitle(message.content)) ??
+      request.proposalTitle;
     request.proposalValidUntil =
       extractProposalValidUntil(message.content) ?? request.proposalValidUntil;
 
@@ -2212,6 +2322,17 @@ const inferPendingAdminRequestHandlingRequest = (
     request.requestId = matchedRequest?.id ?? request.requestId;
     request.requestTitle = matchedRequest?.title ?? request.requestTitle;
     request.clientId = matchedRequest?.clientId ?? request.clientId;
+
+    if (matchedRequest && isAdminRequestFullWorkflowIntent(message.content)) {
+      request.createOpportunity =
+        request.createOpportunity ||
+        (!matchedRequest.opportunityId &&
+          ["proposal_support", "pricing_support"].includes(matchedRequest.requestType));
+      request.createProposal =
+        request.createProposal ||
+        (!matchedRequest.proposalId &&
+          ["proposal_support", "pricing_support"].includes(matchedRequest.requestType));
+    }
   });
 
   if (!request.requestId) {
@@ -3777,6 +3898,11 @@ const createConfirmedOpportunityCreateResult = async (
 
   const owner =
     findOwnerByReferenceInWorkspace(workspace, request.ownerId ?? request.ownerName) ??
+    (request.autoAssignBestOwner
+      ? getBestOwner(workspace.salesData, request.estimatedValue, client.industry ?? "General", {
+          pricingRequests: workspace.pricingRequests,
+        })
+      : null) ??
     null;
 
   const opportunity =
@@ -4413,9 +4539,12 @@ const getRecentConfirmedGenericMutationRequest = (messages: AssistantMessage[]) 
     messages,
     "confirmation_required_generic_mutation",
     [
+      "confirmed_delete_client_workflow",
+      "confirmed_delete_opportunity_workflow",
       "confirmed_create_note_workflow",
       "confirmed_update_note_workflow",
       "confirmed_delete_note_workflow",
+      "confirmed_delete_proposal_workflow",
       "confirmed_create_pricing_request_workflow",
       "confirmed_update_pricing_request_workflow",
       "confirmed_delete_pricing_request_workflow",
@@ -4444,6 +4573,9 @@ const getRecentConfirmedGenericMutationRequest = (messages: AssistantMessage[]) 
 type ConfirmedGenericToolRequest = {
   args: Record<string, unknown>;
   toolName:
+    | "delete_client"
+    | "delete_opportunity"
+    | "delete_proposal"
     | "create_activity"
     | "update_activity"
     | "delete_activity"
@@ -4457,9 +4589,20 @@ type ConfirmedGenericToolRequest = {
 
 const inferConfirmedGenericToolRequest = (
   workspace: IAssistantWorkspace,
+  messages: AssistantMessage[],
   request: string,
 ): ConfirmedGenericToolRequest | null => {
   const normalized = normalizeLookupValue(request);
+  const recentContext = getRecentWorkflowContext(workspace, messages);
+  const recentCreateMutation = [...messages]
+    .reverse()
+    .filter((message) => message.role === "assistant")
+    .flatMap((message) => message.mutations ?? [])
+    .find(
+      (mutation) =>
+        mutation.operation === "create" &&
+        ["client", "opportunity", "proposal"].includes(mutation.entityType),
+    );
   const mentionedOpportunity = extractOpportunityReference(request, workspace);
   const opportunity = findOpportunityByReferenceInWorkspace(workspace, mentionedOpportunity);
   const explicitAssignedToId =
@@ -4532,6 +4675,83 @@ const inferConfirmedGenericToolRequest = (
             noteId: note.id,
           },
           toolName: "delete_note",
+        }
+      : null;
+  }
+
+  const mentionsClientDeletion = /\b(?:delete|remove)\b[\s\S]*\bclient\b/.test(normalized);
+  const mentionsOpportunityDeletion =
+    /\b(?:delete|remove)\b[\s\S]*\b(?:opportunity|deal)\b/.test(normalized);
+  const mentionsProposalDeletion = /\b(?:delete|remove)\b[\s\S]*\bproposal\b/.test(normalized);
+
+  if (mentionsClientDeletion && mentionsProposalDeletion && recentCreateMutation) {
+    if (recentCreateMutation.entityType === "client" && recentContext.client) {
+      return {
+        args: {
+          clientId: recentContext.client.id,
+        },
+        toolName: "delete_client",
+      };
+    }
+
+    if (recentCreateMutation.entityType === "proposal" && recentContext.proposal) {
+      return {
+        args: {
+          proposalId: recentContext.proposal.id,
+        },
+        toolName: "delete_proposal",
+      };
+    }
+  }
+
+  if (mentionsClientDeletion) {
+    const client =
+      findClientByReferenceInWorkspace(
+        workspace,
+        workspace.salesData.clients.find((item) =>
+          normalized.includes(normalizeLookupValue(item.name)),
+        )?.id ?? null,
+      ) ?? recentContext.client;
+
+    return client
+      ? {
+          args: {
+            clientId: client.id,
+          },
+          toolName: "delete_client",
+        }
+      : null;
+  }
+
+  if (mentionsOpportunityDeletion) {
+    const targetOpportunity = opportunity ?? recentContext.opportunity;
+
+    return targetOpportunity
+      ? {
+          args: {
+            opportunityId: targetOpportunity.id,
+          },
+          toolName: "delete_opportunity",
+        }
+      : null;
+  }
+
+  if (mentionsProposalDeletion) {
+    const proposal =
+      findProposalByReferenceInWorkspace(
+        workspace,
+        workspace.salesData.proposals.find((item) =>
+          normalized.includes(normalizeLookupValue(item.title)),
+        )?.id ?? null,
+      ) ??
+      recentContext.proposal;
+
+    return proposal
+      ? {
+          args: {
+            proposalId: proposal.id,
+          },
+          toolName: "delete_proposal",
         }
       : null;
   }
@@ -8319,7 +8539,7 @@ async function createConfirmedGenericMutationLocalResult(
     return null;
   }
 
-  const localRequest = inferConfirmedGenericToolRequest(workspace, confirmedRequest);
+  const localRequest = inferConfirmedGenericToolRequest(workspace, messages, confirmedRequest);
 
   if (!localRequest) {
     return null;
@@ -8341,6 +8561,12 @@ async function createConfirmedGenericMutationLocalResult(
   const resultRecord = output as Record<string, unknown>;
   const responseMessage = (() => {
     switch (localRequest.toolName) {
+      case "delete_client":
+        return `Deleted client ${String(mutation.title ?? "Untitled client")}.`;
+      case "delete_opportunity":
+        return `Deleted opportunity ${String(mutation.title ?? "Untitled opportunity")}.`;
+      case "delete_proposal":
+        return `Deleted proposal ${String(mutation.title ?? "Untitled proposal")}.`;
       case "create_note":
         return `Created note ${String(mutation.title ?? "Untitled note")}.`;
       case "update_note":

--- a/lib/server/assistant-workspace.ts
+++ b/lib/server/assistant-workspace.ts
@@ -15,6 +15,10 @@ import {
   loadAssistantLiveWorkspace,
 } from "@/lib/server/assistant-backend";
 import { getMockWorkspaceSnapshot } from "@/lib/server/mock-workspace-store";
+import {
+  listServiceRequests,
+  type ServiceRequestRecord,
+} from "@/lib/server/service-request-store";
 
 export interface IAssistantWorkspace {
   clientIds?: string[] | null;
@@ -27,6 +31,7 @@ export interface IAssistantWorkspace {
   role: UserRole;
   salesData: ISalesData;
   sessionToken?: string;
+  serviceRequests: ServiceRequestRecord[];
   scopeLabel: string;
   tenantId: string;
   userDisplayName: string;
@@ -189,6 +194,7 @@ export const getAssistantWorkspaceForUser = async (
   const documents = buildScopedDocuments(workspace.documents, salesData, role, user);
   const notes = buildScopedNotes(workspace.notes, salesData, role, user);
   const pricingRequests = buildScopedPricingRequests(workspace.pricingRequests, salesData, role, user);
+  const serviceRequests = listServiceRequests(user);
 
   return {
     clientIds: user.clientIds ?? null,
@@ -198,6 +204,7 @@ export const getAssistantWorkspaceForUser = async (
     role,
     salesData,
     sessionToken: sessionToken ?? undefined,
+    serviceRequests,
     isLiveBackend: Boolean(sessionToken && !isMockAssistantSessionToken(sessionToken)),
     scopeLabel: getScopeLabel(role, user.clientIds),
     tenantId: user.tenantId,

--- a/lib/server/assistant-workspace.ts
+++ b/lib/server/assistant-workspace.ts
@@ -15,6 +15,7 @@ import {
   loadAssistantLiveWorkspace,
 } from "@/lib/server/assistant-backend";
 import { getMockWorkspaceSnapshot } from "@/lib/server/mock-workspace-store";
+import { listLiveServiceRequests } from "@/lib/server/service-request-backend-store";
 import {
   listServiceRequests,
   type ServiceRequestRecord,
@@ -194,7 +195,10 @@ export const getAssistantWorkspaceForUser = async (
   const documents = buildScopedDocuments(workspace.documents, salesData, role, user);
   const notes = buildScopedNotes(workspace.notes, salesData, role, user);
   const pricingRequests = buildScopedPricingRequests(workspace.pricingRequests, salesData, role, user);
-  const serviceRequests = listServiceRequests(user);
+  const serviceRequests =
+    sessionToken && !isMockAssistantSessionToken(sessionToken)
+      ? await listLiveServiceRequests(user, sessionToken)
+      : listServiceRequests(user);
 
   return {
     clientIds: user.clientIds ?? null,

--- a/lib/server/assistant-workspace.ts
+++ b/lib/server/assistant-workspace.ts
@@ -10,17 +10,23 @@ import type {
 } from "@/providers/salesTypes";
 import { isClientScopedUser } from "@/lib/auth/dashboard-access";
 import { getUserRoleLabel, normalizeUserRole } from "@/lib/auth/roles";
+import {
+  isMockAssistantSessionToken,
+  loadAssistantLiveWorkspace,
+} from "@/lib/server/assistant-backend";
 import { getMockWorkspaceSnapshot } from "@/lib/server/mock-workspace-store";
 
 export interface IAssistantWorkspace {
   clientIds?: string[] | null;
   documents: IDocumentItem[];
+  isLiveBackend?: boolean;
   userEmail?: string;
   userId?: string;
   notes: INoteItem[];
   pricingRequests: IPricingRequest[];
   role: UserRole;
   salesData: ISalesData;
+  sessionToken?: string;
   scopeLabel: string;
   tenantId: string;
   userDisplayName: string;
@@ -170,11 +176,15 @@ const buildScopedDocuments = (
   return documents.filter((document) => (document.clientId ? scopedClientIds.has(document.clientId) : false));
 };
 
-export const getAssistantWorkspaceForUser = (
+export const getAssistantWorkspaceForUser = async (
   user: IMockUser,
-): IAssistantWorkspace => {
+  sessionToken?: string | null,
+): Promise<IAssistantWorkspace> => {
   const role: UserRole = normalizeUserRole(user.role);
-  const workspace = getMockWorkspaceSnapshot(user.tenantId);
+  const workspace =
+    sessionToken && !isMockAssistantSessionToken(sessionToken)
+      ? await loadAssistantLiveWorkspace(user, sessionToken)
+      : getMockWorkspaceSnapshot(user.tenantId);
   const salesData = buildScopedSalesData(workspace.salesData, role, user);
   const documents = buildScopedDocuments(workspace.documents, salesData, role, user);
   const notes = buildScopedNotes(workspace.notes, salesData, role, user);
@@ -187,6 +197,8 @@ export const getAssistantWorkspaceForUser = (
     pricingRequests,
     role,
     salesData,
+    sessionToken: sessionToken ?? undefined,
+    isLiveBackend: Boolean(sessionToken && !isMockAssistantSessionToken(sessionToken)),
     scopeLabel: getScopeLabel(role, user.clientIds),
     tenantId: user.tenantId,
     userDisplayName: `${user.firstName} ${user.lastName}`.trim(),

--- a/lib/server/auth-mode.ts
+++ b/lib/server/auth-mode.ts
@@ -1,0 +1,4 @@
+import "server-only";
+
+export const shouldUseUpstreamAuth = () =>
+  process.env.ENABLE_UPSTREAM_AUTH?.trim().toLowerCase() === "true";

--- a/lib/server/local-state-store.ts
+++ b/lib/server/local-state-store.ts
@@ -1,0 +1,104 @@
+import "server-only";
+
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+type PersistedLocalState = {
+  mockWorkspaceStore: Record<string, unknown>;
+  schema: "autosales-local-state-v1";
+  serviceRequestStore: Record<string, unknown>;
+};
+
+const LOCAL_STATE_DIR = path.join(process.cwd(), ".local-state");
+const LOCAL_STATE_FILE = path.join(LOCAL_STATE_DIR, "assistant-workflow.json");
+const TEMP_STATE_FILE = `${LOCAL_STATE_FILE}.tmp`;
+
+let cachedState: PersistedLocalState | null = null;
+
+const clone = <T,>(value: T): T => structuredClone(value);
+
+const createEmptyState = (): PersistedLocalState => ({
+  mockWorkspaceStore: {},
+  schema: "autosales-local-state-v1",
+  serviceRequestStore: {},
+});
+
+const normalizePersistedState = (value: unknown): PersistedLocalState => {
+  if (!value || typeof value !== "object") {
+    return createEmptyState();
+  }
+
+  const candidate = value as Partial<PersistedLocalState>;
+
+  if (candidate.schema !== "autosales-local-state-v1") {
+    return createEmptyState();
+  }
+
+  return {
+    mockWorkspaceStore:
+      candidate.mockWorkspaceStore && typeof candidate.mockWorkspaceStore === "object"
+        ? candidate.mockWorkspaceStore
+        : {},
+    schema: "autosales-local-state-v1",
+    serviceRequestStore:
+      candidate.serviceRequestStore && typeof candidate.serviceRequestStore === "object"
+        ? candidate.serviceRequestStore
+        : {},
+  };
+};
+
+const ensureLocalStateDir = () => {
+  if (!existsSync(LOCAL_STATE_DIR)) {
+    mkdirSync(LOCAL_STATE_DIR, { recursive: true });
+  }
+};
+
+const readMutableState = () => {
+  if (cachedState) {
+    return cachedState;
+  }
+
+  if (!existsSync(LOCAL_STATE_FILE)) {
+    cachedState = createEmptyState();
+    return cachedState;
+  }
+
+  try {
+    const raw = readFileSync(LOCAL_STATE_FILE, "utf8");
+    cachedState = normalizePersistedState(JSON.parse(raw));
+    return cachedState;
+  } catch {
+    cachedState = createEmptyState();
+    return cachedState;
+  }
+};
+
+const flushState = (state: PersistedLocalState) => {
+  ensureLocalStateDir();
+  writeFileSync(TEMP_STATE_FILE, JSON.stringify(state, null, 2), "utf8");
+
+  if (existsSync(LOCAL_STATE_FILE)) {
+    unlinkSync(LOCAL_STATE_FILE);
+  }
+
+  renameSync(TEMP_STATE_FILE, LOCAL_STATE_FILE);
+};
+
+export const readLocalStateSnapshot = () => clone(readMutableState());
+
+export const writeLocalStateSnapshot = (patch: (state: PersistedLocalState) => void) => {
+  const state = readMutableState();
+  patch(state);
+
+  try {
+    flushState(state);
+  } catch {
+    try {
+      unlinkSync(TEMP_STATE_FILE);
+    } catch {
+      // Ignore cleanup failures.
+    }
+  }
+
+  return clone(state);
+};

--- a/lib/server/mock-workspace-store.ts
+++ b/lib/server/mock-workspace-store.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { readLocalStateSnapshot, writeLocalStateSnapshot } from "@/lib/server/local-state-store";
 import type { IMockUser } from "@/app/api/Auth/mock-users";
 import {
   initialActivities,
@@ -84,7 +85,13 @@ type CreatePricingRequestInput = Omit<IPricingRequest, "createdAt" | "id"> & {
 };
 
 const workspaceStore =
-  globalThis.__mockWorkspaceStore__ ?? new Map<string, MockWorkspaceState>();
+  globalThis.__mockWorkspaceStore__ ??
+  new Map<string, MockWorkspaceState>(
+    Object.entries(readLocalStateSnapshot().mockWorkspaceStore).map(([tenantId, state]) => [
+      tenantId,
+      state as MockWorkspaceState,
+    ]),
+  );
 
 globalThis.__mockWorkspaceStore__ = workspaceStore;
 
@@ -92,6 +99,12 @@ const createId = (prefix: string) =>
   `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
 const clone = <T,>(value: T): T => structuredClone(value);
+
+const persistWorkspaceStore = () => {
+  writeLocalStateSnapshot((state) => {
+    state.mockWorkspaceStore = Object.fromEntries(workspaceStore.entries());
+  });
+};
 
 const buildSeedWorkspace = (): MockWorkspaceState => ({
   documents: initialDocuments(),
@@ -119,6 +132,7 @@ const getWorkspaceState = (tenantId: string) => {
 
   const next = buildSeedWorkspace();
   workspaceStore.set(tenantId, next);
+  persistWorkspaceStore();
 
   return next;
 };
@@ -179,6 +193,7 @@ export const createMockClient = (user: IMockUser, input: CreateClientInput) => {
     id: createId("auto"),
     title: "Client created",
   });
+  persistWorkspaceStore();
 
   return clone(client);
 };
@@ -199,6 +214,7 @@ export const updateMockClient = (
     ...workspace.salesData.clients[index],
     ...patch,
   };
+  persistWorkspaceStore();
 
   return clone(workspace.salesData.clients[index]);
 };
@@ -209,6 +225,7 @@ export const deleteMockClient = (tenantId: string, clientId: string) => {
   workspace.salesData.contacts = workspace.salesData.contacts.filter((item) => item.clientId !== clientId);
   workspace.salesData.opportunities = workspace.salesData.opportunities.filter((item) => item.clientId !== clientId);
   workspace.salesData.proposals = workspace.salesData.proposals.filter((item) => item.clientId !== clientId);
+  persistWorkspaceStore();
 };
 
 export const createMockContact = (user: IMockUser, input: Omit<IContact, "id">) => {
@@ -226,6 +243,7 @@ export const createMockContact = (user: IMockUser, input: Omit<IContact, "id">) 
     id: createId("auto"),
     title: "Contact created",
   });
+  persistWorkspaceStore();
 
   return clone(contact);
 };
@@ -246,6 +264,7 @@ export const updateMockContact = (
     ...workspace.salesData.contacts[index],
     ...patch,
   };
+  persistWorkspaceStore();
 
   return clone(workspace.salesData.contacts[index]);
 };
@@ -253,6 +272,7 @@ export const updateMockContact = (
 export const deleteMockContact = (tenantId: string, contactId: string) => {
   const workspace = getWorkspaceState(tenantId);
   workspace.salesData.contacts = workspace.salesData.contacts.filter((item) => item.id !== contactId);
+  persistWorkspaceStore();
 };
 
 export const listMockOpportunities = (tenantId: string) =>
@@ -302,6 +322,7 @@ export const createMockOpportunity = (
     id: createId("auto"),
     title: `Opportunity added to pipeline`,
   });
+  persistWorkspaceStore();
 
   return clone(opportunity);
 };
@@ -325,6 +346,7 @@ export const updateMockOpportunity = (
       patch.expectedCloseDate ?? workspace.salesData.opportunities[index].expectedCloseDate,
     ),
   };
+  persistWorkspaceStore();
 
   return clone(workspace.salesData.opportunities[index]);
 };
@@ -337,6 +359,7 @@ export const deleteMockOpportunity = (tenantId: string, opportunityId: string) =
   workspace.salesData.proposals = workspace.salesData.proposals.filter(
     (item) => item.opportunityId !== opportunityId,
   );
+  persistWorkspaceStore();
 };
 
 export const assignMockOpportunity = (
@@ -396,6 +419,7 @@ export const createMockProposal = (user: IMockUser, input: CreateProposalInput) 
     id: createId("auto"),
     title: `Proposal created`,
   });
+  persistWorkspaceStore();
 
   return clone(proposal);
 };
@@ -427,6 +451,7 @@ export const updateMockProposal = (
       getLineItemsTotal(nextLineItems) ??
       workspace.salesData.proposals[index].value,
   };
+  persistWorkspaceStore();
 
   return clone(workspace.salesData.proposals[index]);
 };
@@ -436,6 +461,7 @@ export const deleteMockProposal = (tenantId: string, proposalId: string) => {
   workspace.salesData.proposals = workspace.salesData.proposals.filter(
     (item) => item.id !== proposalId,
   );
+  persistWorkspaceStore();
 };
 
 export const transitionMockProposal = (
@@ -554,6 +580,7 @@ export const createMockActivity = (user: IMockUser, input: CreateActivityInput) 
     id: createId("auto"),
     title: "Activity created",
   });
+  persistWorkspaceStore();
 
   return clone(activity);
 };
@@ -574,6 +601,7 @@ export const updateMockActivity = (
     ...workspace.salesData.activities[index],
     ...patch,
   };
+  persistWorkspaceStore();
 
   return clone(workspace.salesData.activities[index]);
 };
@@ -583,6 +611,7 @@ export const deleteMockActivity = (tenantId: string, activityId: string) => {
   workspace.salesData.activities = workspace.salesData.activities.filter(
     (item) => item.id !== activityId,
   );
+  persistWorkspaceStore();
 };
 
 export const listMockPricingRequests = (tenantId: string): IPricingRequest[] =>
@@ -608,6 +637,7 @@ export const createMockPricingRequest = (
     id: createId("auto"),
     title: "Commercial request created",
   });
+  persistWorkspaceStore();
 
   return clone(pricingRequest);
 };
@@ -631,6 +661,7 @@ export const updateMockPricingRequest = (
       patch.requiredByDate ?? workspace.pricingRequests[index].requiredByDate,
     ),
   };
+  persistWorkspaceStore();
 
   return clone(workspace.pricingRequests[index]);
 };
@@ -640,6 +671,7 @@ export const deleteMockPricingRequest = (tenantId: string, pricingRequestId: str
   workspace.pricingRequests = workspace.pricingRequests.filter(
     (item) => item.id !== pricingRequestId,
   );
+  persistWorkspaceStore();
 };
 
 export const listMockNotes = (tenantId: string): INoteItem[] =>
@@ -663,6 +695,7 @@ export const createMockNote = (
     id: createId("auto"),
     title: "Note created",
   });
+  persistWorkspaceStore();
 
   return clone(note);
 };
@@ -684,6 +717,7 @@ export const updateMockNote = (
     ...patch,
     createdDate: normalizeDate(patch.createdDate ?? workspace.notes[index].createdDate),
   };
+  persistWorkspaceStore();
 
   return clone(workspace.notes[index]);
 };
@@ -691,6 +725,7 @@ export const updateMockNote = (
 export const deleteMockNote = (tenantId: string, noteId: string) => {
   const workspace = getWorkspaceState(tenantId);
   workspace.notes = workspace.notes.filter((item) => item.id !== noteId);
+  persistWorkspaceStore();
 };
 
 export const syncMockUserWorkspaceProfile = (
@@ -743,6 +778,7 @@ export const syncMockUserWorkspaceProfile = (
     id: createId("auto"),
     title: linkedClientIds.size > 0 && organizationName ? "Client workspace updated" : "Profile updated",
   });
+  persistWorkspaceStore();
 
   return clone(workspace);
 };

--- a/lib/server/request-session-token.ts
+++ b/lib/server/request-session-token.ts
@@ -1,0 +1,24 @@
+import "server-only";
+
+import type { NextRequest } from "next/server";
+
+import { AUTH_COOKIE_NAME } from "@/app/api/Auth/session-cookie";
+
+export const getRequestSessionToken = (request: NextRequest) => {
+  const cookieToken = request.cookies.get(AUTH_COOKIE_NAME)?.value;
+
+  if (cookieToken) {
+    return cookieToken;
+  }
+
+  const authHeader = request.headers.get("authorization");
+
+  if (!authHeader?.startsWith("Bearer ")) {
+    return "";
+  }
+
+  return authHeader.slice("Bearer ".length).trim();
+};
+
+export const isLiveSessionToken = (token?: string | null) =>
+  Boolean(token && !token.startsWith("mock-token::"));

--- a/lib/server/service-request-backend-store.ts
+++ b/lib/server/service-request-backend-store.ts
@@ -1,0 +1,866 @@
+import "server-only";
+
+import type { IMockUser } from "@/app/api/Auth/mock-users";
+import {
+  createLiveOpportunity,
+  createLiveProposal,
+} from "@/lib/server/assistant-backend";
+import { createBackendUrl } from "@/lib/server/backend-url";
+import type {
+  ServiceRequestAssignmentRecord,
+  ServiceRequestPriority,
+  ServiceRequestRecord,
+  ServiceRequestStatus,
+  WorkflowEventRecord,
+} from "@/lib/server/service-request-store";
+import type { IOpportunity, IProposal } from "@/providers/salesTypes";
+
+type BackendPagedResult<T> = {
+  items?: T[] | null;
+};
+
+type BackendNoteDto = Record<string, unknown>;
+
+type BackendUserDto = {
+  email?: string | null;
+  firstName?: string | null;
+  fullName?: string | null;
+  id: string;
+  lastName?: string | null;
+};
+
+type WorkflowEnvelope =
+  | {
+      kind: "request";
+      request: ServiceRequestRecord;
+      schema: "service-request-workflow-v1";
+      tenantId: string;
+    }
+  | {
+      assignment: ServiceRequestAssignmentRecord;
+      kind: "assignment";
+      schema: "service-request-workflow-v1";
+      tenantId: string;
+    }
+  | {
+      event: WorkflowEventRecord;
+      kind: "event";
+      schema: "service-request-workflow-v1";
+      tenantId: string;
+    };
+
+type StoredRequestNote = {
+  noteId: string;
+  request: ServiceRequestRecord;
+};
+
+type StoredAssignmentNote = {
+  assignment: ServiceRequestAssignmentRecord;
+  noteId: string;
+};
+
+type StoredEventNote = {
+  event: WorkflowEventRecord;
+  noteId: string;
+};
+
+type LiveWorkflowState = {
+  assignments: StoredAssignmentNote[];
+  events: StoredEventNote[];
+  requests: StoredRequestNote[];
+};
+
+const WORKFLOW_NOTE_PREFIX = "__service_request_workflow__:";
+const DEFAULT_RELATED_TO_TYPE = 2;
+
+const createId = (prefix: string) =>
+  `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+const nowIso = () => new Date().toISOString();
+
+const normalizeDate = (value?: string | null) => {
+  if (!value) {
+    return new Date().toISOString().split("T")[0];
+  }
+
+  return value.split("T")[0];
+};
+
+const clone = <T,>(value: T): T => structuredClone(value);
+
+const canSeeRequest = (user: IMockUser, request: ServiceRequestRecord) => {
+  if (user.role !== "Client" && (user.clientIds?.length ?? 0) === 0) {
+    return true;
+  }
+
+  return (
+    user.clientIds?.includes(request.clientId) ||
+    request.submittedByUserId === user.id
+  );
+};
+
+const requireInternalUser = (user: IMockUser) => {
+  if (user.role === "Client") {
+    throw new Error("Only internal workspace users can perform this action.");
+  }
+};
+
+const requireClientUser = (user: IMockUser) => {
+  if (user.role !== "Client") {
+    throw new Error("Only client users can perform this action.");
+  }
+};
+
+const extractErrorMessage = (value: unknown) => {
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+
+  if (value && typeof value === "object") {
+    const candidate = value as {
+      detail?: unknown;
+      message?: unknown;
+      title?: unknown;
+    };
+
+    if (typeof candidate.message === "string" && candidate.message.trim()) {
+      return candidate.message;
+    }
+
+    if (typeof candidate.detail === "string" && candidate.detail.trim()) {
+      return candidate.detail;
+    }
+
+    if (typeof candidate.title === "string" && candidate.title.trim()) {
+      return candidate.title;
+    }
+  }
+
+  return null;
+};
+
+const coerceItems = <T,>(payload: BackendPagedResult<T> | T[] | null | undefined) => {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  return payload?.items ?? [];
+};
+
+const readString = (value: unknown) =>
+  typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+
+const serializeEnvelope = (envelope: WorkflowEnvelope) =>
+  `${WORKFLOW_NOTE_PREFIX}${JSON.stringify(envelope)}`;
+
+const parseEnvelope = (content: unknown): WorkflowEnvelope | null => {
+  if (typeof content !== "string" || !content.startsWith(WORKFLOW_NOTE_PREFIX)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(
+      content.slice(WORKFLOW_NOTE_PREFIX.length),
+    ) as WorkflowEnvelope;
+
+    if (parsed?.schema !== "service-request-workflow-v1") {
+      return null;
+    }
+
+    return parsed;
+  } catch {
+    return null;
+  }
+};
+
+const fetchBackend = async <T>(
+  token: string,
+  path: string,
+  init: RequestInit = {},
+): Promise<T> => {
+  const headers = new Headers(init.headers);
+  headers.set("Authorization", `Bearer ${token}`);
+
+  if (init.body && !(init.body instanceof FormData) && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const response = await fetch(createBackendUrl(path), {
+    ...init,
+    headers,
+  });
+
+  if (response.status === 204) {
+    return null as T;
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  const payload = contentType.includes("application/json")
+    ? await response.json()
+    : await response.text();
+
+  if (!response.ok) {
+    throw new Error(
+      extractErrorMessage(payload) ?? `Backend request failed with status ${response.status}.`,
+    );
+  }
+
+  return payload as T;
+};
+
+const listWorkflowNotes = async (token: string) =>
+  coerceItems(
+    await fetchBackend<BackendPagedResult<BackendNoteDto> | BackendNoteDto[]>(
+      token,
+      "/api/Notes?pageNumber=1&pageSize=250",
+    ),
+  );
+
+const createWorkflowNote = async (
+  token: string,
+  relatedToId: string,
+  envelope: WorkflowEnvelope,
+) =>
+  fetchBackend<BackendNoteDto>(token, "/api/Notes", {
+    body: JSON.stringify({
+      content: serializeEnvelope(envelope),
+      isPrivate: false,
+      relatedToId,
+      relatedToType: DEFAULT_RELATED_TO_TYPE,
+    }),
+    method: "POST",
+  });
+
+const updateWorkflowNote = async (
+  token: string,
+  noteId: string,
+  envelope: WorkflowEnvelope,
+) => {
+  await fetchBackend<BackendNoteDto>(token, `/api/Notes/${noteId}`, {
+    body: JSON.stringify({
+      content: serializeEnvelope(envelope),
+      isPrivate: false,
+    }),
+    method: "PUT",
+  });
+};
+
+const loadLiveWorkflowState = async (user: IMockUser, token: string): Promise<LiveWorkflowState> => {
+  const notes = await listWorkflowNotes(token);
+  const state: LiveWorkflowState = {
+    assignments: [],
+    events: [],
+    requests: [],
+  };
+
+  for (const note of notes) {
+    const noteId = readString(note.id);
+    const envelope = parseEnvelope(note.content);
+
+    if (!noteId || !envelope || envelope.tenantId !== user.tenantId) {
+      continue;
+    }
+
+    if (envelope.kind === "request") {
+      state.requests.push({
+        noteId,
+        request: envelope.request,
+      });
+      continue;
+    }
+
+    if (envelope.kind === "assignment") {
+      state.assignments.push({
+        assignment: envelope.assignment,
+        noteId,
+      });
+      continue;
+    }
+
+    state.events.push({
+      event: envelope.event,
+      noteId,
+    });
+  }
+
+  state.requests.sort((left, right) =>
+    right.request.updatedAt.localeCompare(left.request.updatedAt),
+  );
+  state.assignments.sort((left, right) =>
+    right.assignment.updatedAt.localeCompare(left.assignment.updatedAt),
+  );
+  state.events.sort((left, right) =>
+    right.event.createdAt.localeCompare(left.event.createdAt),
+  );
+
+  return state;
+};
+
+const getVisibleRequestOrThrow = async (
+  user: IMockUser,
+  token: string,
+  requestId: string,
+) => {
+  const state = await loadLiveWorkflowState(user, token);
+  const request = state.requests.find((item) => item.request.id === requestId);
+
+  if (!request) {
+    throw new Error("Service request not found.");
+  }
+
+  if (!canSeeRequest(user, request.request)) {
+    throw new Error("You do not have access to this service request.");
+  }
+
+  return { request, state };
+};
+
+const fetchTeamMemberNames = async (token: string) => {
+  const payload = await fetchBackend<BackendPagedResult<BackendUserDto> | BackendUserDto[]>(
+    token,
+    "/api/Users?pageNumber=1&pageSize=100",
+  );
+
+  return new Map(
+    coerceItems(payload).map((user) => {
+      const fullName =
+        readString(user.fullName) ||
+        [readString(user.firstName), readString(user.lastName)].filter(Boolean).join(" ") ||
+        readString(user.email) ||
+        user.id;
+
+      return [user.id, fullName];
+    }),
+  );
+};
+
+const appendEvent = async (
+  token: string,
+  request: ServiceRequestRecord,
+  actor: IMockUser,
+  eventType: string,
+  payloadJson: Record<string, unknown> = {},
+) => {
+  const event: WorkflowEventRecord = {
+    actorType:
+      actor.role === "Client"
+        ? "client"
+        : actor.role === "SalesRep"
+          ? "representative"
+          : actor.role === "Admin"
+            ? "admin"
+            : "workspace_user",
+    actorUserId: actor.id,
+    createdAt: nowIso(),
+    eventType,
+    id: createId("evt"),
+    payloadJson,
+    serviceRequestId: request.id,
+    tenantId: request.tenantId,
+  };
+
+  await createWorkflowNote(token, request.clientId, {
+    event,
+    kind: "event",
+    schema: "service-request-workflow-v1",
+    tenantId: request.tenantId,
+  });
+
+  return event;
+};
+
+export const listLiveServiceRequests = async (
+  user: IMockUser,
+  token: string,
+  filters?: { statuses?: ServiceRequestStatus[] },
+) => {
+  const state = await loadLiveWorkflowState(user, token);
+  const statuses = new Set(filters?.statuses ?? []);
+
+  return state.requests
+    .map((item) => item.request)
+    .filter((request) => {
+      if (!canSeeRequest(user, request)) {
+        return false;
+      }
+
+      if (statuses.size > 0 && !statuses.has(request.status)) {
+        return false;
+      }
+
+      return true;
+    })
+    .map(clone);
+};
+
+export const createLiveServiceRequest = async (
+  user: IMockUser,
+  token: string,
+  input: {
+    clientId: string;
+    description: string;
+    priority?: ServiceRequestPriority;
+    requestType?: string;
+    source?: ServiceRequestRecord["source"];
+    title: string;
+  },
+) => {
+  const now = nowIso();
+  const request: ServiceRequestRecord = {
+    clientId: input.clientId,
+    createdAt: now,
+    description: input.description,
+    id: createId("req"),
+    priority: input.priority ?? "medium",
+    requestType: input.requestType ?? "service_request",
+    source:
+      input.source ??
+      (user.role === "Client" || (user.clientIds?.length ?? 0) > 0
+        ? "client_portal"
+        : "workspace"),
+    status: "submitted",
+    submittedByUserId: user.id,
+    tenantId: user.tenantId,
+    title: input.title,
+    updatedAt: now,
+  };
+
+  await createWorkflowNote(token, request.clientId, {
+    kind: "request",
+    request,
+    schema: "service-request-workflow-v1",
+    tenantId: user.tenantId,
+  });
+
+  await appendEvent(token, request, user, "service_request_submitted", {
+    priority: request.priority,
+    requestType: request.requestType,
+    source: request.source,
+  });
+
+  return clone(request);
+};
+
+export const getLiveServiceRequestDetail = async (
+  user: IMockUser,
+  token: string,
+  requestId: string,
+) => {
+  const { request, state } = await getVisibleRequestOrThrow(user, token, requestId);
+
+  return {
+    assignments: state.assignments
+      .filter((item) => item.assignment.serviceRequestId === request.request.id)
+      .map((item) => clone(item.assignment)),
+    events: state.events
+      .filter((item) => item.event.serviceRequestId === request.request.id)
+      .map((item) => clone(item.event)),
+    request: clone(request.request),
+  };
+};
+
+export const markLiveServiceRequestUnderReview = async (
+  user: IMockUser,
+  token: string,
+  requestId: string,
+) => {
+  requireInternalUser(user);
+
+  const { request } = await getVisibleRequestOrThrow(user, token, requestId);
+  const updated: ServiceRequestRecord = {
+    ...request.request,
+    status: "under_review",
+    updatedAt: nowIso(),
+  };
+
+  await updateWorkflowNote(token, request.noteId, {
+    kind: "request",
+    request: updated,
+    schema: "service-request-workflow-v1",
+    tenantId: user.tenantId,
+  });
+
+  await appendEvent(token, updated, user, "service_request_review_started");
+
+  return clone(updated);
+};
+
+export const createLiveServiceRequestAssignments = async (
+  user: IMockUser,
+  token: string,
+  requestId: string,
+  input: {
+    note?: string;
+    representativeUserIds: string[];
+  },
+) => {
+  requireInternalUser(user);
+
+  const representativeUserIds = [
+    ...new Set(input.representativeUserIds.map((value) => value.trim()).filter(Boolean)),
+  ];
+
+  if (representativeUserIds.length === 0) {
+    throw new Error("At least one representative user ID is required.");
+  }
+
+  const { request, state } = await getVisibleRequestOrThrow(user, token, requestId);
+  const userNames = await fetchTeamMemberNames(token);
+
+  for (const existing of state.assignments.filter(
+    (item) => item.assignment.serviceRequestId === request.request.id,
+  )) {
+    const updatedAssignment: ServiceRequestAssignmentRecord = {
+      ...existing.assignment,
+      decisionNote: input.note?.trim() || existing.assignment.decisionNote,
+      status: "client_rejected",
+      updatedAt: nowIso(),
+    };
+
+    await updateWorkflowNote(token, existing.noteId, {
+      assignment: updatedAssignment,
+      kind: "assignment",
+      schema: "service-request-workflow-v1",
+      tenantId: user.tenantId,
+    });
+  }
+
+  const assignments: ServiceRequestAssignmentRecord[] = [];
+
+  for (const representativeUserId of representativeUserIds) {
+    const assignment: ServiceRequestAssignmentRecord = {
+      assignedByUserId: user.id,
+      createdAt: nowIso(),
+      decisionNote: input.note?.trim() || undefined,
+      id: createId("assign"),
+      representativeName:
+        userNames.get(representativeUserId) ?? representativeUserId,
+      representativeUserId,
+      serviceRequestId: request.request.id,
+      status: "pending_client_approval",
+      updatedAt: nowIso(),
+    };
+
+    assignments.push(assignment);
+
+    await createWorkflowNote(token, request.request.clientId, {
+      assignment,
+      kind: "assignment",
+      schema: "service-request-workflow-v1",
+      tenantId: user.tenantId,
+    });
+  }
+
+  const updatedRequest: ServiceRequestRecord = {
+    ...request.request,
+    status: "awaiting_client_assignment_approval",
+    updatedAt: nowIso(),
+  };
+
+  await updateWorkflowNote(token, request.noteId, {
+    kind: "request",
+    request: updatedRequest,
+    schema: "service-request-workflow-v1",
+    tenantId: user.tenantId,
+  });
+
+  await appendEvent(token, updatedRequest, user, "service_request_assignments_created", {
+    note: input.note?.trim() || null,
+    representativeUserIds,
+  });
+
+  return {
+    assignments: assignments.map(clone),
+    request: clone(updatedRequest),
+  };
+};
+
+export const applyLiveServiceRequestClientDecision = async (
+  user: IMockUser,
+  token: string,
+  requestId: string,
+  input: {
+    assignmentIds: string[];
+    decision: "approve" | "reject";
+    note?: string;
+  },
+) => {
+  requireClientUser(user);
+
+  const { request, state } = await getVisibleRequestOrThrow(user, token, requestId);
+  const assignmentIds = new Set(input.assignmentIds.map((value) => value.trim()).filter(Boolean));
+  const matchingAssignments = state.assignments.filter(
+    (item) =>
+      item.assignment.serviceRequestId === request.request.id &&
+      assignmentIds.has(item.assignment.id),
+  );
+
+  if (matchingAssignments.length === 0) {
+    throw new Error("No matching assignments were found for this request.");
+  }
+
+  const nextAssignmentStatus =
+    input.decision === "approve" ? "pending_rep_response" : "client_rejected";
+
+  for (const stored of matchingAssignments) {
+    const updatedAssignment: ServiceRequestAssignmentRecord = {
+      ...stored.assignment,
+      decisionNote: input.note?.trim() || stored.assignment.decisionNote,
+      status: nextAssignmentStatus,
+      updatedAt: nowIso(),
+    };
+
+    await updateWorkflowNote(token, stored.noteId, {
+      assignment: updatedAssignment,
+      kind: "assignment",
+      schema: "service-request-workflow-v1",
+      tenantId: user.tenantId,
+    });
+  }
+
+  const updatedRequest: ServiceRequestRecord = {
+    ...request.request,
+    status:
+      input.decision === "approve"
+        ? "awaiting_rep_acceptance"
+        : "client_rejected_assignment",
+    updatedAt: nowIso(),
+  };
+
+  await updateWorkflowNote(token, request.noteId, {
+    kind: "request",
+    request: updatedRequest,
+    schema: "service-request-workflow-v1",
+    tenantId: user.tenantId,
+  });
+
+  await appendEvent(token, updatedRequest, user, "service_request_client_decision", {
+    assignmentIds: [...assignmentIds],
+    decision: input.decision,
+    note: input.note?.trim() || null,
+  });
+
+  return clone(updatedRequest);
+};
+
+export const applyLiveServiceRequestRepDecision = async (
+  user: IMockUser,
+  token: string,
+  requestId: string,
+  input: {
+    assignmentId: string;
+    decision: "accept" | "reject";
+    note?: string;
+  },
+) => {
+  const { request, state } = await getVisibleRequestOrThrow(user, token, requestId);
+  const assignment = state.assignments.find(
+    (item) =>
+      item.assignment.serviceRequestId === request.request.id &&
+      item.assignment.id === input.assignmentId,
+  );
+
+  if (!assignment) {
+    throw new Error("Assignment not found for this request.");
+  }
+
+  if (assignment.assignment.representativeUserId !== user.id && user.role !== "Admin") {
+    throw new Error("You do not have access to decide this assignment.");
+  }
+
+  const updatedAssignment: ServiceRequestAssignmentRecord = {
+    ...assignment.assignment,
+    decisionNote: input.note?.trim() || assignment.assignment.decisionNote,
+    status: input.decision === "accept" ? "rep_accepted" : "rep_rejected",
+    updatedAt: nowIso(),
+  };
+
+  await updateWorkflowNote(token, assignment.noteId, {
+    assignment: updatedAssignment,
+    kind: "assignment",
+    schema: "service-request-workflow-v1",
+    tenantId: user.tenantId,
+  });
+
+  const nextState = await loadLiveWorkflowState(user, token);
+  const allAssignments = nextState.assignments
+    .filter((item) => item.assignment.serviceRequestId === request.request.id)
+    .map((item) =>
+      item.assignment.id === updatedAssignment.id ? updatedAssignment : item.assignment,
+    );
+  const hasAccepted = allAssignments.some((item) => item.status === "rep_accepted");
+  const hasPending = allAssignments.some((item) => item.status === "pending_rep_response");
+  const hasRejected = allAssignments.some((item) => item.status === "rep_rejected");
+
+  const updatedRequest: ServiceRequestRecord = {
+    ...request.request,
+    status: hasRejected
+      ? "rep_rejected_assignment"
+      : hasPending
+        ? "awaiting_rep_acceptance"
+        : hasAccepted
+          ? "active"
+          : request.request.status,
+    updatedAt: nowIso(),
+  };
+
+  await updateWorkflowNote(token, request.noteId, {
+    kind: "request",
+    request: updatedRequest,
+    schema: "service-request-workflow-v1",
+    tenantId: user.tenantId,
+  });
+
+  await appendEvent(token, updatedRequest, user, "service_request_representative_decision", {
+    assignmentId: input.assignmentId,
+    decision: input.decision,
+    note: input.note?.trim() || null,
+  });
+
+  return clone(updatedRequest);
+};
+
+export const attachLiveOpportunityToServiceRequest = async (
+  user: IMockUser,
+  token: string,
+  requestId: string,
+  input: {
+    estimatedValue?: number;
+    expectedCloseDate?: string;
+    mode: "create" | "link";
+    opportunityId?: string;
+    ownerId?: string;
+    stage?: string;
+    title?: string;
+  },
+) => {
+  requireInternalUser(user);
+
+  const { request } = await getVisibleRequestOrThrow(user, token, requestId);
+  let opportunityId = input.opportunityId?.trim();
+  let opportunity: IOpportunity | null = null;
+
+  if (input.mode === "create") {
+    const title = input.title?.trim();
+
+    if (!title) {
+      throw new Error("title is required when creating an opportunity.");
+    }
+
+    opportunity = await createLiveOpportunity(token, {
+      clientId: request.request.clientId,
+      createdDate: nowIso().split("T")[0],
+      currency: "ZAR",
+      estimatedValue: Math.max(0, Number(input.estimatedValue ?? 0)),
+      expectedCloseDate: normalizeDate(input.expectedCloseDate),
+      id: "",
+      ownerId: input.ownerId?.trim() || undefined,
+      probability: 50,
+      source: 1,
+      stage: input.stage?.trim() || "Lead",
+      title,
+      value: Math.max(0, Number(input.estimatedValue ?? 0)),
+    } as IOpportunity);
+    opportunityId = opportunity.id;
+  }
+
+  if (!opportunityId) {
+    throw new Error("opportunityId is required when mode is link.");
+  }
+
+  const updatedRequest: ServiceRequestRecord = {
+    ...request.request,
+    opportunityId,
+    status: request.request.status === "submitted" ? "under_review" : request.request.status,
+    updatedAt: nowIso(),
+  };
+
+  await updateWorkflowNote(token, request.noteId, {
+    kind: "request",
+    request: updatedRequest,
+    schema: "service-request-workflow-v1",
+    tenantId: user.tenantId,
+  });
+
+  await appendEvent(token, updatedRequest, user, "service_request_opportunity_linked", {
+    mode: input.mode,
+    opportunityId,
+  });
+
+  return {
+    opportunity,
+    request: clone(updatedRequest),
+  };
+};
+
+export const attachLiveProposalToServiceRequest = async (
+  user: IMockUser,
+  token: string,
+  requestId: string,
+  input: {
+    currency?: string;
+    description?: string;
+    mode: "create" | "link";
+    proposalId?: string;
+    title?: string;
+    validUntil?: string;
+  },
+) => {
+  requireInternalUser(user);
+
+  const { request } = await getVisibleRequestOrThrow(user, token, requestId);
+  let proposalId = input.proposalId?.trim();
+  let proposal: IProposal | null = null;
+
+  if (input.mode === "create") {
+    if (!request.request.opportunityId) {
+      throw new Error("The service request needs an opportunity before creating a proposal.");
+    }
+
+    const title = input.title?.trim();
+
+    if (!title) {
+      throw new Error("title is required when creating a proposal.");
+    }
+
+    proposal = await createLiveProposal(token, {
+      clientId: request.request.clientId,
+      currency: input.currency?.trim() || "ZAR",
+      description: input.description?.trim() || request.request.description,
+      id: "",
+      opportunityId: request.request.opportunityId,
+      title,
+      validUntil: normalizeDate(input.validUntil),
+      value: 0,
+    } as IProposal);
+    proposalId = proposal.id;
+  }
+
+  if (!proposalId) {
+    throw new Error("proposalId is required when mode is link.");
+  }
+
+  const updatedRequest: ServiceRequestRecord = {
+    ...request.request,
+    proposalId,
+    status: "proposal_prepared",
+    updatedAt: nowIso(),
+  };
+
+  await updateWorkflowNote(token, request.noteId, {
+    kind: "request",
+    request: updatedRequest,
+    schema: "service-request-workflow-v1",
+    tenantId: user.tenantId,
+  });
+
+  await appendEvent(token, updatedRequest, user, "service_request_proposal_linked", {
+    mode: input.mode,
+    proposalId,
+  });
+
+  return {
+    proposal,
+    request: clone(updatedRequest),
+  };
+};

--- a/lib/server/service-request-backend-store.ts
+++ b/lib/server/service-request-backend-store.ts
@@ -726,6 +726,8 @@ export const addLiveServiceRequestMessage = async (
   requestId: string,
   input: {
     content: string;
+    recipientType: "client" | "representative" | "both";
+    representativeUserIds?: string[];
   },
 ) => {
   const content = input.content.trim();
@@ -734,10 +736,43 @@ export const addLiveServiceRequestMessage = async (
     throw new Error("Message content is required.");
   }
 
-  const { request } = await getVisibleRequestOrThrow(user, token, requestId);
+  const { request, state } = await getVisibleRequestOrThrow(user, token, requestId);
+  const recipientType = input.recipientType;
+  const representativeUserIds = [
+    ...new Set((input.representativeUserIds ?? []).map((value) => value.trim()).filter(Boolean)),
+  ];
+
+  if (!["client", "representative", "both"].includes(recipientType)) {
+    throw new Error("A valid recipientType is required.");
+  }
+
+  if (
+    (recipientType === "representative" || recipientType === "both") &&
+    representativeUserIds.length === 0
+  ) {
+    throw new Error("At least one representative recipient is required.");
+  }
+
+  const representativeNames = state.assignments
+    .filter(
+      (item) =>
+        item.assignment.serviceRequestId === request.request.id &&
+        representativeUserIds.includes(item.assignment.representativeUserId),
+    )
+    .map((item) => item.assignment.representativeName);
+
+  if (
+    (recipientType === "representative" || recipientType === "both") &&
+    representativeNames.length !== representativeUserIds.length
+  ) {
+    throw new Error("Representative recipients must belong to this request.");
+  }
 
   await appendEvent(token, request.request, user, "service_request_message_added", {
     content,
+    recipientType,
+    representativeNames,
+    representativeUserIds,
   });
 
   return getLiveServiceRequestDetail(user, token, requestId);

--- a/lib/server/service-request-backend-store.ts
+++ b/lib/server/service-request-backend-store.ts
@@ -720,6 +720,29 @@ export const applyLiveServiceRequestRepDecision = async (
   return clone(updatedRequest);
 };
 
+export const addLiveServiceRequestMessage = async (
+  user: IMockUser,
+  token: string,
+  requestId: string,
+  input: {
+    content: string;
+  },
+) => {
+  const content = input.content.trim();
+
+  if (!content) {
+    throw new Error("Message content is required.");
+  }
+
+  const { request } = await getVisibleRequestOrThrow(user, token, requestId);
+
+  await appendEvent(token, request.request, user, "service_request_message_added", {
+    content,
+  });
+
+  return getLiveServiceRequestDetail(user, token, requestId);
+};
+
 export const attachLiveOpportunityToServiceRequest = async (
   user: IMockUser,
   token: string,

--- a/lib/server/service-request-store.ts
+++ b/lib/server/service-request-store.ts
@@ -1,0 +1,774 @@
+import "server-only";
+
+import type { IMockUser } from "@/app/api/Auth/mock-users";
+import {
+  createMockOpportunity,
+  createMockPricingRequest,
+  createMockProposal,
+  listMockOpportunities,
+  listMockPricingRequests,
+  listMockProposals,
+  listMockTeamMembers,
+} from "@/lib/server/mock-workspace-store";
+import { OpportunityStage } from "@/providers/salesTypes";
+
+export type ServiceRequestStatus =
+  | "submitted"
+  | "under_review"
+  | "proposal_prepared"
+  | "awaiting_client_assignment_approval"
+  | "client_rejected_assignment"
+  | "client_approved_assignment"
+  | "awaiting_rep_acceptance"
+  | "rep_rejected_assignment"
+  | "active"
+  | "closed"
+  | "cancelled";
+
+export type ServiceRequestPriority = "low" | "medium" | "high" | "critical";
+
+export type ServiceRequestAssignmentStatus =
+  | "pending_client_approval"
+  | "client_rejected"
+  | "client_approved"
+  | "pending_rep_response"
+  | "rep_rejected"
+  | "rep_accepted";
+
+export type WorkflowActorType =
+  | "admin"
+  | "assistant"
+  | "client"
+  | "representative"
+  | "workspace_user";
+
+export type ServiceRequestRecord = {
+  clientId: string;
+  contractId?: string;
+  createdAt: string;
+  description: string;
+  id: string;
+  opportunityId?: string;
+  pricingRequestId?: string;
+  priority: ServiceRequestPriority;
+  proposalId?: string;
+  requestType: string;
+  source: "assistant" | "client_portal" | "workspace";
+  status: ServiceRequestStatus;
+  submittedByUserId: string;
+  tenantId: string;
+  title: string;
+  updatedAt: string;
+};
+
+export type ServiceRequestAssignmentRecord = {
+  assignedByUserId: string;
+  createdAt: string;
+  decisionNote?: string;
+  id: string;
+  representativeName: string;
+  representativeUserId: string;
+  serviceRequestId: string;
+  status: ServiceRequestAssignmentStatus;
+  updatedAt: string;
+};
+
+export type WorkflowEventRecord = {
+  actorType: WorkflowActorType;
+  actorUserId?: string;
+  createdAt: string;
+  eventType: string;
+  id: string;
+  payloadJson: Record<string, unknown>;
+  serviceRequestId: string;
+  tenantId: string;
+};
+
+type ServiceRequestState = {
+  assignments: ServiceRequestAssignmentRecord[];
+  events: WorkflowEventRecord[];
+  requests: ServiceRequestRecord[];
+};
+
+type LinkOpportunityInput = {
+  estimatedValue?: number;
+  expectedCloseDate?: string;
+  mode: "create" | "link";
+  opportunityId?: string;
+  ownerId?: string;
+  stage?: string;
+  title?: string;
+};
+
+type LinkPricingRequestInput = {
+  assignedToId?: string;
+  description?: string;
+  mode: "create" | "link";
+  pricingRequestId?: string;
+  priority?: number;
+  requiredByDate?: string;
+  title?: string;
+};
+
+type LinkProposalInput = {
+  currency?: string;
+  description?: string;
+  mode: "create" | "link";
+  proposalId?: string;
+  title?: string;
+  validUntil?: string;
+};
+
+declare global {
+  var __serviceRequestStore__: Map<string, ServiceRequestState> | undefined;
+}
+
+const serviceRequestStore =
+  globalThis.__serviceRequestStore__ ?? new Map<string, ServiceRequestState>();
+
+globalThis.__serviceRequestStore__ = serviceRequestStore;
+
+const createId = (prefix: string) =>
+  `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+const clone = <T,>(value: T): T => structuredClone(value);
+
+const nowIso = () => new Date().toISOString();
+
+const normalizeDate = (value?: string | null) => {
+  if (!value) {
+    return new Date().toISOString().split("T")[0];
+  }
+
+  return value.split("T")[0];
+};
+
+const getTenantState = (tenantId: string) => {
+  const existing = serviceRequestStore.get(tenantId);
+
+  if (existing) {
+    return existing;
+  }
+
+  const next: ServiceRequestState = {
+    assignments: [],
+    events: [],
+    requests: [],
+  };
+
+  serviceRequestStore.set(tenantId, next);
+
+  return next;
+};
+
+const isClientScopedUser = (user: IMockUser) =>
+  user.role === "Client" || (user.clientIds?.length ?? 0) > 0;
+
+const isInternalUser = (user: IMockUser) => user.role !== "Client";
+
+const canSeeRequest = (user: IMockUser, request: ServiceRequestRecord) => {
+  if (!isClientScopedUser(user)) {
+    return true;
+  }
+
+  return (
+    user.clientIds?.includes(request.clientId) ||
+    request.submittedByUserId === user.id
+  );
+};
+
+const eventActorTypeForUser = (user: IMockUser): WorkflowActorType => {
+  if (user.role === "Client") {
+    return "client";
+  }
+
+  if (user.role === "SalesRep") {
+    return "representative";
+  }
+
+  if (user.role === "Admin") {
+    return "admin";
+  }
+
+  return "workspace_user";
+};
+
+const appendEvent = (
+  state: ServiceRequestState,
+  request: ServiceRequestRecord,
+  actor: IMockUser,
+  eventType: string,
+  payloadJson: Record<string, unknown> = {},
+) => {
+  state.events.unshift({
+    actorType: eventActorTypeForUser(actor),
+    actorUserId: actor.id,
+    createdAt: nowIso(),
+    eventType,
+    id: createId("evt"),
+    payloadJson,
+    serviceRequestId: request.id,
+    tenantId: request.tenantId,
+  });
+};
+
+const getRequestIndex = (state: ServiceRequestState, requestId: string) =>
+  state.requests.findIndex((request) => request.id === requestId);
+
+const updateRequestRecord = (
+  state: ServiceRequestState,
+  requestId: string,
+  patch: Partial<ServiceRequestRecord>,
+) => {
+  const index = getRequestIndex(state, requestId);
+
+  if (index < 0) {
+    return null;
+  }
+
+  state.requests[index] = {
+    ...state.requests[index],
+    ...patch,
+    updatedAt: nowIso(),
+  };
+
+  return state.requests[index];
+};
+
+const getVisibleRequestOrThrow = (user: IMockUser, requestId: string) => {
+  const state = getTenantState(user.tenantId);
+  const request = state.requests.find((item) => item.id === requestId);
+
+  if (!request) {
+    throw new Error("Service request not found.");
+  }
+
+  if (!canSeeRequest(user, request)) {
+    throw new Error("You do not have access to this service request.");
+  }
+
+  return { request, state };
+};
+
+const requireInternalUser = (user: IMockUser) => {
+  if (!isInternalUser(user)) {
+    throw new Error("Only internal workspace users can perform this action.");
+  }
+};
+
+const requireClientUser = (user: IMockUser) => {
+  if (user.role !== "Client") {
+    throw new Error("Only client users can perform this action.");
+  }
+};
+
+const toServiceRequestDetail = (
+  state: ServiceRequestState,
+  request: ServiceRequestRecord,
+) => ({
+  assignments: clone(
+    state.assignments.filter((assignment) => assignment.serviceRequestId === request.id),
+  ),
+  events: clone(
+    state.events.filter((event) => event.serviceRequestId === request.id),
+  ),
+  request: clone(request),
+});
+
+const getAssignmentRecords = (state: ServiceRequestState, requestId: string) =>
+  state.assignments.filter((assignment) => assignment.serviceRequestId === requestId);
+
+export const listServiceRequests = (
+  user: IMockUser,
+  filters?: { statuses?: ServiceRequestStatus[] },
+) => {
+  const state = getTenantState(user.tenantId);
+  const statuses = new Set(filters?.statuses ?? []);
+
+  return clone(
+    state.requests.filter((request) => {
+      if (!canSeeRequest(user, request)) {
+        return false;
+      }
+
+      if (statuses.size > 0 && !statuses.has(request.status)) {
+        return false;
+      }
+
+      return true;
+    }),
+  );
+};
+
+export const getServiceRequestDetail = (user: IMockUser, requestId: string) => {
+  const { request, state } = getVisibleRequestOrThrow(user, requestId);
+  return toServiceRequestDetail(state, request);
+};
+
+export const createServiceRequest = (
+  user: IMockUser,
+  input: {
+    clientId: string;
+    description: string;
+    priority?: ServiceRequestPriority;
+    requestType?: string;
+    source?: ServiceRequestRecord["source"];
+    title: string;
+  },
+) => {
+  const state = getTenantState(user.tenantId);
+  const now = nowIso();
+  const request: ServiceRequestRecord = {
+    clientId: input.clientId,
+    createdAt: now,
+    description: input.description,
+    id: createId("req"),
+    priority: input.priority ?? "medium",
+    requestType: input.requestType ?? "service_request",
+    source: input.source ?? (isClientScopedUser(user) ? "client_portal" : "workspace"),
+    status: "submitted",
+    submittedByUserId: user.id,
+    tenantId: user.tenantId,
+    title: input.title,
+    updatedAt: now,
+  };
+
+  state.requests.unshift(request);
+  appendEvent(state, request, user, "service_request_submitted", {
+    priority: request.priority,
+    requestType: request.requestType,
+    source: request.source,
+  });
+
+  return clone(request);
+};
+
+export const markServiceRequestUnderReview = (user: IMockUser, requestId: string) => {
+  requireInternalUser(user);
+
+  const { request, state } = getVisibleRequestOrThrow(user, requestId);
+  const updated =
+    updateRequestRecord(state, request.id, {
+      status: "under_review",
+    }) ?? request;
+
+  appendEvent(state, updated, user, "service_request_review_started");
+
+  return clone(updated);
+};
+
+export const attachOpportunityToServiceRequest = (
+  user: IMockUser,
+  requestId: string,
+  input: LinkOpportunityInput,
+) => {
+  requireInternalUser(user);
+
+  const { request, state } = getVisibleRequestOrThrow(user, requestId);
+
+  let opportunityId = input.opportunityId?.trim();
+  let createdOpportunity = null;
+
+  if (input.mode === "link") {
+    if (!opportunityId) {
+      throw new Error("opportunityId is required when mode is link.");
+    }
+
+    const existing = listMockOpportunities(user.tenantId).find(
+      (item) => item.id === opportunityId && item.clientId === request.clientId,
+    );
+
+    if (!existing) {
+      throw new Error("Opportunity not found in the current workspace.");
+    }
+  } else {
+    const title = input.title?.trim();
+
+    if (!title) {
+      throw new Error("title is required when creating an opportunity.");
+    }
+
+    createdOpportunity = createMockOpportunity(user, {
+      clientId: request.clientId,
+      description: input.title?.trim() || request.description,
+      estimatedValue: Math.max(0, Number(input.estimatedValue ?? 0)),
+      expectedCloseDate: normalizeDate(input.expectedCloseDate),
+      ownerId: input.ownerId?.trim() || undefined,
+      stage: input.stage?.trim() || OpportunityStage.New,
+      title,
+    });
+    opportunityId = createdOpportunity.id;
+  }
+
+  const updated = updateRequestRecord(state, request.id, {
+    opportunityId,
+    status: request.status === "submitted" ? "under_review" : request.status,
+  });
+
+  if (!updated) {
+    throw new Error("Service request not found.");
+  }
+
+  appendEvent(state, updated, user, "service_request_opportunity_linked", {
+    mode: input.mode,
+    opportunityId,
+  });
+
+  return {
+    opportunity:
+      createdOpportunity ??
+      listMockOpportunities(user.tenantId).find((item) => item.id === opportunityId) ??
+      null,
+    request: clone(updated),
+  };
+};
+
+export const attachProposalToServiceRequest = (
+  user: IMockUser,
+  requestId: string,
+  input: LinkProposalInput,
+) => {
+  requireInternalUser(user);
+
+  const { request, state } = getVisibleRequestOrThrow(user, requestId);
+
+  let proposalId = input.proposalId?.trim();
+  let createdProposal = null;
+
+  if (input.mode === "link") {
+    if (!proposalId) {
+      throw new Error("proposalId is required when mode is link.");
+    }
+
+    const existing = listMockProposals(user.tenantId).find(
+      (item) => item.id === proposalId && item.clientId === request.clientId,
+    );
+
+    if (!existing) {
+      throw new Error("Proposal not found in the current workspace.");
+    }
+  } else {
+    if (!request.opportunityId) {
+      throw new Error("The service request needs an opportunity before creating a proposal.");
+    }
+
+    const title = input.title?.trim();
+
+    if (!title) {
+      throw new Error("title is required when creating a proposal.");
+    }
+
+    createdProposal = createMockProposal(user, {
+      currency: input.currency?.trim() || "ZAR",
+      description: input.description?.trim() || request.description,
+      opportunityId: request.opportunityId,
+      title,
+      validUntil: normalizeDate(input.validUntil),
+    });
+    proposalId = createdProposal.id;
+  }
+
+  const updated = updateRequestRecord(state, request.id, {
+    proposalId,
+    status: "proposal_prepared",
+  });
+
+  if (!updated) {
+    throw new Error("Service request not found.");
+  }
+
+  appendEvent(state, updated, user, "service_request_proposal_linked", {
+    mode: input.mode,
+    proposalId,
+  });
+
+  return {
+    proposal:
+      createdProposal ??
+      listMockProposals(user.tenantId).find((item) => item.id === proposalId) ??
+      null,
+    request: clone(updated),
+  };
+};
+
+export const attachPricingRequestToServiceRequest = (
+  user: IMockUser,
+  requestId: string,
+  input: LinkPricingRequestInput,
+) => {
+  requireInternalUser(user);
+
+  const { request, state } = getVisibleRequestOrThrow(user, requestId);
+
+  let pricingRequestId = input.pricingRequestId?.trim();
+  let createdPricingRequest = null;
+
+  if (input.mode === "link") {
+    if (!pricingRequestId) {
+      throw new Error("pricingRequestId is required when mode is link.");
+    }
+
+    const existing = listMockPricingRequests(user.tenantId).find(
+      (item) => item.id === pricingRequestId,
+    );
+
+    if (!existing) {
+      throw new Error("Pricing request not found in the current workspace.");
+    }
+  } else {
+    if (!request.opportunityId) {
+      throw new Error("The service request needs an opportunity before creating a pricing request.");
+    }
+
+    const opportunity = listMockOpportunities(user.tenantId).find(
+      (item) => item.id === request.opportunityId,
+    );
+
+    const title = input.title?.trim();
+
+    if (!title) {
+      throw new Error("title is required when creating a pricing request.");
+    }
+
+    createdPricingRequest = createMockPricingRequest(user, {
+      assignedToId: input.assignedToId?.trim() || undefined,
+      description: input.description?.trim() || request.description,
+      opportunityId: request.opportunityId,
+      opportunityTitle: opportunity?.title,
+      priority: input.priority ?? 2,
+      requestedById: user.id,
+      requestedByName: `${user.firstName} ${user.lastName}`.trim(),
+      requiredByDate: normalizeDate(input.requiredByDate),
+      status: "Pending",
+      title,
+    });
+    pricingRequestId = createdPricingRequest.id;
+  }
+
+  const updated = updateRequestRecord(state, request.id, {
+    pricingRequestId,
+  });
+
+  if (!updated) {
+    throw new Error("Service request not found.");
+  }
+
+  appendEvent(state, updated, user, "service_request_pricing_request_linked", {
+    mode: input.mode,
+    pricingRequestId,
+  });
+
+  return {
+    pricingRequest:
+      createdPricingRequest ??
+      listMockPricingRequests(user.tenantId).find((item) => item.id === pricingRequestId) ??
+      null,
+    request: clone(updated),
+  };
+};
+
+export const createServiceRequestAssignments = (
+  user: IMockUser,
+  requestId: string,
+  input: {
+    note?: string;
+    representativeUserIds: string[];
+  },
+) => {
+  requireInternalUser(user);
+
+  const representativeUserIds = [...new Set(input.representativeUserIds.map((value) => value.trim()).filter(Boolean))];
+
+  if (representativeUserIds.length === 0) {
+    throw new Error("At least one representative user ID is required.");
+  }
+
+  const { request, state } = getVisibleRequestOrThrow(user, requestId);
+  const teamMembers = listMockTeamMembers(user.tenantId);
+  const nextAssignments: ServiceRequestAssignmentRecord[] = [];
+
+  for (const representativeUserId of representativeUserIds) {
+    const representative = teamMembers.find((member) => member.id === representativeUserId);
+
+    if (!representative) {
+      throw new Error(`Representative ${representativeUserId} was not found.`);
+    }
+
+    nextAssignments.push({
+      assignedByUserId: user.id,
+      createdAt: nowIso(),
+      decisionNote: input.note?.trim() || undefined,
+      id: createId("assign"),
+      representativeName: representative.name,
+      representativeUserId,
+      serviceRequestId: request.id,
+      status: "pending_client_approval",
+      updatedAt: nowIso(),
+    });
+  }
+
+  state.assignments = state.assignments.filter(
+    (assignment) => assignment.serviceRequestId !== request.id,
+  );
+  state.assignments.unshift(...nextAssignments);
+
+  const updated = updateRequestRecord(state, request.id, {
+    status: "awaiting_client_assignment_approval",
+  });
+
+  if (!updated) {
+    throw new Error("Service request not found.");
+  }
+
+  appendEvent(state, updated, user, "service_request_assignments_created", {
+    note: input.note?.trim() || null,
+    representativeUserIds,
+  });
+
+  return {
+    assignments: clone(nextAssignments),
+    request: clone(updated),
+  };
+};
+
+export const applyServiceRequestClientDecision = (
+  user: IMockUser,
+  requestId: string,
+  input: {
+    assignmentIds: string[];
+    decision: "approve" | "reject";
+    note?: string;
+  },
+) => {
+  requireClientUser(user);
+
+  const { request, state } = getVisibleRequestOrThrow(user, requestId);
+  const assignmentIds = new Set(input.assignmentIds.map((value) => value.trim()).filter(Boolean));
+  const matchingAssignments = state.assignments.filter(
+    (assignment) =>
+      assignment.serviceRequestId === request.id && assignmentIds.has(assignment.id),
+  );
+
+  if (matchingAssignments.length === 0) {
+    throw new Error("No matching assignments were found for this request.");
+  }
+
+  const nextStatus =
+    input.decision === "approve" ? "client_approved" : "client_rejected";
+
+  state.assignments = state.assignments.map((assignment) => {
+    if (!assignmentIds.has(assignment.id) || assignment.serviceRequestId !== request.id) {
+      return assignment;
+    }
+
+    return {
+      ...assignment,
+      decisionNote: input.note?.trim() || assignment.decisionNote,
+      status: nextStatus,
+      updatedAt: nowIso(),
+    };
+  });
+
+  const allAssignments = getAssignmentRecords(state, request.id);
+  const approvedAssignments = allAssignments.filter(
+    (assignment) => assignment.status === "client_approved",
+  );
+
+  if (input.decision === "approve") {
+    state.assignments = state.assignments.map((assignment) => {
+      if (assignment.serviceRequestId !== request.id) {
+        return assignment;
+      }
+
+      if (assignment.status !== "client_approved") {
+        return assignment;
+      }
+
+      return {
+        ...assignment,
+        status: "pending_rep_response",
+        updatedAt: nowIso(),
+      };
+    });
+  }
+
+  const updated = updateRequestRecord(state, request.id, {
+    status:
+      input.decision === "approve" && approvedAssignments.length > 0
+        ? "awaiting_rep_acceptance"
+        : "client_rejected_assignment",
+  });
+
+  if (!updated) {
+    throw new Error("Service request not found.");
+  }
+
+  appendEvent(state, updated, user, "service_request_client_decision", {
+    assignmentIds: [...assignmentIds],
+    decision: input.decision,
+    note: input.note?.trim() || null,
+  });
+
+  return clone(updated);
+};
+
+export const applyServiceRequestRepDecision = (
+  user: IMockUser,
+  requestId: string,
+  input: {
+    assignmentId: string;
+    decision: "accept" | "reject";
+    note?: string;
+  },
+) => {
+  const { request, state } = getVisibleRequestOrThrow(user, requestId);
+  const assignment = state.assignments.find(
+    (item) => item.id === input.assignmentId && item.serviceRequestId === request.id,
+  );
+
+  if (!assignment) {
+    throw new Error("Assignment not found for this request.");
+  }
+
+  if (assignment.representativeUserId !== user.id && user.role !== "Admin") {
+    throw new Error("You do not have access to decide this assignment.");
+  }
+
+  state.assignments = state.assignments.map((item) =>
+    item.id === assignment.id
+      ? {
+          ...item,
+          decisionNote: input.note?.trim() || item.decisionNote,
+          status: input.decision === "accept" ? "rep_accepted" : "rep_rejected",
+          updatedAt: nowIso(),
+        }
+      : item,
+  );
+
+  const allAssignments = getAssignmentRecords(state, request.id);
+  const hasAccepted = allAssignments.some((item) => item.status === "rep_accepted");
+  const hasPending = allAssignments.some((item) => item.status === "pending_rep_response");
+  const hasRejected = allAssignments.some((item) => item.status === "rep_rejected");
+
+  const updated = updateRequestRecord(state, request.id, {
+    status: hasRejected
+      ? "rep_rejected_assignment"
+      : hasPending
+        ? "awaiting_rep_acceptance"
+        : hasAccepted
+          ? "active"
+          : request.status,
+  });
+
+  if (!updated) {
+    throw new Error("Service request not found.");
+  }
+
+  appendEvent(state, updated, user, "service_request_representative_decision", {
+    assignmentId: input.assignmentId,
+    decision: input.decision,
+    note: input.note?.trim() || null,
+  });
+
+  return clone(updated);
+};

--- a/lib/server/service-request-store.ts
+++ b/lib/server/service-request-store.ts
@@ -772,3 +772,25 @@ export const applyServiceRequestRepDecision = (
 
   return clone(updated);
 };
+
+export const addServiceRequestMessage = (
+  user: IMockUser,
+  requestId: string,
+  input: {
+    content: string;
+  },
+) => {
+  const content = input.content.trim();
+
+  if (!content) {
+    throw new Error("Message content is required.");
+  }
+
+  const { request, state } = getVisibleRequestOrThrow(user, requestId);
+
+  appendEvent(state, request, user, "service_request_message_added", {
+    content,
+  });
+
+  return getServiceRequestDetail(user, requestId);
+};

--- a/lib/server/service-request-store.ts
+++ b/lib/server/service-request-store.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import type { IMockUser } from "@/app/api/Auth/mock-users";
+import { readLocalStateSnapshot, writeLocalStateSnapshot } from "@/lib/server/local-state-store";
 import {
   createMockOpportunity,
   createMockPricingRequest,
@@ -84,6 +85,8 @@ export type WorkflowEventRecord = {
   tenantId: string;
 };
 
+type MessageRecipientType = "client" | "representative" | "both";
+
 type ServiceRequestState = {
   assignments: ServiceRequestAssignmentRecord[];
   events: WorkflowEventRecord[];
@@ -124,7 +127,13 @@ declare global {
 }
 
 const serviceRequestStore =
-  globalThis.__serviceRequestStore__ ?? new Map<string, ServiceRequestState>();
+  globalThis.__serviceRequestStore__ ??
+  new Map<string, ServiceRequestState>(
+    Object.entries(readLocalStateSnapshot().serviceRequestStore).map(([tenantId, state]) => [
+      tenantId,
+      state as ServiceRequestState,
+    ]),
+  );
 
 globalThis.__serviceRequestStore__ = serviceRequestStore;
 
@@ -132,6 +141,12 @@ const createId = (prefix: string) =>
   `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
 const clone = <T,>(value: T): T => structuredClone(value);
+
+const persistServiceRequestStore = () => {
+  writeLocalStateSnapshot((state) => {
+    state.serviceRequestStore = Object.fromEntries(serviceRequestStore.entries());
+  });
+};
 
 const nowIso = () => new Date().toISOString();
 
@@ -157,6 +172,7 @@ const getTenantState = (tenantId: string) => {
   };
 
   serviceRequestStore.set(tenantId, next);
+  persistServiceRequestStore();
 
   return next;
 };
@@ -210,6 +226,7 @@ const appendEvent = (
     serviceRequestId: request.id,
     tenantId: request.tenantId,
   });
+  persistServiceRequestStore();
 };
 
 const getRequestIndex = (state: ServiceRequestState, requestId: string) =>
@@ -231,6 +248,7 @@ const updateRequestRecord = (
     ...patch,
     updatedAt: nowIso(),
   };
+  persistServiceRequestStore();
 
   return state.requests[index];
 };
@@ -339,6 +357,7 @@ export const createServiceRequest = (
     requestType: request.requestType,
     source: request.source,
   });
+  persistServiceRequestStore();
 
   return clone(request);
 };
@@ -611,6 +630,7 @@ export const createServiceRequestAssignments = (
     (assignment) => assignment.serviceRequestId !== request.id,
   );
   state.assignments.unshift(...nextAssignments);
+  persistServiceRequestStore();
 
   const updated = updateRequestRecord(state, request.id, {
     status: "awaiting_client_assignment_approval",
@@ -668,6 +688,7 @@ export const applyServiceRequestClientDecision = (
       updatedAt: nowIso(),
     };
   });
+  persistServiceRequestStore();
 
   const allAssignments = getAssignmentRecords(state, request.id);
   const approvedAssignments = allAssignments.filter(
@@ -690,6 +711,7 @@ export const applyServiceRequestClientDecision = (
         updatedAt: nowIso(),
       };
     });
+    persistServiceRequestStore();
   }
 
   const updated = updateRequestRecord(state, request.id, {
@@ -744,6 +766,7 @@ export const applyServiceRequestRepDecision = (
         }
       : item,
   );
+  persistServiceRequestStore();
 
   const allAssignments = getAssignmentRecords(state, request.id);
   const hasAccepted = allAssignments.some((item) => item.status === "rep_accepted");
@@ -778,6 +801,8 @@ export const addServiceRequestMessage = (
   requestId: string,
   input: {
     content: string;
+    recipientType: MessageRecipientType;
+    representativeUserIds?: string[];
   },
 ) => {
   const content = input.content.trim();
@@ -787,9 +812,39 @@ export const addServiceRequestMessage = (
   }
 
   const { request, state } = getVisibleRequestOrThrow(user, requestId);
+  const recipientType = input.recipientType;
+  const representativeUserIds = [
+    ...new Set((input.representativeUserIds ?? []).map((value) => value.trim()).filter(Boolean)),
+  ];
+
+  if (!["client", "representative", "both"].includes(recipientType)) {
+    throw new Error("A valid recipientType is required.");
+  }
+
+  if (
+    (recipientType === "representative" || recipientType === "both") &&
+    representativeUserIds.length === 0
+  ) {
+    throw new Error("At least one representative recipient is required.");
+  }
+
+  const assignments = getAssignmentRecords(state, request.id);
+  const representativeNames = assignments
+    .filter((assignment) => representativeUserIds.includes(assignment.representativeUserId))
+    .map((assignment) => assignment.representativeName);
+
+  if (
+    (recipientType === "representative" || recipientType === "both") &&
+    representativeNames.length !== representativeUserIds.length
+  ) {
+    throw new Error("Representative recipients must belong to this request.");
+  }
 
   appendEvent(state, request, user, "service_request_message_added", {
     content,
+    recipientType,
+    representativeNames,
+    representativeUserIds,
   });
 
   return getServiceRequestDetail(user, requestId);

--- a/openapi/owned-sales-automation.json
+++ b/openapi/owned-sales-automation.json
@@ -1,0 +1,5681 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Owned Sales Automation API",
+    "version": "0.1.0",
+    "description": "Repo-owned API contract derived from the captured SalesAutomation swagger and extended with workflow endpoints required for assistant-driven automation."
+  },
+  "servers": [
+    {
+      "url": "/",
+      "description": "Local application server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Auth"
+    },
+    {
+      "name": "Clients"
+    },
+    {
+      "name": "Contacts"
+    },
+    {
+      "name": "Opportunities"
+    },
+    {
+      "name": "Proposals"
+    },
+    {
+      "name": "PricingRequests"
+    },
+    {
+      "name": "Activities"
+    },
+    {
+      "name": "Notes"
+    },
+    {
+      "name": "Users"
+    },
+    {
+      "name": "ServiceRequests"
+    }
+  ],
+  "paths": {
+    "/api/Auth/login": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequestDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequestDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponseDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponseDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Auth/register": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterRequestDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterRequestDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponseDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponseDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Auth/me": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Clients": {
+      "get": {
+        "tags": [
+          "Clients"
+        ],
+        "parameters": [
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "searchTerm",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "industry",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "isActive",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientDtoPagedResultDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientDtoPagedResultDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientDtoPagedResultDto"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Clients"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateClientDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateClientDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateClientDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Clients/{id}": {
+      "get": {
+        "tags": [
+          "Clients"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Clients"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateClientDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateClientDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateClientDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Clients"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Contacts": {
+      "get": {
+        "tags": [
+          "Contacts"
+        ],
+        "parameters": [
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "clientId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "searchTerm",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "isActive",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDtoPagedResultDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDtoPagedResultDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDtoPagedResultDto"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Contacts"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateContactDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateContactDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateContactDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Contacts/{id}": {
+      "get": {
+        "tags": [
+          "Contacts"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Contacts"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContactDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContactDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContactDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Contacts"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Contacts/by-client/{clientId}": {
+      "get": {
+        "tags": [
+          "Contacts"
+        ],
+        "parameters": [
+          {
+            "name": "clientId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ContactDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ContactDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ContactDto"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Opportunities": {
+      "get": {
+        "tags": [
+          "Opportunities"
+        ],
+        "parameters": [
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "clientId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "ownerId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "stage",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/OpportunityStage"
+            }
+          },
+          {
+            "name": "searchTerm",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "isActive",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDtoPagedResultDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDtoPagedResultDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDtoPagedResultDto"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Opportunities"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOpportunityDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOpportunityDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOpportunityDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Opportunities/{id}": {
+      "get": {
+        "tags": [
+          "Opportunities"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Opportunities"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateOpportunityDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateOpportunityDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateOpportunityDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Opportunities"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Opportunities/{id}/stage": {
+      "put": {
+        "tags": [
+          "Opportunities"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateStageDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateStageDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateStageDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Opportunities/{id}/assign": {
+      "post": {
+        "tags": [
+          "Opportunities"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignOpportunityDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignOpportunityDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignOpportunityDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Proposals": {
+      "get": {
+        "tags": [
+          "Proposals"
+        ],
+        "parameters": [
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "opportunityId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "clientId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/ProposalStatus"
+            }
+          },
+          {
+            "name": "searchTerm",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProposalDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProposalDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProposalDto"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Proposals"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateProposalDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateProposalDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateProposalDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalWithLineItemsDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalWithLineItemsDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalWithLineItemsDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Proposals/{id}": {
+      "get": {
+        "tags": [
+          "Proposals"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalWithLineItemsDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalWithLineItemsDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalWithLineItemsDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Proposals"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProposalDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProposalDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProposalDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Proposals"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Proposals/{id}/submit": {
+      "put": {
+        "tags": [
+          "Proposals"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Proposals/{id}/approve": {
+      "put": {
+        "tags": [
+          "Proposals"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Proposals/{id}/reject": {
+      "put": {
+        "tags": [
+          "Proposals"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/PricingRequests": {
+      "get": {
+        "tags": [
+          "PricingRequests"
+        ],
+        "parameters": [
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "opportunityId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "assignedToId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/PricingRequestStatus"
+            }
+          },
+          {
+            "name": "priority",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/Priority"
+            }
+          },
+          {
+            "name": "searchTerm",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PricingRequestDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PricingRequestDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PricingRequestDto"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "PricingRequests"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePricingRequestDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePricingRequestDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePricingRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingRequestDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingRequestDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingRequestDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/PricingRequests/{id}": {
+      "get": {
+        "tags": [
+          "PricingRequests"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingRequestDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingRequestDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingRequestDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "PricingRequests"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePricingRequestDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePricingRequestDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePricingRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingRequestDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingRequestDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingRequestDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "PricingRequests"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/PricingRequests/{id}/assign": {
+      "post": {
+        "tags": [
+          "PricingRequests"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignPricingRequestDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignPricingRequestDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignPricingRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingRequestDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingRequestDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingRequestDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/PricingRequests/{id}/complete": {
+      "put": {
+        "tags": [
+          "PricingRequests"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingRequestDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingRequestDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingRequestDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Activities": {
+      "get": {
+        "tags": [
+          "Activities"
+        ],
+        "parameters": [
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "assignedToId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/ActivityType"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/ActivityStatus"
+            }
+          },
+          {
+            "name": "relatedToType",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/RelatedToType"
+            }
+          },
+          {
+            "name": "relatedToId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "searchTerm",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActivityDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActivityDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActivityDto"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Activities"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateActivityDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateActivityDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateActivityDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Activities/{id}": {
+      "get": {
+        "tags": [
+          "Activities"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Activities"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateActivityDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateActivityDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateActivityDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Activities"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Activities/{id}/complete": {
+      "put": {
+        "tags": [
+          "Activities"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteActivityDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteActivityDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteActivityDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Activities/{id}/cancel": {
+      "put": {
+        "tags": [
+          "Activities"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Notes": {
+      "get": {
+        "tags": [
+          "Notes"
+        ],
+        "parameters": [
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "relatedToType",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/RelatedToType"
+            }
+          },
+          {
+            "name": "relatedToId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Notes"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateNoteDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateNoteDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateNoteDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/Notes/{id}": {
+      "get": {
+        "tags": [
+          "Notes"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Notes"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateNoteDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateNoteDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateNoteDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Notes"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/Users": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            }
+          },
+          {
+            "name": "role",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "searchTerm",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "isActive",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/Users/{id}": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/service-requests": {
+      "get": {
+        "tags": [
+          "ServiceRequests"
+        ],
+        "summary": "List service requests visible to the current user.",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated statuses to filter by."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceRequestPagedResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ServiceRequests"
+        ],
+        "summary": "Create a new client or admin service request.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateServiceRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceRequestDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/service-requests/{requestId}": {
+      "get": {
+        "tags": [
+          "ServiceRequests"
+        ],
+        "summary": "Get the detail view for a single service request.",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceRequestDetailDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/service-requests/{requestId}/review": {
+      "post": {
+        "tags": [
+          "ServiceRequests"
+        ],
+        "summary": "Mark a service request as under review.",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceRequestDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/service-requests/{requestId}/opportunity": {
+      "post": {
+        "tags": [
+          "ServiceRequests"
+        ],
+        "summary": "Create or link an opportunity for a service request.",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServiceRequestOpportunityDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/service-requests/{requestId}/proposal": {
+      "post": {
+        "tags": [
+          "ServiceRequests"
+        ],
+        "summary": "Create or link a proposal for a service request.",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServiceRequestProposalDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalWithLineItemsDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/service-requests/{requestId}/assignments": {
+      "post": {
+        "tags": [
+          "ServiceRequests"
+        ],
+        "summary": "Assign one or more representatives to a service request.",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateServiceRequestAssignmentsDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceRequestAssignmentsResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/service-requests/{requestId}/client-decision": {
+      "post": {
+        "tags": [
+          "ServiceRequests"
+        ],
+        "summary": "Apply the client's approval or rejection of proposed assignments.",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServiceRequestDecisionDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceRequestDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/service-requests/{requestId}/rep-decision": {
+      "post": {
+        "tags": [
+          "ServiceRequests"
+        ],
+        "summary": "Apply the representative's acceptance or rejection of an assignment.",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServiceRequestRepDecisionDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceRequestDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "LoginRequestDto": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "password": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LoginResponseDto": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "nullable": true
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "tenantId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": {}
+      },
+      "RegisterRequestDto": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "password": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "phoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "role": {
+            "type": "string",
+            "nullable": true
+          },
+          "tenantName": {
+            "type": "string",
+            "nullable": true
+          },
+          "tenantId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ClientDtoPagedResultDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClientDto"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPreviousPage": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNextPage": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateClientDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "industry": {
+            "type": "string",
+            "nullable": true
+          },
+          "companySize": {
+            "type": "string",
+            "nullable": true
+          },
+          "website": {
+            "type": "string",
+            "nullable": true
+          },
+          "billingAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "taxNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "clientType": {
+            "$ref": "#/components/schemas/ClientType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ClientDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "industry": {
+            "type": "string",
+            "nullable": true
+          },
+          "companySize": {
+            "type": "string",
+            "nullable": true
+          },
+          "website": {
+            "type": "string",
+            "nullable": true
+          },
+          "billingAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "taxNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "clientType": {
+            "$ref": "#/components/schemas/ClientType"
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "createdById": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdByName": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "contactsCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "opportunitiesCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "contractsCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateClientDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "industry": {
+            "type": "string",
+            "nullable": true
+          },
+          "companySize": {
+            "type": "string",
+            "nullable": true
+          },
+          "website": {
+            "type": "string",
+            "nullable": true
+          },
+          "billingAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "taxNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "clientType": {
+            "$ref": "#/components/schemas/ClientType"
+          },
+          "isActive": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContactDtoPagedResultDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactDto"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPreviousPage": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNextPage": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateContactDto": {
+        "type": "object",
+        "properties": {
+          "clientId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "phoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "position": {
+            "type": "string",
+            "nullable": true
+          },
+          "isPrimaryContact": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContactDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "clientId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "clientName": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "fullName": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "phoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "position": {
+            "type": "string",
+            "nullable": true
+          },
+          "isPrimaryContact": {
+            "type": "boolean"
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateContactDto": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "phoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "position": {
+            "type": "string",
+            "nullable": true
+          },
+          "isPrimaryContact": {
+            "type": "boolean"
+          },
+          "isActive": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "OpportunityStage": {
+        "enum": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "OpportunityDtoPagedResultDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpportunityDto"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPreviousPage": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNextPage": {
+            "type": "boolean",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateOpportunityDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "clientId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "contactId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "estimatedValue": {
+            "type": "number",
+            "format": "double"
+          },
+          "currency": {
+            "type": "string",
+            "nullable": true
+          },
+          "probability": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "source": {
+            "$ref": "#/components/schemas/OpportunitySource"
+          },
+          "expectedCloseDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "OpportunityDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "clientId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "clientName": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "contactName": {
+            "type": "string",
+            "nullable": true
+          },
+          "ownerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "ownerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "estimatedValue": {
+            "type": "number",
+            "format": "double"
+          },
+          "currency": {
+            "type": "string",
+            "nullable": true
+          },
+          "probability": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "stage": {
+            "$ref": "#/components/schemas/OpportunityStage"
+          },
+          "stageName": {
+            "type": "string",
+            "nullable": true
+          },
+          "source": {
+            "$ref": "#/components/schemas/OpportunitySource"
+          },
+          "expectedCloseDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "actualCloseDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "lossReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "closedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateOpportunityDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "estimatedValue": {
+            "type": "number",
+            "format": "double"
+          },
+          "currency": {
+            "type": "string",
+            "nullable": true
+          },
+          "probability": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "source": {
+            "$ref": "#/components/schemas/OpportunitySource"
+          },
+          "expectedCloseDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateStageDto": {
+        "type": "object",
+        "properties": {
+          "stage": {
+            "$ref": "#/components/schemas/OpportunityStage"
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "lossReason": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AssignOpportunityDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProposalStatus": {
+        "enum": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "ProposalDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "proposalNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "opportunityId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "opportunityTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "clientId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "clientName": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/ProposalStatus"
+          },
+          "statusName": {
+            "type": "string",
+            "nullable": true
+          },
+          "totalAmount": {
+            "type": "number",
+            "format": "double"
+          },
+          "currency": {
+            "type": "string",
+            "nullable": true
+          },
+          "validUntil": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "submittedDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "approvedDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "createdById": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdByName": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lineItemsCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateProposalDto": {
+        "type": "object",
+        "properties": {
+          "opportunityId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "currency": {
+            "type": "string",
+            "nullable": true
+          },
+          "validUntil": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lineItems": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateProposalLineItemDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProposalWithLineItemsDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "proposalNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "opportunityId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "opportunityTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "clientId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "clientName": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/ProposalStatus"
+          },
+          "statusName": {
+            "type": "string",
+            "nullable": true
+          },
+          "totalAmount": {
+            "type": "number",
+            "format": "double"
+          },
+          "currency": {
+            "type": "string",
+            "nullable": true
+          },
+          "validUntil": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "submittedDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "approvedDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "createdById": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdByName": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lineItemsCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "lineItems": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProposalLineItemDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateProposalDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "currency": {
+            "type": "string",
+            "nullable": true
+          },
+          "validUntil": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PricingRequestStatus": {
+        "enum": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Priority": {
+        "enum": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "PricingRequestDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "opportunityId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "opportunityTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestedById": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "requestedByName": {
+            "type": "string",
+            "nullable": true
+          },
+          "assignedToId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "assignedToName": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/PricingRequestStatus"
+          },
+          "statusName": {
+            "type": "string",
+            "nullable": true
+          },
+          "priority": {
+            "$ref": "#/components/schemas/Priority"
+          },
+          "priorityName": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requiredByDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "completedDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreatePricingRequestDto": {
+        "type": "object",
+        "properties": {
+          "opportunityId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "assignedToId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "priority": {
+            "$ref": "#/components/schemas/Priority"
+          },
+          "requiredByDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdatePricingRequestDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "priority": {
+            "$ref": "#/components/schemas/Priority"
+          },
+          "requiredByDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AssignPricingRequestDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ActivityType": {
+        "enum": [
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "ActivityStatus": {
+        "enum": [
+          1,
+          2,
+          3
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "RelatedToType": {
+        "enum": [
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "ActivityDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "$ref": "#/components/schemas/ActivityType"
+          },
+          "typeName": {
+            "type": "string",
+            "nullable": true
+          },
+          "subject": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "relatedToType": {
+            "$ref": "#/components/schemas/RelatedToType"
+          },
+          "relatedToTypeName": {
+            "type": "string",
+            "nullable": true
+          },
+          "relatedToId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "relatedToTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "assignedToId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "assignedToName": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/ActivityStatus"
+          },
+          "statusName": {
+            "type": "string",
+            "nullable": true
+          },
+          "priority": {
+            "$ref": "#/components/schemas/Priority"
+          },
+          "priorityName": {
+            "type": "string",
+            "nullable": true
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "completedDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "duration": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "location": {
+            "type": "string",
+            "nullable": true
+          },
+          "outcome": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdById": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdByName": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "isOverdue": {
+            "type": "boolean"
+          },
+          "participantsCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateActivityDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/ActivityType"
+          },
+          "subject": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "relatedToType": {
+            "$ref": "#/components/schemas/RelatedToType"
+          },
+          "relatedToId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "assignedToId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "priority": {
+            "$ref": "#/components/schemas/Priority"
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "duration": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "location": {
+            "type": "string",
+            "nullable": true
+          },
+          "participants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateActivityParticipantDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateActivityDto": {
+        "type": "object",
+        "properties": {
+          "subject": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "assignedToId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "priority": {
+            "$ref": "#/components/schemas/Priority"
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "duration": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "location": {
+            "type": "string",
+            "nullable": true
+          },
+          "outcome": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CompleteActivityDto": {
+        "type": "object",
+        "properties": {
+          "outcome": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateNoteDto": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "nullable": true
+          },
+          "relatedToType": {
+            "$ref": "#/components/schemas/RelatedToType"
+          },
+          "relatedToId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "isPrivate": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateNoteDto": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "nullable": true
+          },
+          "isPrivate": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ClientType": {
+        "enum": [
+          1,
+          2,
+          3
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "OpportunitySource": {
+        "enum": [
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "CreateProposalLineItemDto": {
+        "type": "object",
+        "properties": {
+          "productServiceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "unitPrice": {
+            "type": "number",
+            "format": "double"
+          },
+          "discount": {
+            "type": "number",
+            "format": "double"
+          },
+          "taxRate": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProposalLineItemDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "proposalId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "productServiceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "unitPrice": {
+            "type": "number",
+            "format": "double"
+          },
+          "discount": {
+            "type": "number",
+            "format": "double"
+          },
+          "taxRate": {
+            "type": "number",
+            "format": "double"
+          },
+          "totalPrice": {
+            "type": "number",
+            "format": "double"
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateActivityParticipantDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "contactId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "isRequired": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServiceRequestStatus": {
+        "type": "string",
+        "enum": [
+          "submitted",
+          "under_review",
+          "proposal_prepared",
+          "awaiting_client_assignment_approval",
+          "client_rejected_assignment",
+          "client_approved_assignment",
+          "awaiting_rep_acceptance",
+          "rep_rejected_assignment",
+          "active",
+          "closed",
+          "cancelled"
+        ]
+      },
+      "ServiceRequestPriority": {
+        "type": "string",
+        "enum": [
+          "low",
+          "medium",
+          "high",
+          "critical"
+        ]
+      },
+      "AssignmentDecision": {
+        "type": "string",
+        "enum": [
+          "approve",
+          "reject",
+          "accept"
+        ]
+      },
+      "ServiceRequestDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "tenantId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "clientId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "submittedByUserId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "requestType": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ServiceRequestStatus"
+          },
+          "priority": {
+            "$ref": "#/components/schemas/ServiceRequestPriority"
+          },
+          "source": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "tenantId",
+          "clientId",
+          "submittedByUserId",
+          "title",
+          "description",
+          "requestType",
+          "status",
+          "priority",
+          "source",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "ServiceRequestPagedResult": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServiceRequestDto"
+            }
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "CreateServiceRequestDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "clientId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "requestType": {
+            "type": "string"
+          },
+          "priority": {
+            "$ref": "#/components/schemas/ServiceRequestPriority"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "clientId",
+          "title",
+          "description"
+        ]
+      },
+      "ServiceRequestDetailDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "request": {
+            "$ref": "#/components/schemas/ServiceRequestDto"
+          },
+          "assignments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServiceRequestAssignmentDto"
+            }
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkflowEventDto"
+            }
+          }
+        },
+        "required": [
+          "request",
+          "assignments",
+          "events"
+        ]
+      },
+      "ServiceRequestAssignmentDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "serviceRequestId": {
+            "type": "string"
+          },
+          "representativeUserId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "assignedByUserId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string"
+          },
+          "decisionNote": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "serviceRequestId",
+          "representativeUserId",
+          "assignedByUserId",
+          "status",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "WorkflowEventDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "serviceRequestId": {
+            "type": "string"
+          },
+          "actorUserId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "actorType": {
+            "type": "string"
+          },
+          "eventType": {
+            "type": "string"
+          },
+          "payloadJson": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "serviceRequestId",
+          "actorType",
+          "eventType",
+          "payloadJson",
+          "createdAt"
+        ]
+      },
+      "ServiceRequestOpportunityDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "create",
+              "link"
+            ]
+          },
+          "opportunityId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "estimatedValue": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "expectedCloseDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "stage": {
+            "type": "string",
+            "nullable": true
+          },
+          "ownerId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "required": [
+          "mode"
+        ]
+      },
+      "ServiceRequestProposalDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "create",
+              "link"
+            ]
+          },
+          "proposalId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "validUntil": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "currency": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "mode"
+        ]
+      },
+      "CreateServiceRequestAssignmentsDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "representativeUserIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "note": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "representativeUserIds"
+        ]
+      },
+      "ServiceRequestAssignmentsResponseDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "request": {
+            "$ref": "#/components/schemas/ServiceRequestDto"
+          },
+          "assignments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServiceRequestAssignmentDto"
+            }
+          }
+        },
+        "required": [
+          "request",
+          "assignments"
+        ]
+      },
+      "ServiceRequestDecisionDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "decision": {
+            "type": "string",
+            "enum": [
+              "approve",
+              "reject"
+            ]
+          },
+          "assignmentIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "note": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "decision",
+          "assignmentIds"
+        ]
+      },
+      "ServiceRequestRepDecisionDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "assignmentId": {
+            "type": "string"
+          },
+          "decision": {
+            "type": "string",
+            "enum": [
+              "accept",
+              "reject"
+            ]
+          },
+          "note": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "assignmentId",
+          "decision"
+        ]
+      }
+    }
+  }
+}

--- a/providers/authProvider/index.tsx
+++ b/providers/authProvider/index.tsx
@@ -31,6 +31,17 @@ import {
   type IUserRegisterRequest,
 } from "./context";
 import { AuthReducer } from "./reducers";
+
+class AuthRequestError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "AuthRequestError";
+    this.status = status;
+  }
+}
+
 export const useAuthState = () => {
   const context = useContext(AuthStateContext);
 
@@ -83,7 +94,7 @@ const authRequest = async <T,>(
   const payload = (await readJsonPayload<T & { message?: string }>(response));
 
   if (!response.ok) {
-    throw new Error(payload.message ?? "Authentication failed.");
+    throw new AuthRequestError(payload.message ?? "Authentication failed.", response.status);
   }
 
   return payload;
@@ -179,9 +190,19 @@ export default function AuthProvider({ children }: AuthProviderProps) {
       return;
     } catch (error) {
       console.error(error);
+
+      if (error instanceof AuthRequestError && (error.status === 401 || error.status === 403)) {
+        clearAuthSession();
+        dispatch(logoutSuccess());
+        return;
+      }
+
+      if (storedUser) {
+        dispatch(getMeSuccess(storedUser));
+        return;
+      }
     }
 
-    clearAuthSession();
     dispatch(logoutSuccess());
   }, []);
 

--- a/scripts/build-owned-openapi.mjs
+++ b/scripts/build-owned-openapi.mjs
@@ -1,0 +1,715 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const sourcePath = path.join(root, "swagger-live.json");
+const targetPath = path.join(root, "openapi", "owned-sales-automation.json");
+
+const source = JSON.parse(fs.readFileSync(sourcePath, "utf8"));
+
+const selectedPaths = [
+  "/api/Auth/login",
+  "/api/Auth/register",
+  "/api/Auth/me",
+  "/api/Clients",
+  "/api/Clients/{id}",
+  "/api/Contacts",
+  "/api/Contacts/{id}",
+  "/api/Contacts/by-client/{clientId}",
+  "/api/Opportunities",
+  "/api/Opportunities/{id}",
+  "/api/Opportunities/{id}/stage",
+  "/api/Opportunities/{id}/assign",
+  "/api/Proposals",
+  "/api/Proposals/{id}",
+  "/api/Proposals/{id}/submit",
+  "/api/Proposals/{id}/approve",
+  "/api/Proposals/{id}/reject",
+  "/api/PricingRequests",
+  "/api/PricingRequests/{id}",
+  "/api/PricingRequests/{id}/assign",
+  "/api/PricingRequests/{id}/complete",
+  "/api/Activities",
+  "/api/Activities/{id}",
+  "/api/Activities/{id}/complete",
+  "/api/Activities/{id}/cancel",
+  "/api/Notes",
+  "/api/Notes/{id}",
+  "/api/Users",
+  "/api/Users/{id}",
+];
+
+const ownedWorkflowPaths = {
+  "/api/service-requests": {
+    get: {
+      tags: ["ServiceRequests"],
+      summary: "List service requests visible to the current user.",
+      parameters: [
+        {
+          name: "status",
+          in: "query",
+          schema: {
+            type: "string",
+          },
+          description: "Comma-separated statuses to filter by.",
+        },
+      ],
+      responses: {
+        200: {
+          description: "OK",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/ServiceRequestPagedResult",
+              },
+            },
+          },
+        },
+      },
+    },
+    post: {
+      tags: ["ServiceRequests"],
+      summary: "Create a new client or admin service request.",
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              $ref: "#/components/schemas/CreateServiceRequestDto",
+            },
+          },
+        },
+      },
+      responses: {
+        201: {
+          description: "Created",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/ServiceRequestDto",
+              },
+            },
+          },
+        },
+        400: {
+          description: "Bad Request",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/ProblemDetails",
+              },
+            },
+          },
+        },
+        403: {
+          description: "Forbidden",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/ProblemDetails",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  "/api/service-requests/{requestId}": {
+    get: {
+      tags: ["ServiceRequests"],
+      summary: "Get the detail view for a single service request.",
+      parameters: [
+        {
+          name: "requestId",
+          in: "path",
+          required: true,
+          schema: {
+            type: "string",
+          },
+        },
+      ],
+      responses: {
+        200: {
+          description: "OK",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/ServiceRequestDetailDto",
+              },
+            },
+          },
+        },
+        404: {
+          description: "Not Found",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/ProblemDetails",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  "/api/service-requests/{requestId}/review": {
+    post: {
+      tags: ["ServiceRequests"],
+      summary: "Mark a service request as under review.",
+      parameters: [
+        {
+          name: "requestId",
+          in: "path",
+          required: true,
+          schema: {
+            type: "string",
+          },
+        },
+      ],
+      responses: {
+        200: {
+          description: "OK",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/ServiceRequestDto",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  "/api/service-requests/{requestId}/opportunity": {
+    post: {
+      tags: ["ServiceRequests"],
+      summary: "Create or link an opportunity for a service request.",
+      parameters: [
+        {
+          name: "requestId",
+          in: "path",
+          required: true,
+          schema: {
+            type: "string",
+          },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              $ref: "#/components/schemas/ServiceRequestOpportunityDto",
+            },
+          },
+        },
+      },
+      responses: {
+        200: {
+          description: "OK",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/OpportunityDto",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  "/api/service-requests/{requestId}/proposal": {
+    post: {
+      tags: ["ServiceRequests"],
+      summary: "Create or link a proposal for a service request.",
+      parameters: [
+        {
+          name: "requestId",
+          in: "path",
+          required: true,
+          schema: {
+            type: "string",
+          },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              $ref: "#/components/schemas/ServiceRequestProposalDto",
+            },
+          },
+        },
+      },
+      responses: {
+        200: {
+          description: "OK",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/ProposalWithLineItemsDto",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  "/api/service-requests/{requestId}/assignments": {
+    post: {
+      tags: ["ServiceRequests"],
+      summary: "Assign one or more representatives to a service request.",
+      parameters: [
+        {
+          name: "requestId",
+          in: "path",
+          required: true,
+          schema: {
+            type: "string",
+          },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              $ref: "#/components/schemas/CreateServiceRequestAssignmentsDto",
+            },
+          },
+        },
+      },
+      responses: {
+        201: {
+          description: "Created",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/ServiceRequestAssignmentsResponseDto",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  "/api/service-requests/{requestId}/client-decision": {
+    post: {
+      tags: ["ServiceRequests"],
+      summary: "Apply the client's approval or rejection of proposed assignments.",
+      parameters: [
+        {
+          name: "requestId",
+          in: "path",
+          required: true,
+          schema: {
+            type: "string",
+          },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              $ref: "#/components/schemas/ServiceRequestDecisionDto",
+            },
+          },
+        },
+      },
+      responses: {
+        200: {
+          description: "OK",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/ServiceRequestDto",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  "/api/service-requests/{requestId}/rep-decision": {
+    post: {
+      tags: ["ServiceRequests"],
+      summary: "Apply the representative's acceptance or rejection of an assignment.",
+      parameters: [
+        {
+          name: "requestId",
+          in: "path",
+          required: true,
+          schema: {
+            type: "string",
+          },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              $ref: "#/components/schemas/ServiceRequestRepDecisionDto",
+            },
+          },
+        },
+      },
+      responses: {
+        200: {
+          description: "OK",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/ServiceRequestDto",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const ownedWorkflowSchemas = {
+  ServiceRequestStatus: {
+    type: "string",
+    enum: [
+      "submitted",
+      "under_review",
+      "proposal_prepared",
+      "awaiting_client_assignment_approval",
+      "client_rejected_assignment",
+      "client_approved_assignment",
+      "awaiting_rep_acceptance",
+      "rep_rejected_assignment",
+      "active",
+      "closed",
+      "cancelled",
+    ],
+  },
+  ServiceRequestPriority: {
+    type: "string",
+    enum: ["low", "medium", "high", "critical"],
+  },
+  AssignmentDecision: {
+    type: "string",
+    enum: ["approve", "reject", "accept"],
+  },
+  ServiceRequestDto: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      id: { type: "string" },
+      tenantId: { type: "string", format: "uuid" },
+      clientId: { type: "string", format: "uuid" },
+      submittedByUserId: { type: "string", format: "uuid" },
+      title: { type: "string" },
+      description: { type: "string" },
+      requestType: { type: "string" },
+      status: { $ref: "#/components/schemas/ServiceRequestStatus" },
+      priority: { $ref: "#/components/schemas/ServiceRequestPriority" },
+      source: { type: "string" },
+      createdAt: { type: "string", format: "date-time" },
+      updatedAt: { type: "string", format: "date-time" },
+    },
+    required: [
+      "id",
+      "tenantId",
+      "clientId",
+      "submittedByUserId",
+      "title",
+      "description",
+      "requestType",
+      "status",
+      "priority",
+      "source",
+      "createdAt",
+      "updatedAt",
+    ],
+  },
+  ServiceRequestPagedResult: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      items: {
+        type: "array",
+        items: {
+          $ref: "#/components/schemas/ServiceRequestDto",
+        },
+      },
+    },
+    required: ["items"],
+  },
+  CreateServiceRequestDto: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      clientId: { type: "string", format: "uuid" },
+      title: { type: "string" },
+      description: { type: "string" },
+      requestType: { type: "string" },
+      priority: { $ref: "#/components/schemas/ServiceRequestPriority" },
+      source: { type: "string" },
+    },
+    required: ["clientId", "title", "description"],
+  },
+  ServiceRequestDetailDto: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      request: {
+        $ref: "#/components/schemas/ServiceRequestDto",
+      },
+      assignments: {
+        type: "array",
+        items: {
+          $ref: "#/components/schemas/ServiceRequestAssignmentDto",
+        },
+      },
+      events: {
+        type: "array",
+        items: {
+          $ref: "#/components/schemas/WorkflowEventDto",
+        },
+      },
+    },
+    required: ["request", "assignments", "events"],
+  },
+  ServiceRequestAssignmentDto: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      id: { type: "string" },
+      serviceRequestId: { type: "string" },
+      representativeUserId: { type: "string", format: "uuid" },
+      assignedByUserId: { type: "string", format: "uuid" },
+      status: { type: "string" },
+      decisionNote: { type: "string", nullable: true },
+      createdAt: { type: "string", format: "date-time" },
+      updatedAt: { type: "string", format: "date-time" },
+    },
+    required: [
+      "id",
+      "serviceRequestId",
+      "representativeUserId",
+      "assignedByUserId",
+      "status",
+      "createdAt",
+      "updatedAt",
+    ],
+  },
+  WorkflowEventDto: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      id: { type: "string" },
+      serviceRequestId: { type: "string" },
+      actorUserId: { type: "string", format: "uuid", nullable: true },
+      actorType: { type: "string" },
+      eventType: { type: "string" },
+      payloadJson: { type: "object", additionalProperties: true },
+      createdAt: { type: "string", format: "date-time" },
+    },
+    required: [
+      "id",
+      "serviceRequestId",
+      "actorType",
+      "eventType",
+      "payloadJson",
+      "createdAt",
+    ],
+  },
+  ServiceRequestOpportunityDto: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      mode: { type: "string", enum: ["create", "link"] },
+      opportunityId: { type: "string", format: "uuid", nullable: true },
+      title: { type: "string", nullable: true },
+      estimatedValue: { type: "number", format: "double", nullable: true },
+      expectedCloseDate: { type: "string", format: "date-time", nullable: true },
+      stage: { type: "string", nullable: true },
+      ownerId: { type: "string", format: "uuid", nullable: true },
+    },
+    required: ["mode"],
+  },
+  ServiceRequestProposalDto: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      mode: { type: "string", enum: ["create", "link"] },
+      proposalId: { type: "string", format: "uuid", nullable: true },
+      title: { type: "string", nullable: true },
+      description: { type: "string", nullable: true },
+      validUntil: { type: "string", format: "date-time", nullable: true },
+      currency: { type: "string", nullable: true },
+    },
+    required: ["mode"],
+  },
+  CreateServiceRequestAssignmentsDto: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      representativeUserIds: {
+        type: "array",
+        items: {
+          type: "string",
+          format: "uuid",
+        },
+      },
+      note: { type: "string", nullable: true },
+    },
+    required: ["representativeUserIds"],
+  },
+  ServiceRequestAssignmentsResponseDto: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      request: { $ref: "#/components/schemas/ServiceRequestDto" },
+      assignments: {
+        type: "array",
+        items: {
+          $ref: "#/components/schemas/ServiceRequestAssignmentDto",
+        },
+      },
+    },
+    required: ["request", "assignments"],
+  },
+  ServiceRequestDecisionDto: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      decision: { type: "string", enum: ["approve", "reject"] },
+      assignmentIds: {
+        type: "array",
+        items: { type: "string" },
+      },
+      note: { type: "string", nullable: true },
+    },
+    required: ["decision", "assignmentIds"],
+  },
+  ServiceRequestRepDecisionDto: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      assignmentId: { type: "string" },
+      decision: { type: "string", enum: ["accept", "reject"] },
+      note: { type: "string", nullable: true },
+    },
+    required: ["assignmentId", "decision"],
+  },
+};
+
+const extractRefs = (value, refs = new Set()) => {
+  if (!value || typeof value !== "object") {
+    return refs;
+  }
+
+  if (typeof value.$ref === "string") {
+    refs.add(value.$ref);
+  }
+
+  for (const child of Object.values(value)) {
+    extractRefs(child, refs);
+  }
+
+  return refs;
+};
+
+const refsToCollect = new Set();
+const ownedPaths = {};
+
+for (const pathName of selectedPaths) {
+  const pathValue = source.paths?.[pathName];
+
+  if (!pathValue) {
+    continue;
+  }
+
+  ownedPaths[pathName] = pathValue;
+  extractRefs(pathValue, refsToCollect);
+}
+
+for (const pathValue of Object.values(ownedWorkflowPaths)) {
+  extractRefs(pathValue, refsToCollect);
+}
+
+const collectedSchemas = {};
+const queue = [...refsToCollect];
+const seen = new Set();
+
+while (queue.length > 0) {
+  const ref = queue.shift();
+
+  if (!ref || seen.has(ref)) {
+    continue;
+  }
+
+  seen.add(ref);
+
+  if (!ref.startsWith("#/components/schemas/")) {
+    continue;
+  }
+
+  const schemaName = ref.split("/").pop();
+  const schema = source.components?.schemas?.[schemaName];
+
+  if (!schema || collectedSchemas[schemaName]) {
+    continue;
+  }
+
+  collectedSchemas[schemaName] = schema;
+  const childRefs = extractRefs(schema);
+
+  for (const childRef of childRefs) {
+    if (!seen.has(childRef)) {
+      queue.push(childRef);
+    }
+  }
+}
+
+for (const [schemaName, schema] of Object.entries(ownedWorkflowSchemas)) {
+  collectedSchemas[schemaName] = schema;
+}
+
+const ownedSpec = {
+  openapi: source.openapi ?? "3.0.1",
+  info: {
+    title: "Owned Sales Automation API",
+    version: "0.1.0",
+    description:
+      "Repo-owned API contract derived from the captured SalesAutomation swagger and extended with workflow endpoints required for assistant-driven automation.",
+  },
+  servers: [
+    {
+      url: "/",
+      description: "Local application server",
+    },
+  ],
+  tags: [
+    { name: "Auth" },
+    { name: "Clients" },
+    { name: "Contacts" },
+    { name: "Opportunities" },
+    { name: "Proposals" },
+    { name: "PricingRequests" },
+    { name: "Activities" },
+    { name: "Notes" },
+    { name: "Users" },
+    { name: "ServiceRequests" },
+  ],
+  paths: {
+    ...ownedPaths,
+    ...ownedWorkflowPaths,
+  },
+  components: {
+    schemas: collectedSchemas,
+  },
+};
+
+fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+fs.writeFileSync(targetPath, `${JSON.stringify(ownedSpec, null, 2)}\n`);
+
+console.log(`Wrote ${targetPath}`);


### PR DESCRIPTION
## Summary
- move assistant workflow execution onto the owned backend workflow API
- harden assistant approvals, persistence, CRUD handling, and workflow messaging
- include the activity modal hydration fix needed by the workflow surfaces

## Verification
- npm run lint
- npm run build

Refs #181
Refs #232
