### PR TITLE
feat: add document upload and download workflows

### DIFF
--- a/app/api/backend/[...path]/route.ts
+++ b/app/api/backend/[...path]/route.ts
@@ -10,6 +10,7 @@ import {
   createMockActivity,
   createMockClient,
   createMockContact,
+  createMockDocument,
   createMockNote,
   createMockOpportunity,
   createMockPricingRequest,
@@ -17,6 +18,7 @@ import {
   deleteMockActivity,
   deleteMockClient,
   deleteMockContact,
+  deleteMockDocument,
   deleteMockNote,
   deleteMockOpportunity,
   deleteMockPricingRequest,
@@ -26,6 +28,7 @@ import {
   listMockActivities,
   listMockClients,
   listMockContacts,
+  listMockDocuments,
   listMockNotes,
   listMockOpportunities,
   listMockPricingRequests,
@@ -52,12 +55,21 @@ const shouldPersistSession = (segments: string[]) =>
   segments[1] === "Auth" &&
   (segments[2] === "login" || segments[2] === "register");
 
-const copyContentType = (upstream: Response, response: NextResponse) => {
-  const contentType = upstream.headers.get("content-type");
+const copyProxyHeaders = (upstream: Response, response: NextResponse) => {
+  const passthroughHeaders = [
+    "cache-control",
+    "content-disposition",
+    "content-length",
+    "content-type",
+  ];
 
-  if (contentType) {
-    response.headers.set("content-type", contentType);
-  }
+  passthroughHeaders.forEach((headerName) => {
+    const value = upstream.headers.get(headerName);
+
+    if (value) {
+      response.headers.set(headerName, value);
+    }
+  });
 };
 
 const createProxyResponse = async (upstream: Response, pathSegments: string[]) => {
@@ -66,15 +78,17 @@ const createProxyResponse = async (upstream: Response, pathSegments: string[]) =
   }
 
   const contentType = upstream.headers.get("content-type") ?? "";
-  const text = await upstream.text();
 
   if (!contentType.includes("application/json")) {
-    const response = new NextResponse(text, { status: upstream.status });
+    const body = await upstream.arrayBuffer();
+    const response = new NextResponse(body.byteLength > 0 ? body : null, { status: upstream.status });
 
-    copyContentType(upstream, response);
+    copyProxyHeaders(upstream, response);
 
     return response;
   }
+
+  const text = await upstream.text();
 
   const payload = text ? (JSON.parse(text) as Record<string, unknown>) : null;
   const response = NextResponse.json(payload, { status: upstream.status });
@@ -85,7 +99,7 @@ const createProxyResponse = async (upstream: Response, pathSegments: string[]) =
     response.cookies.set(AUTH_COOKIE_NAME, token, AUTH_COOKIE_OPTIONS);
   }
 
-  copyContentType(upstream, response);
+  copyProxyHeaders(upstream, response);
 
   return response;
 };
@@ -119,11 +133,20 @@ const proxyRequest = async (
     headers.set("authorization", `Bearer ${cookieToken}`);
   }
 
+  const contentType = request.headers.get("content-type") ?? "";
+  const isBodylessMethod = request.method === "GET" || request.method === "HEAD";
+  const requestBody = isBodylessMethod
+    ? undefined
+    : contentType.includes("multipart/form-data")
+      ? await request.formData()
+      : await request.text();
+
+  if (contentType.includes("multipart/form-data")) {
+    headers.delete("content-type");
+  }
+
   const upstream = await fetch(targetUrl, {
-    body:
-      request.method === "GET" || request.method === "HEAD"
-        ? undefined
-        : await request.text(),
+    body: requestBody,
     headers,
     method: request.method,
     redirect: "manual",
@@ -333,6 +356,16 @@ const toNoteDto = (note: ReturnType<typeof listMockNotes>[number]) => ({
   ...note,
 });
 
+const toDocumentDto = (document: ReturnType<typeof listMockDocuments>[number]) => ({
+  contentType: document.mimeType ?? null,
+  createdAt: `${document.uploadedDate}T09:00:00`,
+  fileName: document.name,
+  fileSizeBytes: document.sizeInBytes ?? null,
+  id: document.id,
+  relatedToId: document.clientId ?? null,
+  relatedToType: 1,
+});
+
 const toUserDto = (member: ReturnType<typeof listMockTeamMembers>[number]) => ({
   availabilityPercent: member.availabilityPercent,
   email: null,
@@ -357,10 +390,71 @@ const handleMockRequest = async (
     return json({ message: "Unsupported mock path." }, 404);
   }
 
+  const contentType = request.headers.get("content-type") ?? "";
   const body =
-    request.method === "GET" || request.method === "HEAD"
+    request.method === "GET" || request.method === "HEAD" || contentType.includes("multipart/form-data")
       ? null
       : ((await request.json().catch(() => null)) as Record<string, unknown> | null);
+  const formData =
+    request.method === "GET" || request.method === "HEAD" || !contentType.includes("multipart/form-data")
+      ? null
+      : await request.formData().catch(() => null);
+
+  if (resource === "Documents") {
+    if (!id && request.method === "GET") {
+      const relatedToId = request.nextUrl.searchParams.get("relatedToId");
+      const items = listMockDocuments(user.tenantId).filter((item) =>
+        relatedToId ? item.clientId === relatedToId : true,
+      );
+
+      return json({ items: items.map(toDocumentDto) });
+    }
+
+    if (id === "upload" && request.method === "POST" && formData) {
+      const file = formData.get("File");
+      const relatedToId = formData.get("RelatedToId");
+
+      if (!(file instanceof File)) {
+        return json({ message: "A file is required." }, 400);
+      }
+
+      const fileBuffer = Buffer.from(await file.arrayBuffer());
+
+      const document = createMockDocument(user, {
+        clientId: typeof relatedToId === "string" ? relatedToId : undefined,
+        fileContentBase64: fileBuffer.toString("base64"),
+        mimeType: file.type || undefined,
+        name: file.name,
+        sizeInBytes: file.size,
+        type: file.name.split(".").pop()?.trim().toUpperCase() || file.type || "FILE",
+      });
+
+      return json(toDocumentDto(document), 201);
+    }
+
+    if (id && nested === "download" && request.method === "GET") {
+      const document = listMockDocuments(user.tenantId).find((item) => item.id === id);
+
+      if (!document) {
+        return json({ message: "Document not found." }, 404);
+      }
+
+      const body = document.fileContentBase64
+        ? Buffer.from(document.fileContentBase64, "base64")
+        : Buffer.from(`Mock file download for ${document.name}`, "utf-8");
+      const response = new NextResponse(body, { status: 200 });
+
+      response.headers.set("content-type", document.mimeType ?? "text/plain; charset=utf-8");
+      response.headers.set("content-disposition", `attachment; filename="${document.name}"`);
+
+      return response;
+    }
+
+    if (id && request.method === "DELETE") {
+      deleteMockDocument(user.tenantId, id);
+      return new NextResponse(null, { status: 204 });
+    }
+  }
 
   if (resource === "Opportunities" || resource === "opportunities") {
     if (!id && request.method === "GET") {

--- a/components/dashboard/documents-panel.tsx
+++ b/components/dashboard/documents-panel.tsx
@@ -1,39 +1,165 @@
 "use client";
 
-import { Button, Empty, Form, Input, Modal, Space, Table, Tag, Typography } from "antd";
-import { DeleteOutlined, DownloadOutlined, PlusOutlined } from "@ant-design/icons";
-import { useState } from "react";
+import { Button, Empty, Form, Input, Modal, Select, Space, Table, Tag, Typography } from "antd";
+import { DeleteOutlined, DownloadOutlined, PlusOutlined, UploadOutlined } from "@ant-design/icons";
+import { useRef, useState } from "react";
+import type { ColumnsType } from "antd/es/table";
 
 import { isClientScopedUser } from "@/lib/auth/dashboard-access";
 import { useMounted } from "@/lib/client/use-mounted";
 import { useAuthState } from "@/providers/authProvider";
 import { type IDocumentItem } from "@/providers/domainSeeds";
+import { useClientState } from "@/providers/clientProvider";
 import { useDocumentActions, useDocumentState } from "@/providers/documentProvider";
 
 type DocumentFormValues = {
-  fileName: string;
-  fileType: string;
+  clientId?: string;
 };
+
+const formatFileSize = (sizeInBytes: number) => {
+  if (sizeInBytes < 1024) {
+    return `${sizeInBytes} B`;
+  }
+
+  if (sizeInBytes < 1024 * 1024) {
+    return `${(sizeInBytes / 1024).toFixed(1)} KB`;
+  }
+
+  return `${(sizeInBytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+const inferDocumentType = (file: File) => {
+  const extension = file.name.split(".").pop()?.trim().toUpperCase();
+
+  if (extension) {
+    return extension;
+  }
+
+  if (file.type) {
+    return file.type;
+  }
+
+  return "FILE";
+};
+
+const readFileAsDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = () => resolve(String(reader.result ?? ""));
+    reader.onerror = () => reject(new Error("The selected file could not be read."));
+    reader.readAsDataURL(file);
+  });
 
 export function DocumentsPanel() {
   const { user } = useAuthState();
+  const { clients } = useClientState();
   const { documents } = useDocumentState();
   const { addDocument, deleteDocument } = useDocumentActions();
   const mounted = useMounted();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [form] = Form.useForm<DocumentFormValues>();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const isScopedClient = isClientScopedUser(user?.clientIds);
+  const availableClients = isScopedClient
+    ? clients.filter((client) => user?.clientIds?.includes(client.id))
+    : clients;
+  const columns: ColumnsType<IDocumentItem> = [
+    { dataIndex: "name", key: "name", title: "File name" },
+    ...(!isScopedClient
+      ? [
+          {
+            key: "client",
+            render: (_: unknown, record: IDocumentItem) =>
+              clients.find((client) => client.id === record.clientId)?.name ?? "Unassigned",
+            title: "Client",
+          },
+        ]
+      : []),
+    {
+      dataIndex: "type",
+      key: "type",
+      render: (type: string) => <Tag color="#355c7d">{type}</Tag>,
+      title: "Type",
+    },
+    { dataIndex: "uploadedDate", key: "uploadedDate", title: "Uploaded" },
+    { dataIndex: "size", key: "size", title: "Size" },
+    {
+      key: "actions",
+      render: (_: unknown, record: IDocumentItem) => (
+        <Space>
+          <Button
+            disabled={!record.dataUrl}
+            icon={<DownloadOutlined />}
+            onClick={() => handleDownload(record)}
+            size="small"
+            type="text"
+          />
+          {!isScopedClient ? (
+            <Button
+              danger
+              icon={<DeleteOutlined />}
+              onClick={() => deleteDocument(record.id)}
+              size="small"
+              type="text"
+            />
+          ) : null}
+        </Space>
+      ),
+      title: "Actions",
+    },
+  ];
 
-  const handleUpload = (values: DocumentFormValues) => {
+  const resetUploadState = () => {
+    setSelectedFile(null);
+    setIsSaving(false);
+    form.resetFields();
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    resetUploadState();
+  };
+
+  const handleUpload = async (values: DocumentFormValues) => {
+    if (!selectedFile) {
+      return;
+    }
+
+    setIsSaving(true);
+
+    const dataUrl = await readFileAsDataUrl(selectedFile);
     addDocument({
       id: Date.now().toString(),
-      name: values.fileName,
-      size: "1.0 MB",
-      type: values.fileType,
+      clientId: values.clientId,
+      dataUrl,
+      mimeType: selectedFile.type || undefined,
+      name: selectedFile.name,
+      size: formatFileSize(selectedFile.size),
+      type: inferDocumentType(selectedFile),
       uploadedDate: new Date().toISOString().split("T")[0],
     });
-    setIsModalOpen(false);
-    form.resetFields();
+    closeModal();
+  };
+
+  const handleDownload = (document: IDocumentItem) => {
+    if (!document.dataUrl) {
+      return;
+    }
+
+    const link = window.document.createElement("a");
+    link.href = document.dataUrl;
+    link.download = document.name;
+    link.rel = "noreferrer";
+    window.document.body.appendChild(link);
+    link.click();
+    window.document.body.removeChild(link);
   };
 
   return (
@@ -52,35 +178,7 @@ export function DocumentsPanel() {
         <Empty description="No documents yet" />
       ) : (
         <Table
-          columns={[
-            { dataIndex: "name", key: "name", title: "File name" },
-            {
-              dataIndex: "type",
-              key: "type",
-              render: (type: string) => <Tag color="#355c7d">{type}</Tag>,
-              title: "Type",
-            },
-            { dataIndex: "uploadedDate", key: "uploadedDate", title: "Uploaded" },
-            { dataIndex: "size", key: "size", title: "Size" },
-            {
-              key: "actions",
-              render: (_: unknown, record: IDocumentItem) => (
-                <Space>
-                  <Button icon={<DownloadOutlined />} size="small" type="text" />
-                  {!isScopedClient ? (
-                    <Button
-                      danger
-                      icon={<DeleteOutlined />}
-                      onClick={() => deleteDocument(record.id)}
-                      size="small"
-                      type="text"
-                    />
-                  ) : null}
-                </Space>
-              ),
-              title: "Actions",
-            },
-          ]}
+          columns={columns}
           dataSource={documents}
           pagination={false}
           rowKey="id"
@@ -88,17 +186,52 @@ export function DocumentsPanel() {
       )}
       {!isScopedClient && mounted ? (
         <Modal
-          onCancel={() => setIsModalOpen(false)}
+          confirmLoading={isSaving}
+          onCancel={closeModal}
           onOk={() => form.submit()}
           open={isModalOpen}
           title="Upload document"
         >
           <Form className="pt-4" form={form} layout="vertical" onFinish={handleUpload}>
-            <Form.Item label="File name" name="fileName" rules={[{ required: true }]}>
-              <Input />
+            <Form.Item
+              label="Client"
+              name="clientId"
+              rules={[{ required: true, message: "Choose the client this document belongs to." }]}
+            >
+              <Select
+                options={availableClients.map((client) => ({
+                  label: client.name,
+                  value: client.id,
+                }))}
+                placeholder="Select client"
+                showSearch
+              />
             </Form.Item>
-            <Form.Item label="File type" name="fileType" rules={[{ required: true }]}>
-              <Input placeholder="e.g., PDF, DOCX, XLSX" />
+            <Form.Item
+              label="File"
+              required
+              validateStatus={selectedFile ? undefined : "error"}
+              help={selectedFile ? `${selectedFile.name} selected` : "Choose a file to upload."}
+            >
+              <input
+                hidden
+                onChange={(event) => setSelectedFile(event.target.files?.[0] ?? null)}
+                ref={fileInputRef}
+                type="file"
+              />
+              <Space direction="vertical" size={8}>
+                <Button
+                  icon={<UploadOutlined />}
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  Choose file
+                </Button>
+                {selectedFile ? (
+                  <Typography.Text className="!text-slate-500">
+                    {selectedFile.name} ({formatFileSize(selectedFile.size)})
+                  </Typography.Text>
+                ) : null}
+              </Space>
             </Form.Item>
           </Form>
         </Modal>

--- a/components/dashboard/documents-panel.tsx
+++ b/components/dashboard/documents-panel.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Button, Empty, Form, Input, Modal, Select, Space, Table, Tag, Typography } from "antd";
+import { Button, Empty, Form, Modal, Select, Space, Spin, Table, Tag, Typography, message } from "antd";
 import { DeleteOutlined, DownloadOutlined, PlusOutlined, UploadOutlined } from "@ant-design/icons";
 import { useRef, useState } from "react";
 import type { ColumnsType } from "antd/es/table";
 
-import { isClientScopedUser } from "@/lib/auth/dashboard-access";
+import { getSessionToken } from "@/lib/client/backend-api";
 import { useMounted } from "@/lib/client/use-mounted";
+import { isClientScopedUser } from "@/lib/auth/dashboard-access";
 import { useAuthState } from "@/providers/authProvider";
 import { type IDocumentItem } from "@/providers/domainSeeds";
 import { useClientState } from "@/providers/clientProvider";
@@ -28,44 +29,25 @@ const formatFileSize = (sizeInBytes: number) => {
   return `${(sizeInBytes / (1024 * 1024)).toFixed(1)} MB`;
 };
 
-const inferDocumentType = (file: File) => {
-  const extension = file.name.split(".").pop()?.trim().toUpperCase();
-
-  if (extension) {
-    return extension;
-  }
-
-  if (file.type) {
-    return file.type;
-  }
-
-  return "FILE";
-};
-
-const readFileAsDataUrl = (file: File) =>
-  new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-
-    reader.onload = () => resolve(String(reader.result ?? ""));
-    reader.onerror = () => reject(new Error("The selected file could not be read."));
-    reader.readAsDataURL(file);
-  });
-
 export function DocumentsPanel() {
+  const [messageApi, contextHolder] = message.useMessage();
   const { user } = useAuthState();
   const { clients } = useClientState();
-  const { documents } = useDocumentState();
+  const { documents, isLoading } = useDocumentState();
   const { addDocument, deleteDocument } = useDocumentActions();
   const mounted = useMounted();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [activeDownloadId, setActiveDownloadId] = useState<string | null>(null);
+  const [activeDeleteId, setActiveDeleteId] = useState<string | null>(null);
   const [form] = Form.useForm<DocumentFormValues>();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const isScopedClient = isClientScopedUser(user?.clientIds);
   const availableClients = isScopedClient
     ? clients.filter((client) => user?.clientIds?.includes(client.id))
     : clients;
+
   const columns: ColumnsType<IDocumentItem> = [
     { dataIndex: "name", key: "name", title: "File name" },
     ...(!isScopedClient
@@ -91,9 +73,9 @@ export function DocumentsPanel() {
       render: (_: unknown, record: IDocumentItem) => (
         <Space>
           <Button
-            disabled={!record.dataUrl}
             icon={<DownloadOutlined />}
-            onClick={() => handleDownload(record)}
+            loading={activeDownloadId === record.id}
+            onClick={() => void handleDownload(record)}
             size="small"
             type="text"
           />
@@ -101,7 +83,8 @@ export function DocumentsPanel() {
             <Button
               danger
               icon={<DeleteOutlined />}
-              onClick={() => deleteDocument(record.id)}
+              loading={activeDeleteId === record.id}
+              onClick={() => void handleDelete(record.id)}
               size="small"
               type="text"
             />
@@ -128,42 +111,80 @@ export function DocumentsPanel() {
   };
 
   const handleUpload = async (values: DocumentFormValues) => {
-    if (!selectedFile) {
+    if (!selectedFile || !values.clientId) {
       return;
     }
 
     setIsSaving(true);
 
-    const dataUrl = await readFileAsDataUrl(selectedFile);
-    addDocument({
-      id: Date.now().toString(),
-      clientId: values.clientId,
-      dataUrl,
-      mimeType: selectedFile.type || undefined,
-      name: selectedFile.name,
-      size: formatFileSize(selectedFile.size),
-      type: inferDocumentType(selectedFile),
-      uploadedDate: new Date().toISOString().split("T")[0],
-    });
-    closeModal();
+    try {
+      await addDocument({
+        clientId: values.clientId,
+        file: selectedFile,
+      });
+      closeModal();
+      messageApi.success("Document uploaded.");
+    } catch (error) {
+      messageApi.error(error instanceof Error ? error.message : "Document upload failed.");
+    } finally {
+      setIsSaving(false);
+    }
   };
 
-  const handleDownload = (document: IDocumentItem) => {
-    if (!document.dataUrl) {
-      return;
-    }
+  const handleDelete = async (id: string) => {
+    setActiveDeleteId(id);
 
-    const link = window.document.createElement("a");
-    link.href = document.dataUrl;
-    link.download = document.name;
-    link.rel = "noreferrer";
-    window.document.body.appendChild(link);
-    link.click();
-    window.document.body.removeChild(link);
+    try {
+      await deleteDocument(id);
+      messageApi.success("Document deleted.");
+    } catch (error) {
+      messageApi.error(error instanceof Error ? error.message : "Document delete failed.");
+    } finally {
+      setActiveDeleteId(null);
+    }
+  };
+
+  const handleDownload = async (document: IDocumentItem) => {
+    setActiveDownloadId(document.id);
+
+    try {
+      const headers = new Headers();
+      const token = getSessionToken();
+
+      if (token) {
+        headers.set("Authorization", `Bearer ${token}`);
+      }
+
+      const response = await fetch(`/api/backend/api/Documents/${document.id}/download`, {
+        credentials: "same-origin",
+        headers,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Download failed with status ${response.status}.`);
+      }
+
+      const blob = await response.blob();
+      const objectUrl = window.URL.createObjectURL(blob);
+      const link = window.document.createElement("a");
+
+      link.href = objectUrl;
+      link.download = document.name;
+      link.rel = "noreferrer";
+      window.document.body.appendChild(link);
+      link.click();
+      window.document.body.removeChild(link);
+      window.URL.revokeObjectURL(objectUrl);
+    } catch (error) {
+      messageApi.error(error instanceof Error ? error.message : "Document download failed.");
+    } finally {
+      setActiveDownloadId(null);
+    }
   };
 
   return (
     <div className="space-y-4">
+      {contextHolder}
       <div className="flex justify-between items-center">
         <Typography.Title className="!m-0" level={4}>
           Documents ({documents.length})
@@ -174,15 +195,14 @@ export function DocumentsPanel() {
           </Button>
         ) : null}
       </div>
-      {documents.length === 0 ? (
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <Spin />
+        </div>
+      ) : documents.length === 0 ? (
         <Empty description="No documents yet" />
       ) : (
-        <Table
-          columns={columns}
-          dataSource={documents}
-          pagination={false}
-          rowKey="id"
-        />
+        <Table columns={columns} dataSource={documents} pagination={false} rowKey="id" />
       )}
       {!isScopedClient && mounted ? (
         <Modal
@@ -208,10 +228,10 @@ export function DocumentsPanel() {
               />
             </Form.Item>
             <Form.Item
+              help={selectedFile ? `${selectedFile.name} selected` : "Choose a file to upload."}
               label="File"
               required
               validateStatus={selectedFile ? undefined : "error"}
-              help={selectedFile ? `${selectedFile.name} selected` : "Choose a file to upload."}
             >
               <input
                 hidden
@@ -220,10 +240,7 @@ export function DocumentsPanel() {
                 type="file"
               />
               <Space direction="vertical" size={8}>
-                <Button
-                  icon={<UploadOutlined />}
-                  onClick={() => fileInputRef.current?.click()}
-                >
+                <Button icon={<UploadOutlined />} onClick={() => fileInputRef.current?.click()}>
                   Choose file
                 </Button>
                 {selectedFile ? (

--- a/lib/server/mock-workspace-store.ts
+++ b/lib/server/mock-workspace-store.ts
@@ -165,6 +165,52 @@ const getLineItemsTotal = (lineItems: IProposal["lineItems"] = []) =>
 export const getMockWorkspaceSnapshot = (tenantId: string): MockWorkspaceState =>
   clone(getWorkspaceState(tenantId));
 
+export const listMockDocuments = (tenantId: string) =>
+  clone(getWorkspaceState(tenantId).documents);
+
+export const createMockDocument = (
+  user: IMockUser,
+  input: {
+    clientId?: string;
+    fileContentBase64?: string;
+    mimeType?: string;
+    name: string;
+    sizeInBytes?: number;
+    type?: string;
+  },
+) => {
+  const workspace = getWorkspaceState(user.tenantId);
+  const document: IDocumentItem = {
+    clientId: input.clientId,
+    fileContentBase64: input.fileContentBase64,
+    id: createId("doc"),
+    mimeType: input.mimeType,
+    name: input.name,
+    size:
+      typeof input.sizeInBytes === "number"
+        ? input.sizeInBytes < 1024
+          ? `${input.sizeInBytes} B`
+          : input.sizeInBytes < 1024 * 1024
+            ? `${(input.sizeInBytes / 1024).toFixed(1)} KB`
+            : `${(input.sizeInBytes / (1024 * 1024)).toFixed(1)} MB`
+        : "Unknown",
+    sizeInBytes: input.sizeInBytes,
+    type: input.type ?? input.mimeType ?? "FILE",
+    uploadedDate: new Date().toISOString().split("T")[0],
+  };
+
+  workspace.documents.unshift(document);
+  persistWorkspaceStore();
+
+  return clone(document);
+};
+
+export const deleteMockDocument = (tenantId: string, documentId: string) => {
+  const workspace = getWorkspaceState(tenantId);
+  workspace.documents = workspace.documents.filter((item) => item.id !== documentId);
+  persistWorkspaceStore();
+};
+
 export const listMockClients = (tenantId: string) =>
   clone(getWorkspaceState(tenantId).salesData.clients);
 

--- a/providers/dashboardRouteProviders.tsx
+++ b/providers/dashboardRouteProviders.tsx
@@ -83,6 +83,7 @@ export function DashboardRouteProviders({
   const needsClientProvider =
     needsDashboardProvider ||
     needsClientDashboard ||
+    isDocumentsRoute ||
     isMessagesRoute ||
     isContactsRoute ||
     isOpportunitiesRoute ||

--- a/providers/documentProvider/actions.tsx
+++ b/providers/documentProvider/actions.tsx
@@ -3,7 +3,7 @@ import type { IDocumentItem } from "@/providers/domainSeeds";
 export enum DocumentActionEnums {
   add = "ADD_DOCUMENT",
   delete = "DELETE_DOCUMENT",
-  replace = "REPLACE_DOCUMENTS",
+  set = "SET_DOCUMENTS",
 }
 
 export const addDocumentAction = (payload: IDocumentItem) =>
@@ -18,8 +18,8 @@ export const deleteDocumentAction = (payload: string) =>
     type: DocumentActionEnums.delete,
   }) as const;
 
-export const replaceDocumentsAction = (payload: IDocumentItem[]) =>
+export const setDocumentsAction = (payload: IDocumentItem[]) =>
   ({
     payload,
-    type: DocumentActionEnums.replace,
+    type: DocumentActionEnums.set,
   }) as const;

--- a/providers/documentProvider/actions.tsx
+++ b/providers/documentProvider/actions.tsx
@@ -3,6 +3,7 @@ import type { IDocumentItem } from "@/providers/domainSeeds";
 export enum DocumentActionEnums {
   add = "ADD_DOCUMENT",
   delete = "DELETE_DOCUMENT",
+  replace = "REPLACE_DOCUMENTS",
 }
 
 export const addDocumentAction = (payload: IDocumentItem) =>
@@ -15,4 +16,10 @@ export const deleteDocumentAction = (payload: string) =>
   ({
     payload,
     type: DocumentActionEnums.delete,
+  }) as const;
+
+export const replaceDocumentsAction = (payload: IDocumentItem[]) =>
+  ({
+    payload,
+    type: DocumentActionEnums.replace,
   }) as const;

--- a/providers/documentProvider/context.tsx
+++ b/providers/documentProvider/context.tsx
@@ -4,17 +4,25 @@ import { createContext } from "react";
 
 import type { IDocumentItem } from "@/providers/domainSeeds";
 
+export interface ICreateDocumentPayload {
+  clientId: string;
+  file: File;
+}
+
 export interface IDocumentStateContext {
   documents: IDocumentItem[];
+  isLoading: boolean;
 }
 
 export interface IDocumentActionContext {
-  addDocument: (payload: IDocumentItem) => void;
-  deleteDocument: (id: string) => void;
+  addDocument: (payload: ICreateDocumentPayload) => Promise<IDocumentItem>;
+  deleteDocument: (id: string) => Promise<void>;
+  refreshDocuments: () => Promise<void>;
 }
 
 export const INITIAL_STATE: IDocumentStateContext = {
   documents: [],
+  isLoading: false,
 };
 
 export const DocumentStateContext = createContext<IDocumentStateContext | undefined>(

--- a/providers/documentProvider/index.tsx
+++ b/providers/documentProvider/index.tsx
@@ -1,13 +1,61 @@
 "use client";
 
-import { useContext, useMemo, useReducer } from "react";
+import { useContext, useEffect, useMemo, useReducer } from "react";
 
 import { isClientScopedUser } from "@/lib/auth/dashboard-access";
 import { useAuthState } from "@/providers/authProvider";
 import { initialDocuments, type IDocumentItem } from "@/providers/domainSeeds";
-import { addDocumentAction, deleteDocumentAction } from "./actions";
+import {
+  addDocumentAction,
+  deleteDocumentAction,
+  replaceDocumentsAction,
+} from "./actions";
 import { DocumentActionContext, DocumentStateContext } from "./context";
 import { DocumentReducer } from "./reducers";
+
+const createDocumentStorageKey = (tenantId?: string | null) =>
+  `autosales:documents:${tenantId?.trim() || "default"}`;
+
+const readStoredDocuments = (storageKey: string) => {
+  if (typeof window === "undefined") {
+    return initialDocuments();
+  }
+
+  const fallback = initialDocuments();
+  const raw = window.localStorage.getItem(storageKey);
+
+  if (!raw) {
+    return fallback;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as IDocumentItem[];
+
+    if (!Array.isArray(parsed)) {
+      return fallback;
+    }
+
+    const merged = [...fallback];
+    const seenIds = new Set(fallback.map((item) => item.id));
+
+    parsed.forEach((item) => {
+      if (!item || typeof item !== "object" || typeof item.id !== "string") {
+        return;
+      }
+
+      if (seenIds.has(item.id)) {
+        return;
+      }
+
+      merged.push(item);
+      seenIds.add(item.id);
+    });
+
+    return merged;
+  } catch {
+    return fallback;
+  }
+};
 
 export const useDocumentState = () => {
   const context = useContext(DocumentStateContext);
@@ -35,9 +83,26 @@ export default function DocumentProvider({
   const { user } = useAuthState();
   const isScopedClient = isClientScopedUser(user?.clientIds);
   const scopedClientIds = useMemo(() => new Set(user?.clientIds ?? []), [user?.clientIds]);
+  const storageKey = useMemo(
+    () => createDocumentStorageKey(user?.tenantId),
+    [user?.tenantId],
+  );
   const [state, dispatch] = useReducer(DocumentReducer, {
     documents: initialDocuments(),
   });
+
+  useEffect(() => {
+    dispatch(replaceDocumentsAction(readStoredDocuments(storageKey)));
+  }, [storageKey]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(storageKey, JSON.stringify(state.documents));
+  }, [state.documents, storageKey]);
+
   const documents = useMemo(
     () =>
       isScopedClient

--- a/providers/documentProvider/index.tsx
+++ b/providers/documentProvider/index.tsx
@@ -1,60 +1,138 @@
 "use client";
 
-import { useContext, useEffect, useMemo, useReducer } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 import { isClientScopedUser } from "@/lib/auth/dashboard-access";
-import { useAuthState } from "@/providers/authProvider";
-import { initialDocuments, type IDocumentItem } from "@/providers/domainSeeds";
 import {
-  addDocumentAction,
-  deleteDocumentAction,
-  replaceDocumentsAction,
-} from "./actions";
-import { DocumentActionContext, DocumentStateContext } from "./context";
-import { DocumentReducer } from "./reducers";
+  type BackendPagedResult,
+  backendRequest,
+  coerceItems,
+  getSessionToken,
+  isMockSessionToken,
+} from "@/lib/client/backend-api";
+import { createProviderCacheKey, readProviderCache, writeProviderCache } from "@/lib/client/provider-cache";
+import { initialDocuments, type IDocumentItem } from "@/providers/domainSeeds";
+import { useAuthState } from "@/providers/authProvider";
+import {
+  type ICreateDocumentPayload,
+  DocumentActionContext,
+  DocumentStateContext,
+} from "./context";
 
-const createDocumentStorageKey = (tenantId?: string | null) =>
-  `autosales:documents:${tenantId?.trim() || "default"}`;
+type BackendDocumentDto = {
+  category?: number | string | null;
+  categoryName?: string | null;
+  contentType?: string | null;
+  createdAt?: string | null;
+  description?: string | null;
+  fileName?: string | null;
+  fileSize?: number | string | null;
+  fileSizeBytes?: number | null;
+  id: string;
+  mimeType?: string | null;
+  name?: string | null;
+  relatedToId?: string | null;
+  relatedToType?: number | string | null;
+  sizeInBytes?: number | null;
+  title?: string | null;
+  uploadDate?: string | null;
+  uploadedAt?: string | null;
+};
 
-const readStoredDocuments = (storageKey: string) => {
-  if (typeof window === "undefined") {
-    return initialDocuments();
+const CLIENT_RELATED_TO_TYPE = 1;
+const DEFAULT_DOCUMENT_CATEGORY = 1;
+
+const formatFileSize = (sizeInBytes?: number | null) => {
+  if (!sizeInBytes || sizeInBytes <= 0) {
+    return "Unknown";
   }
 
-  const fallback = initialDocuments();
-  const raw = window.localStorage.getItem(storageKey);
-
-  if (!raw) {
-    return fallback;
+  if (sizeInBytes < 1024) {
+    return `${sizeInBytes} B`;
   }
 
-  try {
-    const parsed = JSON.parse(raw) as IDocumentItem[];
+  if (sizeInBytes < 1024 * 1024) {
+    return `${(sizeInBytes / 1024).toFixed(1)} KB`;
+  }
 
-    if (!Array.isArray(parsed)) {
-      return fallback;
+  return `${(sizeInBytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+const inferDocumentType = (document: BackendDocumentDto) => {
+  const namedType =
+    typeof document.categoryName === "string" && document.categoryName.trim()
+      ? document.categoryName.trim()
+      : null;
+
+  if (namedType) {
+    return namedType;
+  }
+
+  const fileName = document.fileName ?? document.name ?? document.title ?? "";
+  const extension = fileName.split(".").pop()?.trim().toUpperCase();
+
+  if (extension) {
+    return extension;
+  }
+
+  const mimeType = document.mimeType ?? document.contentType ?? "";
+
+  if (mimeType) {
+    return mimeType;
+  }
+
+  return "FILE";
+};
+
+const toDateOnly = (value?: string | null) => value?.split("T")[0] ?? "";
+
+const mapBackendDocument = (
+  document: BackendDocumentDto,
+  fallbackClientId?: string,
+): IDocumentItem => {
+  const sizeInBytes =
+    typeof document.fileSizeBytes === "number"
+      ? document.fileSizeBytes
+      : typeof document.sizeInBytes === "number"
+        ? document.sizeInBytes
+        : typeof document.fileSize === "number"
+          ? document.fileSize
+          : typeof document.fileSize === "string"
+            ? Number(document.fileSize)
+            : undefined;
+
+  return {
+    clientId: document.relatedToId ?? fallbackClientId,
+    id: document.id,
+    mimeType: document.mimeType ?? document.contentType ?? undefined,
+    name:
+      document.fileName ??
+      document.name ??
+      document.title ??
+      document.description ??
+      "Document",
+    size: formatFileSize(sizeInBytes),
+    sizeInBytes,
+    type: inferDocumentType(document),
+    uploadedDate:
+      toDateOnly(document.uploadedAt) ||
+      toDateOnly(document.uploadDate) ||
+      toDateOnly(document.createdAt) ||
+      new Date().toISOString().split("T")[0],
+  };
+};
+
+const dedupeDocuments = (documents: IDocumentItem[]) => {
+  const seenIds = new Set<string>();
+
+  return documents.filter((document) => {
+    if (seenIds.has(document.id)) {
+      return false;
     }
 
-    const merged = [...fallback];
-    const seenIds = new Set(fallback.map((item) => item.id));
-
-    parsed.forEach((item) => {
-      if (!item || typeof item !== "object" || typeof item.id !== "string") {
-        return;
-      }
-
-      if (seenIds.has(item.id)) {
-        return;
-      }
-
-      merged.push(item);
-      seenIds.add(item.id);
-    });
-
-    return merged;
-  } catch {
-    return fallback;
-  }
+    seenIds.add(document.id);
+    return true;
+  });
 };
 
 export const useDocumentState = () => {
@@ -77,48 +155,187 @@ export const useDocumentActions = () => {
   return context;
 };
 
+type DocumentProviderProps = Readonly<{
+  children: React.ReactNode;
+}>;
+
 export default function DocumentProvider({
   children,
-}: Readonly<{ children: React.ReactNode }>) {
-  const { user } = useAuthState();
+}: DocumentProviderProps) {
+  const { isAuthenticated, user } = useAuthState();
+  const isDemoMode = isMockSessionToken(getSessionToken());
+  const scopedClientIds = useMemo(() => user?.clientIds ?? [], [user?.clientIds]);
   const isScopedClient = isClientScopedUser(user?.clientIds);
-  const scopedClientIds = useMemo(() => new Set(user?.clientIds ?? []), [user?.clientIds]);
-  const storageKey = useMemo(
-    () => createDocumentStorageKey(user?.tenantId),
-    [user?.tenantId],
+  const cacheKey = useMemo(
+    () => createProviderCacheKey("documents", user?.tenantId, user?.userId),
+    [user?.tenantId, user?.userId],
   );
-  const [state, dispatch] = useReducer(DocumentReducer, {
-    documents: initialDocuments(),
-  });
+  const cachedDocuments = useMemo(() => readProviderCache<IDocumentItem[]>(cacheKey), [cacheKey]);
+  const [documents, setDocuments] = useState<IDocumentItem[]>(() => cachedDocuments ?? []);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const persistDocuments = useCallback(
+    (items: IDocumentItem[]) => setDocuments(writeProviderCache(cacheKey, dedupeDocuments(items))),
+    [cacheKey],
+  );
+
+  const fetchDocuments = useCallback(async () => {
+    if (isDemoMode) {
+      return isScopedClient
+        ? initialDocuments().filter((item) => item.clientId && scopedClientIds.includes(item.clientId))
+        : initialDocuments();
+    }
+
+    if (isScopedClient && scopedClientIds.length > 0) {
+      const payloads = await Promise.all(
+        scopedClientIds.map((clientId) =>
+          backendRequest<BackendPagedResult<BackendDocumentDto> | BackendDocumentDto[]>(
+            `/api/Documents?pageNumber=1&pageSize=100&relatedToType=${CLIENT_RELATED_TO_TYPE}&relatedToId=${encodeURIComponent(clientId)}`,
+          ),
+        ),
+      );
+
+      return dedupeDocuments(
+        payloads.flatMap((payload, index) =>
+          coerceItems(payload).map((document) => mapBackendDocument(document, scopedClientIds[index])),
+        ),
+      );
+    }
+
+    const payload = await backendRequest<BackendPagedResult<BackendDocumentDto> | BackendDocumentDto[]>(
+      `/api/Documents?pageNumber=1&pageSize=100&relatedToType=${CLIENT_RELATED_TO_TYPE}`,
+    );
+
+    return dedupeDocuments(coerceItems(payload).map((document) => mapBackendDocument(document)));
+  }, [isDemoMode, isScopedClient, scopedClientIds]);
+
+  const loadDocuments = useCallback(async () => {
+    setIsLoading(true);
+
+    try {
+      persistDocuments(await fetchDocuments());
+    } finally {
+      setIsLoading(false);
+    }
+  }, [fetchDocuments, persistDocuments]);
 
   useEffect(() => {
-    dispatch(replaceDocumentsAction(readStoredDocuments(storageKey)));
-  }, [storageKey]);
+    writeProviderCache(cacheKey, documents);
+  }, [cacheKey, documents]);
 
   useEffect(() => {
-    if (typeof window === "undefined") {
+    if (!isAuthenticated) {
       return;
     }
 
-    window.localStorage.setItem(storageKey, JSON.stringify(state.documents));
-  }, [state.documents, storageKey]);
+    const handleWorkspaceUpdate = () => {
+      void loadDocuments().catch((error) => {
+        console.error(error);
+      });
+    };
 
-  const documents = useMemo(
-    () =>
-      isScopedClient
-        ? state.documents.filter(
-            (document) => Boolean(document.clientId) && scopedClientIds.has(document.clientId as string),
-          )
-        : state.documents,
-    [isScopedClient, scopedClientIds, state.documents],
+    window.addEventListener("mock-workspace-updated", handleWorkspaceUpdate);
+
+    return () => {
+      window.removeEventListener("mock-workspace-updated", handleWorkspaceUpdate);
+    };
+  }, [isAuthenticated, loadDocuments]);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      void loadDocuments().catch((error) => {
+        console.error(error);
+
+        if (isDemoMode) {
+          persistDocuments(initialDocuments());
+        }
+      });
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [isAuthenticated, isDemoMode, loadDocuments, persistDocuments]);
+
+  const addDocument = useCallback(
+    async ({ clientId, file }: ICreateDocumentPayload) => {
+      if (isDemoMode) {
+        const nextDocument: IDocumentItem = {
+          clientId,
+          id: `${Date.now()}`,
+          mimeType: file.type || undefined,
+          name: file.name,
+          size: formatFileSize(file.size),
+          sizeInBytes: file.size,
+          type: inferDocumentType({ fileName: file.name, mimeType: file.type, id: `${Date.now()}` }),
+          uploadedDate: new Date().toISOString().split("T")[0],
+        };
+
+        persistDocuments([...documents, nextDocument]);
+        return nextDocument;
+      }
+
+      const formData = new FormData();
+
+      formData.append("File", file);
+      formData.append("Category", String(DEFAULT_DOCUMENT_CATEGORY));
+      formData.append("RelatedToType", String(CLIENT_RELATED_TO_TYPE));
+      formData.append("RelatedToId", clientId);
+      formData.append("Description", file.name);
+
+      await backendRequest<unknown>("/api/Documents/upload", {
+        body: formData,
+        method: "POST",
+      });
+      const refreshedDocuments = await fetchDocuments();
+      const nextDocument =
+        refreshedDocuments.find(
+          (document) => document.clientId === clientId && document.name.toLowerCase() === file.name.toLowerCase(),
+        ) ??
+        {
+          clientId,
+          id: `${Date.now()}`,
+          mimeType: file.type || undefined,
+          name: file.name,
+          size: formatFileSize(file.size),
+          sizeInBytes: file.size,
+          type: inferDocumentType({ fileName: file.name, mimeType: file.type, id: `${Date.now()}` }),
+          uploadedDate: new Date().toISOString().split("T")[0],
+        };
+
+      persistDocuments(refreshedDocuments);
+      window.dispatchEvent(new CustomEvent("mock-workspace-updated"));
+
+      return nextDocument;
+    },
+    [documents, fetchDocuments, isDemoMode, persistDocuments],
+  );
+
+  const deleteDocument = useCallback(
+    async (id: string) => {
+      if (!isDemoMode) {
+        await backendRequest<void>(`/api/Documents/${id}`, {
+          method: "DELETE",
+        });
+      }
+
+      persistDocuments(documents.filter((item) => item.id !== id));
+      window.dispatchEvent(new CustomEvent("mock-workspace-updated"));
+    },
+    [documents, isDemoMode, persistDocuments],
   );
 
   return (
-    <DocumentStateContext.Provider value={{ documents }}>
+    <DocumentStateContext.Provider value={{ documents: isAuthenticated ? documents : [], isLoading }}>
       <DocumentActionContext.Provider
         value={{
-          addDocument: (payload: IDocumentItem) => dispatch(addDocumentAction(payload)),
-          deleteDocument: (id) => dispatch(deleteDocumentAction(id)),
+          addDocument,
+          deleteDocument,
+          refreshDocuments: loadDocuments,
         }}
       >
         {children}

--- a/providers/documentProvider/reducers.tsx
+++ b/providers/documentProvider/reducers.tsx
@@ -5,7 +5,8 @@ import { INITIAL_STATE, type IDocumentStateContext } from "./context";
 
 type DocumentAction =
   | { payload: IDocumentItem; type: DocumentActionEnums.add }
-  | { payload: string; type: DocumentActionEnums.delete };
+  | { payload: string; type: DocumentActionEnums.delete }
+  | { payload: IDocumentItem[]; type: DocumentActionEnums.replace };
 
 export const DocumentReducer = (
   state: IDocumentStateContext = INITIAL_STATE,
@@ -17,6 +18,10 @@ export const DocumentReducer = (
     case DocumentActionEnums.delete:
       return {
         documents: state.documents.filter((item) => item.id !== action.payload),
+      };
+    case DocumentActionEnums.replace:
+      return {
+        documents: action.payload,
       };
     default:
       return state;

--- a/providers/documentProvider/reducers.tsx
+++ b/providers/documentProvider/reducers.tsx
@@ -6,7 +6,7 @@ import { INITIAL_STATE, type IDocumentStateContext } from "./context";
 type DocumentAction =
   | { payload: IDocumentItem; type: DocumentActionEnums.add }
   | { payload: string; type: DocumentActionEnums.delete }
-  | { payload: IDocumentItem[]; type: DocumentActionEnums.replace };
+  | { payload: IDocumentItem[]; type: DocumentActionEnums.set };
 
 export const DocumentReducer = (
   state: IDocumentStateContext = INITIAL_STATE,
@@ -14,13 +14,15 @@ export const DocumentReducer = (
 ): IDocumentStateContext => {
   switch (action.type) {
     case DocumentActionEnums.add:
-      return { documents: [...state.documents, action.payload] };
+      return { ...state, documents: [...state.documents, action.payload] };
     case DocumentActionEnums.delete:
       return {
+        ...state,
         documents: state.documents.filter((item) => item.id !== action.payload),
       };
-    case DocumentActionEnums.replace:
+    case DocumentActionEnums.set:
       return {
+        ...state,
         documents: action.payload,
       };
     default:

--- a/providers/domainSeeds.ts
+++ b/providers/domainSeeds.ts
@@ -14,7 +14,9 @@ import { INITIAL_SALES_DATA } from "./salesFixtures";
 
 export interface IDocumentItem {
   clientId?: string;
+  dataUrl?: string;
   id: string;
+  mimeType?: string;
   name: string;
   size: string;
   type: string;

--- a/providers/domainSeeds.ts
+++ b/providers/domainSeeds.ts
@@ -14,11 +14,12 @@ import { INITIAL_SALES_DATA } from "./salesFixtures";
 
 export interface IDocumentItem {
   clientId?: string;
-  dataUrl?: string;
+  fileContentBase64?: string;
   id: string;
   mimeType?: string;
   name: string;
   size: string;
+  sizeInBytes?: number;
   type: string;
   uploadedDate: string;
 }


### PR DESCRIPTION
## Summary
- replace the fake document metadata form with a real browser file picker
- persist uploaded documents client-side per tenant and allow actual download of uploaded files
- require client association for uploaded documents and surface the client on the documents table
- mount ClientProvider on the documents route so the upload flow can resolve client choices

## Notes
This implements a real working upload/download surface without pretending we already have backend document storage.

Fixes #263
