### PR TITLE
fix: wrap client dashboard home with DashboardProvider

### DIFF
--- a/providers/dashboardRouteProviders.tsx
+++ b/providers/dashboardRouteProviders.tsx
@@ -71,7 +71,8 @@ export function DashboardRouteProviders({
     isTeamMembersRoute;
   const needsSalesRepDashboard = isDashboardHome && !isScopedClientUser && role === "SalesRep";
   const needsClientDashboard = isDashboardHome && isScopedClientUser;
-  const needsDashboardProvider = needsManagementDashboard || needsSalesRepDashboard;
+  const needsDashboardProvider =
+    needsManagementDashboard || needsSalesRepDashboard || needsClientDashboard;
   const needsTeamMembersProvider =
     needsDashboardProvider ||
     needsClientDashboard ||


### PR DESCRIPTION
## Summary
- wrap the client dashboard home route with DashboardProvider
- fix the runtime error thrown by useDashboardState() in ClientMessageCenter
- keep this bugfix isolated from assistant runtime changes

Fixes #279
