### PR TITLE
fix: harden cookie auth and dashboard access control

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,11 +1,22 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { AUTH_COOKIE_NAME } from "@/app/api/Auth/session-cookie";
 import { DashboardFrame } from "@/components/dashboard/dashboard-frame";
 import { DashboardRouteProviders } from "@/providers/dashboardRouteProviders";
 
-export default function DashboardLayout({
+export default async function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(AUTH_COOKIE_NAME)?.value?.trim();
+
+  if (!sessionToken) {
+    redirect("/login");
+  }
+
   return (
     <DashboardFrame>
       <DashboardRouteProviders>{children}</DashboardRouteProviders>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -54,7 +54,12 @@ function DashboardHomeLoading() {
 }
 
 function DashboardPageContent() {
-  const { user } = useAuthState();
+  const { isAuthenticated, isPending, user } = useAuthState();
+
+  if (isPending || !isAuthenticated) {
+    return <DashboardHomeLoading />;
+  }
+
   const isScopedClientUser = isClientScopedUser(user?.clientIds);
   const role = getPrimaryUserRole(user?.roles);
 

--- a/components/dashboard/assistant-panel.tsx
+++ b/components/dashboard/assistant-panel.tsx
@@ -12,7 +12,6 @@ import { useSearchParams } from "next/navigation";
 
 import { isClientScopedUser } from "@/lib/auth/dashboard-access";
 import { getPrimaryUserRole, getUserRoleLabel, isManagerRole } from "@/lib/auth/roles";
-import { getSessionToken } from "@/lib/client/backend-api";
 import { clearSessionDraft, readSessionDraft, writeSessionDraft } from "@/lib/client/session-drafts";
 import { useAuthState } from "@/providers/authProvider";
 import type { UserRole } from "@/providers/salesTypes";
@@ -232,9 +231,8 @@ export function AssistantPanel() {
 
     const loadAssistantStatus = async () => {
       try {
-        const token = getSessionToken();
         const response = await fetch("/api/assistant/status", {
-          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+          credentials: "same-origin",
         });
         const payload = (await response.json()) as {
           isConfigured?: boolean;
@@ -304,14 +302,13 @@ export function AssistantPanel() {
     setIsSubmitting(true);
 
     try {
-      const token = getSessionToken();
       const response = await fetch("/api/assistant", {
         body: JSON.stringify({ messages: nextMessages }),
         headers: {
           "Content-Type": "application/json",
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
         method: "POST",
+        credentials: "same-origin",
       });
 
       const payload = (await response.json()) as {

--- a/components/dashboard/dashboard-frame.tsx
+++ b/components/dashboard/dashboard-frame.tsx
@@ -14,7 +14,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { backendRequest, coerceItems, getSessionToken } from "@/lib/client/backend-api";
+import { backendRequest, coerceItems } from "@/lib/client/backend-api";
 import { listServiceRequests } from "@/lib/client/service-request-api";
 import { getPrimaryUserRole, getUserRoleLabel, isManagerRole } from "@/lib/auth/roles";
 import { dashboardNavItems } from "@/constants/dashboard-nav";
@@ -83,7 +83,7 @@ export function DashboardFrame({ children }: DashboardFrameProps) {
       return;
     }
 
-    if (!isAuthenticated && !getSessionToken()) {
+    if (!isAuthenticated) {
       router.replace("/login");
       return;
     }

--- a/components/dashboard/dashboard-frame.tsx
+++ b/components/dashboard/dashboard-frame.tsx
@@ -247,6 +247,27 @@ export function DashboardFrame({ children }: DashboardFrameProps) {
   const isMessageAlertDismissed =
     incomingMessageCount > 0 && dismissedMessageSignature === currentMessageAlertSignature;
 
+  if (isPending) {
+    return (
+      <div className="min-h-screen bg-slate-50 p-6">
+        <div className="mx-auto max-w-7xl space-y-4">
+          <div className="h-16 rounded-2xl bg-slate-200/80" />
+          <div className="grid gap-4 md:grid-cols-4">
+            <div className="h-28 rounded-2xl bg-slate-200/70" />
+            <div className="h-28 rounded-2xl bg-slate-200/70" />
+            <div className="h-28 rounded-2xl bg-slate-200/70" />
+            <div className="h-28 rounded-2xl bg-slate-200/70" />
+          </div>
+          <div className="h-80 rounded-2xl bg-slate-200/60" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
   const dismissAdminAlert = () => {
     if (typeof window !== "undefined") {
       window.sessionStorage.setItem(alertDismissKey, currentAlertSignature);

--- a/components/dashboard/priority-advisor.tsx
+++ b/components/dashboard/priority-advisor.tsx
@@ -4,7 +4,6 @@ import { DeleteOutlined, SendOutlined } from "@ant-design/icons";
 import { Alert, Button, Card, Input, Spin, Tag, Typography } from "antd";
 import { useEffect, useMemo, useState } from "react";
 
-import { getSessionToken } from "@/lib/client/backend-api";
 import { clearSessionDraft, readSessionDraft, writeSessionDraft } from "@/lib/client/session-drafts";
 import { useAuthState } from "@/providers/authProvider";
 import { getAdvisorResponse } from "@/providers/salesSelectors";
@@ -282,7 +281,6 @@ export function PriorityAdvisor() {
     setIsLoading(true);
 
     try {
-      const token = getSessionToken();
       const advisorResponse = await fetch("/api/assistant", {
         body: JSON.stringify({
           messages: nextMessages.map((message) =>
@@ -296,9 +294,9 @@ export function PriorityAdvisor() {
         }),
         headers: {
           "Content-Type": "application/json",
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
         method: "POST",
+        credentials: "same-origin",
       });
 
       const payload = (await advisorResponse.json()) as {

--- a/lib/client/auth-session.ts
+++ b/lib/client/auth-session.ts
@@ -3,41 +3,16 @@
 import type { AuthSessionUser } from "@/lib/auth/auth-contract";
 
 const AUTH_STORAGE_KEY = "auth_user";
-const LEGACY_TOKEN_KEY = "token";
 
 const getStorage = () =>
-  typeof window === "undefined" ? null : window.localStorage;
+  typeof window === "undefined" ? null : window.sessionStorage;
 
-const migrateLegacySessionValue = (key: string) => {
-  if (typeof window === "undefined") {
-    return null;
-  }
+const sanitizeStoredUser = (user: AuthSessionUser): AuthSessionUser => ({
+  ...user,
+  token: null,
+});
 
-  const localValue = window.localStorage.getItem(key);
-
-  if (localValue) {
-    return localValue;
-  }
-
-  const sessionValue = window.sessionStorage.getItem(key);
-
-  if (!sessionValue) {
-    return null;
-  }
-
-  try {
-    window.localStorage.setItem(key, sessionValue);
-    window.sessionStorage.removeItem(key);
-  } catch {
-    // Ignore migration failures and use the legacy value for this request.
-  }
-
-  return sessionValue;
-};
-
-export const getSessionToken = () =>
-  getStorage()?.getItem(LEGACY_TOKEN_KEY) ??
-  migrateLegacySessionValue(LEGACY_TOKEN_KEY);
+export const getSessionToken = () => null;
 
 export const getStoredAuthUser = (): AuthSessionUser | null => {
   const storage = getStorage();
@@ -46,9 +21,7 @@ export const getStoredAuthUser = (): AuthSessionUser | null => {
     return null;
   }
 
-  const raw =
-    storage.getItem(AUTH_STORAGE_KEY) ??
-    migrateLegacySessionValue(AUTH_STORAGE_KEY);
+  const raw = storage.getItem(AUTH_STORAGE_KEY);
 
   if (!raw) {
     return null;
@@ -61,6 +34,8 @@ export const getStoredAuthUser = (): AuthSessionUser | null => {
   }
 };
 
+export const isStoredMockSession = () => Boolean(getStoredAuthUser()?.isMockSession);
+
 export const storeAuthSession = (user: AuthSessionUser) => {
   const storage = getStorage();
 
@@ -68,11 +43,7 @@ export const storeAuthSession = (user: AuthSessionUser) => {
     return;
   }
 
-  if (user.token) {
-    storage.setItem(LEGACY_TOKEN_KEY, user.token);
-  }
-
-  storage.setItem(AUTH_STORAGE_KEY, JSON.stringify(user));
+  storage.setItem(AUTH_STORAGE_KEY, JSON.stringify(sanitizeStoredUser(user)));
 };
 
 export const clearAuthSession = () => {
@@ -80,8 +51,8 @@ export const clearAuthSession = () => {
     return;
   }
 
-  window.localStorage.removeItem(LEGACY_TOKEN_KEY);
-  window.localStorage.removeItem(AUTH_STORAGE_KEY);
-  window.sessionStorage.removeItem(LEGACY_TOKEN_KEY);
   window.sessionStorage.removeItem(AUTH_STORAGE_KEY);
+  window.localStorage.removeItem("token");
+  window.localStorage.removeItem(AUTH_STORAGE_KEY);
+  window.sessionStorage.removeItem("token");
 };

--- a/lib/client/backend-api.ts
+++ b/lib/client/backend-api.ts
@@ -14,8 +14,8 @@ import {
   type IProposal,
   type ITeamMember,
 } from "@/providers/salesTypes";
-import { getSessionToken } from "@/lib/client/auth-session";
-export { getSessionToken } from "@/lib/client/auth-session";
+import { getSessionToken, isStoredMockSession } from "@/lib/client/auth-session";
+export { getSessionToken, isStoredMockSession } from "@/lib/client/auth-session";
 
 export type BackendPagedResult<T> = {
   items?: T[] | null;
@@ -184,14 +184,9 @@ export const backendRequest = async <T>(
   init: RequestInit = {},
 ): Promise<T> => {
   const headers = new Headers(init.headers);
-  const token = getSessionToken();
 
   if (init.body && !(init.body instanceof FormData) && !headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json");
-  }
-
-  if (token && !headers.has("Authorization")) {
-    headers.set("Authorization", `Bearer ${token}`);
   }
 
   const response = await fetch(`/api/backend${path}`, {

--- a/lib/client/service-request-api.ts
+++ b/lib/client/service-request-api.ts
@@ -1,7 +1,5 @@
 "use client";
 
-import { getSessionToken } from "@/lib/client/backend-api";
-
 export type ServiceRequestStatus =
   | "submitted"
   | "under_review"
@@ -105,11 +103,6 @@ const extractErrorMessage = (value: unknown) => {
 
 const serviceRequestApi = async <T>(path: string, init: RequestInit = {}): Promise<T> => {
   const headers = new Headers(init.headers);
-  const token = getSessionToken();
-
-  if (token) {
-    headers.set("Authorization", `Bearer ${token}`);
-  }
 
   if (init.body && !(init.body instanceof FormData) && !headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json");

--- a/providers/activityProvider/index.tsx
+++ b/providers/activityProvider/index.tsx
@@ -10,8 +10,7 @@ import {
   buildCreateActivityPayload,
   buildUpdateActivityPayload,
   coerceItems,
-  getSessionToken,
-  isMockSessionToken,
+  isStoredMockSession,
   mapBackendActivity,
 } from "@/lib/client/backend-api";
 import { createProviderCacheKey, readProviderCache, writeProviderCache } from "@/lib/client/provider-cache";
@@ -49,7 +48,7 @@ export default function ActivityProvider({
   children,
 }: ActivityProviderProps) {
   const { isAuthenticated, user } = useAuthState();
-  const isDemoMode = isMockSessionToken(getSessionToken());
+  const isDemoMode = isStoredMockSession();
   const role = getPrimaryUserRole(user?.roles);
   const cacheKey = useMemo(
     () => createProviderCacheKey("activities", user?.tenantId, user?.userId, role),

--- a/providers/authProvider/index.tsx
+++ b/providers/authProvider/index.tsx
@@ -7,7 +7,6 @@ import { getDashboardHomePath } from "@/lib/auth/dashboard-access";
 import { getPrimaryUserRole } from "@/lib/auth/roles";
 import {
   clearAuthSession,
-  getSessionToken,
   getStoredAuthUser,
   storeAuthSession,
 } from "@/lib/client/auth-session";
@@ -84,14 +83,9 @@ const authRequest = async <T,>(
   init: RequestInit = {},
 ) => {
   const headers = new Headers(init.headers);
-  const token = getSessionToken();
 
   if (init.body && !headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json");
-  }
-
-  if (path === "/api/Auth/me" && token && !headers.has("Authorization")) {
-    headers.set("Authorization", `Bearer ${token}`);
   }
 
   const response = await fetch(path, {
@@ -120,7 +114,7 @@ const mergeAuthUser = (
   clientIds: payload.clientIds ?? fallback?.clientIds ?? null,
   isMockSession: payload.isMockSession ?? fallback?.isMockSession ?? false,
   roles: payload.roles ?? fallback?.roles ?? null,
-  token: payload.token ?? fallback?.token ?? getSessionToken(),
+  token: null,
 });
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
@@ -195,13 +189,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   const getMe = useCallback(async () => {
     dispatch(getMePending());
     const storedUser = getStoredAuthUser();
-    const token = storedUser?.token ?? getSessionToken();
-
-    if (!token && !storedUser) {
-      clearAuthSession();
-      dispatch(logoutSuccess());
-      return;
-    }
 
     try {
       const response = await authRequest<Partial<IUserLoginResponse>>(

--- a/providers/clientProvider/index.tsx
+++ b/providers/clientProvider/index.tsx
@@ -11,8 +11,7 @@ import {
   buildCreateClientPayload,
   buildUpdateClientPayload,
   coerceItems,
-  getSessionToken,
-  isMockSessionToken,
+  isStoredMockSession,
   mapBackendClient,
 } from "@/lib/client/backend-api";
 import { createProviderCacheKey, readProviderCache, writeProviderCache } from "@/lib/client/provider-cache";
@@ -48,7 +47,7 @@ export default function ClientProvider({
   children,
 }: ClientProviderProps) {
   const { isAuthenticated, user } = useAuthState();
-  const isDemoMode = isMockSessionToken(getSessionToken());
+  const isDemoMode = isStoredMockSession();
   const scopedClientIds = useMemo(() => new Set(user?.clientIds ?? []), [user?.clientIds]);
   const isScopedClient = isClientScopedUser(user?.clientIds);
   const cacheKey = useMemo(

--- a/providers/contactProvider/index.tsx
+++ b/providers/contactProvider/index.tsx
@@ -11,8 +11,7 @@ import {
   buildCreateContactPayload,
   buildUpdateContactPayload,
   coerceItems,
-  getSessionToken,
-  isMockSessionToken,
+  isStoredMockSession,
   mapBackendContact,
 } from "@/lib/client/backend-api";
 import { createProviderCacheKey, readProviderCache, writeProviderCache } from "@/lib/client/provider-cache";
@@ -48,7 +47,7 @@ export default function ContactProvider({
   children,
 }: ContactProviderProps) {
   const { isAuthenticated, user } = useAuthState();
-  const isDemoMode = isMockSessionToken(getSessionToken());
+  const isDemoMode = isStoredMockSession();
   const scopedClientIds = useMemo(() => new Set(user?.clientIds ?? []), [user?.clientIds]);
   const isScopedClient = isClientScopedUser(user?.clientIds);
   const cacheKey = useMemo(

--- a/providers/noteProvider/index.tsx
+++ b/providers/noteProvider/index.tsx
@@ -6,8 +6,7 @@ import { isClientScopedUser } from "@/lib/auth/dashboard-access";
 import {
   backendRequest,
   coerceItems,
-  getSessionToken,
-  isMockSessionToken,
+  isStoredMockSession,
 } from "@/lib/client/backend-api";
 import { createProviderCacheKey, readProviderCache, writeProviderCache } from "@/lib/client/provider-cache";
 import { useAuthState } from "@/providers/authProvider";
@@ -38,7 +37,7 @@ export default function NoteProvider({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   const { isAuthenticated, user } = useAuthState();
-  const isDemoMode = isMockSessionToken(getSessionToken());
+  const isDemoMode = isStoredMockSession();
   const scopedClientIds = useMemo(() => new Set(user?.clientIds ?? []), [user?.clientIds]);
   const isScopedClient = isClientScopedUser(user?.clientIds);
   const cacheKey = useMemo(

--- a/providers/opportunityProvider/index.tsx
+++ b/providers/opportunityProvider/index.tsx
@@ -14,8 +14,7 @@ import {
   buildUpdateOpportunityPayload,
   buildUpdateOpportunityStagePayload,
   coerceItems,
-  getSessionToken,
-  isMockSessionToken,
+  isStoredMockSession,
   mapBackendOpportunity,
 } from "@/lib/client/backend-api";
 import { createProviderCacheKey, readProviderCache, writeProviderCache } from "@/lib/client/provider-cache";
@@ -47,7 +46,7 @@ export default function OpportunityProvider({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   const { isAuthenticated, user } = useAuthState();
-  const isDemoMode = isMockSessionToken(getSessionToken());
+  const isDemoMode = isStoredMockSession();
   const role = getPrimaryUserRole(user?.roles);
   const scopedClientIds = useMemo(() => new Set(user?.clientIds ?? []), [user?.clientIds]);
   const isScopedClient = isClientScopedUser(user?.clientIds);

--- a/providers/pricingRequestProvider/index.tsx
+++ b/providers/pricingRequestProvider/index.tsx
@@ -11,8 +11,7 @@ import {
   buildCreatePricingRequestPayload,
   buildUpdatePricingRequestPayload,
   coerceItems,
-  getSessionToken,
-  isMockSessionToken,
+  isStoredMockSession,
   mapBackendPricingRequest,
 } from "@/lib/client/backend-api";
 import { createProviderCacheKey, readProviderCache, writeProviderCache } from "@/lib/client/provider-cache";
@@ -50,7 +49,7 @@ export default function PricingRequestProvider({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   const { isAuthenticated, user } = useAuthState();
-  const isDemoMode = isMockSessionToken(getSessionToken());
+  const isDemoMode = isStoredMockSession();
   const role = getPrimaryUserRole(user?.roles);
   const cacheKey = useMemo(
     () => createProviderCacheKey("pricing-requests", user?.tenantId, user?.userId, role),

--- a/providers/proposalProvider/index.tsx
+++ b/providers/proposalProvider/index.tsx
@@ -11,8 +11,7 @@ import {
   buildProposalLineItemPayload,
   buildUpdateProposalPayload,
   coerceItems,
-  getSessionToken,
-  isMockSessionToken,
+  isStoredMockSession,
   mapBackendProposal,
 } from "@/lib/client/backend-api";
 import { createProviderCacheKey, readProviderCache, writeProviderCache } from "@/lib/client/provider-cache";
@@ -104,7 +103,7 @@ export default function ProposalProvider({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   const { isAuthenticated, user } = useAuthState();
-  const isDemoMode = isMockSessionToken(getSessionToken());
+  const isDemoMode = isStoredMockSession();
   const scopedClientIds = useMemo(() => new Set(user?.clientIds ?? []), [user?.clientIds]);
   const isScopedClient = isClientScopedUser(user?.clientIds);
   const cacheKey = useMemo(

--- a/providers/teamMembersProvider/index.tsx
+++ b/providers/teamMembersProvider/index.tsx
@@ -8,8 +8,7 @@ import {
   type BackendUserDto,
   backendRequest,
   coerceItems,
-  getSessionToken,
-  isMockSessionToken,
+  isStoredMockSession,
   mapBackendUser,
 } from "@/lib/client/backend-api";
 import { createProviderCacheKey, writeProviderCache, readProviderCache } from "@/lib/client/provider-cache";
@@ -54,7 +53,7 @@ export default function TeamMembersProvider({
 }: Readonly<{ children: React.ReactNode }>) {
   const fallbackTeamMembers = useMemo(() => initialTeamMembers(), []);
   const { isAuthenticated, user } = useAuthState();
-  const isDemoMode = isMockSessionToken(getSessionToken());
+  const isDemoMode = isStoredMockSession();
   const role = getPrimaryUserRole(user?.roles);
   const cacheKey = useMemo(
     () => createProviderCacheKey("team-members", user?.tenantId, user?.userId, role),

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,26 +1,80 @@
 import { NextResponse, type NextRequest } from "next/server";
 
 import { AUTH_COOKIE_NAME } from "@/app/api/Auth/session-cookie";
-import { canAccessDashboardPath, DASHBOARD_HOME_PATH } from "@/lib/auth/dashboard-access";
-import { normalizeUserRole } from "@/lib/auth/roles";
+import type { AuthSessionUser } from "@/lib/auth/auth-contract";
+import { canAccessDashboardPath, getDashboardHomePath } from "@/lib/auth/dashboard-access";
+import { getPrimaryUserRole } from "@/lib/auth/roles";
 import { getUserFromSessionToken } from "@/lib/auth/session-user";
+import { createBackendUrl } from "@/lib/server/backend-url";
 
-export function proxy(request: NextRequest) {
-  const { pathname } = request.nextUrl;
-  const token = request.cookies.get(AUTH_COOKIE_NAME)?.value;
+const toSessionUser = (user: ReturnType<typeof getUserFromSessionToken>): AuthSessionUser | null => {
+  if (!user) {
+    return null;
+  }
+
+  return {
+    clientIds: user.clientIds ?? [],
+    email: user.email,
+    firstName: user.firstName,
+    isMockSession: user.password === "",
+    lastName: user.lastName,
+    roles: [user.role],
+    tenantId: user.tenantId,
+    tenantName: user.tenantName,
+    token: null,
+    userId: user.id,
+  };
+};
+
+const fetchAuthorizedSessionUser = async (token: string) => {
+  const directUser = toSessionUser(getUserFromSessionToken(token));
+
+  if (token.startsWith("mock-token::")) {
+    return directUser;
+  }
+
+  try {
+    const upstream = await fetch(createBackendUrl("/api/Auth/me"), {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+      method: "GET",
+      redirect: "manual",
+    });
+
+    if (!upstream.ok || upstream.status === 204) {
+      return directUser;
+    }
+
+    const payload = (await upstream.json()) as AuthSessionUser | null;
+
+    return payload ?? directUser;
+  } catch {
+    return directUser;
+  }
+};
+
+const redirectTo = (request: NextRequest, pathname: string) =>
+  NextResponse.redirect(new URL(pathname, request.url));
+
+export async function proxy(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+  const token = request.cookies.get(AUTH_COOKIE_NAME)?.value?.trim();
 
   if (!token) {
-    return NextResponse.redirect(new URL("/login", request.url));
+    return redirectTo(request, "/login");
   }
 
-  const user = getUserFromSessionToken(token);
+  const sessionUser = await fetchAuthorizedSessionUser(token);
 
-  if (!user) {
-    return NextResponse.redirect(new URL("/login", request.url));
+  if (!sessionUser) {
+    return redirectTo(request, "/login");
   }
 
-  if (!canAccessDashboardPath(pathname, normalizeUserRole(user.role), user.clientIds)) {
-    return NextResponse.redirect(new URL(DASHBOARD_HOME_PATH, request.url));
+  const role = getPrimaryUserRole(sessionUser.roles);
+
+  if (!canAccessDashboardPath(pathname, role, sessionUser.clientIds)) {
+    return redirectTo(request, getDashboardHomePath(role, sessionUser.clientIds));
   }
 
   return NextResponse.next();


### PR DESCRIPTION
Fixes #286

## Summary
Harden the client auth flow around cookie-backed sessions and block unauthorized dashboard access before render.

## Scope
- remove client-side bearer token reliance
- rely on cookie-backed auth restoration via `/api/Auth/me`
- gate `/dashboard` access before render
- enforce dashboard route access earlier for unauthorized users

## Verification
- `npm run build`
