### PR TITLE
fix: stabilize request workflow persistence and ai handling

### DIFF
--- a/app/api/Auth/mock-users.ts
+++ b/app/api/Auth/mock-users.ts
@@ -22,6 +22,8 @@ export interface IMockUser {
 
 const AUTO_SALES_TENANT_ID = "mock-tenant-autosales";
 const AUTO_SALES_TENANT_NAME = "AutoSales Mock Workspace";
+const SHARED_DEMO_TENANT_ID = "11111111-1111-1111-1111-111111111111";
+const SHARED_DEMO_TENANT_NAME = "Shared Demo Tenant";
 const AUTO_SALES_REP_PASSWORD = "Sales123";
 const AUTO_SALES_ADMIN_MEMBER_IDS = new Set(["tm02"]);
 
@@ -41,10 +43,41 @@ const toAutoSalesRepEmail = (name: string) =>
     .trim()
     .replace(/\s+/g, ".")}@autosales.com`;
 
+const createTenantBoundUser = (
+  tenant: { id: string; name: string },
+  user: Omit<IMockUser, "tenantId" | "tenantName">,
+): IMockUser => ({
+  ...user,
+  tenantId: tenant.id,
+  tenantName: tenant.name,
+});
+
+const createAutoSalesUser = (
+  user: Omit<IMockUser, "tenantId" | "tenantName">,
+): IMockUser =>
+  createTenantBoundUser(
+    {
+      id: AUTO_SALES_TENANT_ID,
+      name: AUTO_SALES_TENANT_NAME,
+    },
+    user,
+  );
+
+const createSharedDemoUser = (
+  user: Omit<IMockUser, "tenantId" | "tenantName">,
+): IMockUser =>
+  createTenantBoundUser(
+    {
+      id: SHARED_DEMO_TENANT_ID,
+      name: SHARED_DEMO_TENANT_NAME,
+    },
+    user,
+  );
+
 const createAutoSalesRepUser = (member: (typeof MOCK_TEAM_MEMBERS)[number]): IMockUser => {
   const [firstName, ...rest] = member.name.split(" ");
 
-  return {
+  return createAutoSalesUser({
     clientIds: [],
     email: toAutoSalesRepEmail(member.name),
     firstName: firstName ?? member.name,
@@ -52,47 +85,53 @@ const createAutoSalesRepUser = (member: (typeof MOCK_TEAM_MEMBERS)[number]): IMo
     lastName: rest.join(" ") || "Rep",
     password: AUTO_SALES_REP_PASSWORD,
     role: AUTO_SALES_ADMIN_MEMBER_IDS.has(member.id) ? "Admin" : "SalesRep",
-    tenantId: AUTO_SALES_TENANT_ID,
-    tenantName: AUTO_SALES_TENANT_NAME,
-  };
+  });
 };
 
 const autoSalesRepUsers = MOCK_TEAM_MEMBERS.filter((member) =>
   isClientFacingRole(member.role),
 ).map(createAutoSalesRepUser);
 
+const validateMockUserConfiguration = (entries: Map<string, IMockUser>) => {
+  for (const [email, user] of entries) {
+    if (email.endsWith("@autosales.com") && user.tenantId !== AUTO_SALES_TENANT_ID) {
+      throw new Error(`Mock user ${email} must belong to the AutoSales tenant.`);
+    }
+
+    if (email === "clients@autosales.com" && user.role !== "Client") {
+      throw new Error("clients@autosales.com must be configured as a Client user.");
+    }
+  }
+};
+
 const users = new Map<string, IMockUser>([
   [
     "admin@autosales.com",
-    {
+    createAutoSalesUser({
       clientIds: [],
       email: "admin@autosales.com",
       firstName: "Admin",
-      id: "admin-shared-demo",
+      id: "admin-autosales",
       lastName: "User",
       password: "Admin123",
       role: "Admin",
-      tenantId: "11111111-1111-1111-1111-111111111111",
-      tenantName: "Shared Demo Tenant",
-    },
+    }),
   ],
   [
     "clients@autosales.com",
-    {
+    createAutoSalesUser({
       clientIds: ["c1"],
       email: "clients@autosales.com",
       firstName: "Client",
       id: "legacy-client-viewer",
       lastName: "Tester",
       password: "Clients123",
-      role: "SalesRep",
-      tenantId: AUTO_SALES_TENANT_ID,
-      tenantName: AUTO_SALES_TENANT_NAME,
-    },
+      role: "Client",
+    }),
   ],
   [
     "salesrep@autosales.com",
-    {
+    createAutoSalesUser({
       clientIds: [],
       email: "salesrep@autosales.com",
       firstName: "Lebo",
@@ -100,13 +139,11 @@ const users = new Map<string, IMockUser>([
       lastName: "Dlamini",
       password: AUTO_SALES_REP_PASSWORD,
       role: "Admin",
-      tenantId: AUTO_SALES_TENANT_ID,
-      tenantName: AUTO_SALES_TENANT_NAME,
-    },
+    }),
   ],
   [
     "admin@salesautomation.com",
-    {
+    createSharedDemoUser({
       clientIds: [],
       email: "admin@salesautomation.com",
       firstName: "Admin",
@@ -114,13 +151,11 @@ const users = new Map<string, IMockUser>([
       lastName: "User",
       password: "Admin@123",
       role: "Admin",
-      tenantId: "11111111-1111-1111-1111-111111111111",
-      tenantName: "Shared Demo Tenant",
-    },
+    }),
   ],
   [
     "salesrep@salesautomation.com",
-    {
+    createSharedDemoUser({
       clientIds: [],
       email: "salesrep@salesautomation.com",
       firstName: "Lebo",
@@ -128,13 +163,11 @@ const users = new Map<string, IMockUser>([
       lastName: "Dlamini",
       password: "Pass@123",
       role: "SalesRep",
-      tenantId: "11111111-1111-1111-1111-111111111111",
-      tenantName: "Shared Demo Tenant",
-    },
+    }),
   ],
   [
     "client@boxfusion.com",
-    {
+    createSharedDemoUser({
       clientIds: ["c1"],
       email: "client@boxfusion.com",
       firstName: "Boxfusion",
@@ -142,12 +175,12 @@ const users = new Map<string, IMockUser>([
       lastName: "Client",
       password: "Pass@123",
       role: "Client",
-      tenantId: "11111111-1111-1111-1111-111111111111",
-      tenantName: "Shared Demo Tenant",
-    },
+    }),
   ],
   ...autoSalesRepUsers.map((user) => [user.email, user] as const),
 ]);
+
+validateMockUserConfiguration(users);
 
 let nextId = 3;
 
@@ -192,8 +225,8 @@ export const registerMockUser = ({
     lastName,
     password,
     role,
-    tenantId: "11111111-1111-1111-1111-111111111111",
-    tenantName: tenantName || "Shared Demo Tenant",
+    tenantId: SHARED_DEMO_TENANT_ID,
+    tenantName: tenantName || SHARED_DEMO_TENANT_NAME,
   };
 
   users.set(normalizedEmail, user);

--- a/components/dashboard/client-dashboard-overview.tsx
+++ b/components/dashboard/client-dashboard-overview.tsx
@@ -4,14 +4,13 @@ import { FileTextOutlined, FolderOpenOutlined, MessageOutlined, ProfileOutlined 
 import { Card, Col, Empty, Row, Space, Tag, Typography } from "antd";
 import dynamic from "next/dynamic";
 import Link from "next/link";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
+import { listServiceRequests, type ServiceRequestRecord } from "@/lib/client/service-request-api";
 import { useAuthState } from "@/providers/authProvider";
 import { useClientState } from "@/providers/clientProvider";
 import { useContractState } from "@/providers/contractProvider";
 import { useDocumentState } from "@/providers/documentProvider";
-import type { INoteItem } from "@/providers/domainSeeds";
-import { useNoteState } from "@/providers/noteProvider";
 import { useProposalState } from "@/providers/proposalProvider";
 
 const ClientMessageCenter = dynamic(
@@ -30,21 +29,13 @@ const ClientMessageCenter = dynamic(
   },
 );
 
-const CLIENT_MESSAGE_CATEGORY = "Client Message";
-const LEGACY_CLIENT_MESSAGE_PREFIX = `${CLIENT_MESSAGE_CATEGORY} `;
-
-const isClientMessage = (note: INoteItem) =>
-  note.kind === "client_message" ||
-  note.category === CLIENT_MESSAGE_CATEGORY ||
-  note.category?.startsWith(LEGACY_CLIENT_MESSAGE_PREFIX);
-
 export function ClientDashboardOverview() {
   const { user } = useAuthState();
   const { clients } = useClientState();
   const { contracts } = useContractState();
   const { documents } = useDocumentState();
-  const { notes } = useNoteState();
   const { proposals } = useProposalState();
+  const [serviceRequests, setServiceRequests] = useState<ServiceRequestRecord[]>([]);
 
   const primaryClientId = user?.clientIds?.[0];
   const client = clients.find((item) => item.id === primaryClientId) ?? null;
@@ -57,10 +48,34 @@ export function ClientDashboardOverview() {
     () => documents.filter((item) => item.clientId === client?.id),
     [client?.id, documents],
   );
-  const clientMessages = useMemo(
-    () => notes.filter((item) => item.clientId === client?.id && isClientMessage(item)),
-    [client?.id, notes],
-  );
+  useEffect(() => {
+    if (!client?.id) {
+      setServiceRequests([]);
+      return;
+    }
+
+    let isActive = true;
+
+    void listServiceRequests()
+      .then((items) => {
+        if (!isActive) {
+          return;
+        }
+
+        setServiceRequests(items.filter((item) => item.clientId === client.id));
+      })
+      .catch((error) => {
+        console.error(error);
+
+        if (isActive) {
+          setServiceRequests([]);
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [client?.id]);
   const clientProposals = useMemo(
     () => proposals.filter((item) => item.clientId === client?.id),
     [client?.id, proposals],
@@ -70,8 +85,8 @@ export function ClientDashboardOverview() {
   const latestDocument = [...clientDocuments].sort((left, right) =>
     right.uploadedDate.localeCompare(left.uploadedDate),
   )[0];
-  const latestMessage = [...clientMessages].sort((left, right) =>
-    right.createdDate.localeCompare(left.createdDate),
+  const latestMessage = [...serviceRequests].sort((left, right) =>
+    right.updatedAt.localeCompare(left.updatedAt),
   )[0];
   const latestProposal = [...clientProposals].sort((left, right) =>
     right.validUntil.localeCompare(left.validUntil),
@@ -130,10 +145,10 @@ export function ClientDashboardOverview() {
                 <MessageOutlined className="text-lg text-[#355c7d]" />
                 <Typography.Text className="!text-slate-500">Messages</Typography.Text>
                 <Typography.Title className="!m-0" level={3}>
-                  {clientMessages.length}
+                  {serviceRequests.length}
                 </Typography.Title>
                 <Typography.Text className="!text-slate-500">
-                  {latestMessage ? `${latestMessage.title} is the latest thread.` : "No account messages yet."}
+                  {latestMessage ? `${latestMessage.title} is the latest request thread.` : "No account requests yet."}
                 </Typography.Text>
               </Space>
             </Card>

--- a/components/dashboard/client-message-center.tsx
+++ b/components/dashboard/client-message-center.tsx
@@ -8,20 +8,24 @@ import {
   Form,
   Input,
   Modal,
-  Select,
   Space,
   Tag,
   Typography,
   message,
 } from "antd";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
+import {
+  addServiceRequestMessage,
+  applyServiceRequestClientDecision,
+  createServiceRequest,
+  getServiceRequestDetail,
+  listServiceRequests,
+  type ServiceRequestDetail,
+  type ServiceRequestRecord,
+} from "@/lib/client/service-request-api";
 import { useAuthState } from "@/providers/authProvider";
 import { useClientState } from "@/providers/clientProvider";
-import { useDashboardState } from "@/providers/dashboardProvider";
-import type { INoteItem } from "@/providers/domainSeeds";
-import { useNoteActions, useNoteState } from "@/providers/noteProvider";
-import { useOpportunityState } from "@/providers/opportunityProvider";
 import { useStyles } from "./client-message-center.styles";
 
 type ClientMessageCenterProps = Readonly<{
@@ -30,64 +34,67 @@ type ClientMessageCenterProps = Readonly<{
 
 type MessageFormValues = {
   content: string;
-  representativeId: string;
   subject: string;
 };
 
-const CLIENT_MESSAGE_CATEGORY = "Client Message";
-const LEGACY_CLIENT_MESSAGE_PREFIX = `${CLIENT_MESSAGE_CATEGORY} `;
-
-const clientFacingRole = (role: string) =>
-  [
-    "Account Executive",
-    "Sales Consultant",
-    "Client Success",
-    "Business Development",
-    "Pipeline Director",
-  ].some((token) => role.includes(token));
-
-const createMessageId = () =>
-  `client-message-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
-
-const isClientMessage = (note: INoteItem) =>
-  note.kind === "client_message" ||
-  note.category === CLIENT_MESSAGE_CATEGORY ||
-  note.category?.startsWith(LEGACY_CLIENT_MESSAGE_PREFIX);
-
-const getRepresentativeName = (note: INoteItem) => {
-  if (note.representativeName) {
-    return note.representativeName;
-  }
-
-  if (note.category?.startsWith(LEGACY_CLIENT_MESSAGE_PREFIX)) {
-    return note.category
-      .slice(LEGACY_CLIENT_MESSAGE_PREFIX.length)
-      .replace(/^[-\u2022]\s*/, "");
-  }
-
-  return "Account team";
-};
-
-const getMessageStatusColor = (status?: INoteItem["status"]) => {
+const getStatusColor = (status: ServiceRequestRecord["status"]) => {
   switch (status) {
-    case "Acknowledged":
+    case "submitted":
+      return "blue";
+    case "under_review":
+      return "gold";
+    case "proposal_prepared":
+      return "cyan";
+    case "awaiting_client_assignment_approval":
+    case "awaiting_rep_acceptance":
+      return "orange";
+    case "client_approved_assignment":
+    case "active":
       return "green";
-    case "Sent":
+    case "client_rejected_assignment":
+    case "rep_rejected_assignment":
+    case "cancelled":
+      return "red";
+    case "closed":
+      return "default";
     default:
       return "blue";
   }
 };
 
-const getMessageSourceLabel = (note: INoteItem) => {
-  switch (note.source) {
-    case "workspace":
-      return "Account team";
-    case "assistant":
-      return "Advisor";
-    case "client_portal":
-    default:
-      return "You";
+const formatStatusLabel = (status: ServiceRequestRecord["status"]) =>
+  status.replace(/_/g, " ");
+
+const formatEventSummary = (detail: ServiceRequestDetail | undefined) => {
+  const latestEvent = detail?.events[0];
+
+  if (!latestEvent) {
+    return null;
   }
+
+  if (latestEvent.eventType === "service_request_message_added") {
+    const content = String(latestEvent.payloadJson.content ?? "").trim();
+
+    return content || "A new message was added to this request.";
+  }
+
+  if (latestEvent.eventType === "service_request_assignments_created") {
+    return "Your request was assigned for client review.";
+  }
+
+  if (latestEvent.eventType === "service_request_client_decision") {
+    return "A client assignment decision was recorded.";
+  }
+
+  if (latestEvent.eventType === "service_request_representative_decision") {
+    return "A representative responded to this request.";
+  }
+
+  if (latestEvent.eventType === "service_request_review_started") {
+    return "Your request is now under review.";
+  }
+
+  return null;
 };
 
 export const ClientMessageCenter = ({
@@ -95,98 +102,152 @@ export const ClientMessageCenter = ({
 }: ClientMessageCenterProps) => {
   const { user } = useAuthState();
   const { clients } = useClientState();
-  const { notes } = useNoteState();
-  const { addNote } = useNoteActions();
-  const { opportunities } = useOpportunityState();
-  const { teamMembers } = useDashboardState();
   const { styles } = useStyles();
   const [messageApi, contextHolder] = message.useMessage();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [serviceRequests, setServiceRequests] = useState<ServiceRequestRecord[]>([]);
+  const [serviceRequestDetailsById, setServiceRequestDetailsById] = useState<
+    Record<string, ServiceRequestDetail>
+  >({});
+  const [activeRequest, setActiveRequest] = useState<ServiceRequestRecord | null>(null);
   const [form] = Form.useForm<MessageFormValues>();
 
   const primaryClientId = user?.clientIds?.[0];
   const client = clients.find((item) => item.id === primaryClientId) ?? clients[0];
 
-  const representativeOptions = useMemo(() => {
-    if (!client) {
-      return [];
-    }
+  const loadServiceRequests = useCallback(async () => {
+    const requests = await listServiceRequests();
+    const scopedRequests = requests
+      .filter((request) => request.clientId === client?.id)
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
 
-    const accountLeadIds = new Set(
-      opportunities
-        .filter((opportunity) => opportunity.clientId === client.id && opportunity.ownerId)
-        .map((opportunity) => opportunity.ownerId as string),
+    setServiceRequests(scopedRequests);
+
+    const details = await Promise.all(
+      scopedRequests.map(async (request) => [request.id, await getServiceRequestDetail(request.id)] as const),
     );
+    setServiceRequestDetailsById(Object.fromEntries(details));
+  }, [client?.id]);
 
-    return teamMembers
-      .filter((member) => clientFacingRole(member.role))
-      .map((member) => ({
-        id: member.id,
-        isAccountLead: accountLeadIds.has(member.id),
-        label: `${member.name}${accountLeadIds.has(member.id) ? " (Account lead)" : ""}`,
-        name: member.name,
-        score: (accountLeadIds.has(member.id) ? 100 : 0) + member.availabilityPercent,
-      }))
-      .sort((left, right) => right.score - left.score || left.name.localeCompare(right.name));
-  }, [client, opportunities, teamMembers]);
-
-  const clientMessages = useMemo<INoteItem[]>(() => {
-    if (!client) {
-      return [];
+  useEffect(() => {
+    if (!client?.id) {
+      setServiceRequests([]);
+      setServiceRequestDetailsById({});
+      return;
     }
 
-    return notes
-      .filter((note) => note.clientId === client.id && isClientMessage(note))
-      .sort((left, right) => right.createdDate.localeCompare(left.createdDate));
-  }, [client, notes]);
+    let isActive = true;
 
-  const openComposer = (representativeId?: string) => {
-    form.setFieldsValue({
-      content: client ? `Hello, we would like help with ${client.name}.` : undefined,
-      representativeId: representativeId ?? representativeOptions[0]?.id ?? "",
-      subject: client ? `${client.name} account request` : "Client account request",
+    void loadServiceRequests().catch((error) => {
+      console.error(error);
+
+      if (isActive) {
+        setServiceRequests([]);
+        setServiceRequestDetailsById({});
+      }
     });
+
+    return () => {
+      isActive = false;
+    };
+  }, [client?.id, loadServiceRequests]);
+
+  const requestThreads = useMemo(
+    () => serviceRequests.slice(0, compact ? 3 : 6),
+    [compact, serviceRequests],
+  );
+
+  const openComposer = (request?: ServiceRequestRecord) => {
+    form.setFieldsValue({
+      content: request ? "" : client ? `Hello, we need help with ${client.name}.` : "",
+      subject: request?.title ?? (client ? `${client.name} account request` : "Client account request"),
+    });
+    setActiveRequest(request ?? null);
     setIsModalOpen(true);
   };
 
   const closeComposer = () => {
     setIsModalOpen(false);
+    setActiveRequest(null);
     form.resetFields();
   };
 
   const handleSubmit = async (values: MessageFormValues) => {
-    const representative = representativeOptions.find(
-      (option) => option.id === values.representativeId,
-    );
-
-    if (!representative || !client) {
-      messageApi.error("Please choose a representative before sending the message.");
+    if (!client) {
+      messageApi.error("No client workspace is linked to this account.");
       return;
     }
 
     setIsSubmitting(true);
 
     try {
-      await addNote({
-        category: CLIENT_MESSAGE_CATEGORY,
-        clientId: client.id,
-        content: values.content.trim(),
-        createdDate: new Date().toISOString().split("T")[0],
-        id: createMessageId(),
-        kind: "client_message",
-        representativeId: representative.id,
-        representativeName: representative.name,
-        source: "client_portal",
-        status: "Sent",
-        submittedBy: user?.email ?? undefined,
-        title: values.subject.trim(),
-      });
-      messageApi.success(`Message sent to ${representative.name}.`);
+      if (activeRequest) {
+        const assignedRepresentativeUserIds =
+          serviceRequestDetailsById[activeRequest.id]?.assignments.map(
+            (assignment) => assignment.representativeUserId,
+          ) ?? [];
+
+        await addServiceRequestMessage(activeRequest.id, {
+          content: values.content.trim(),
+          recipientType: "representative",
+          representativeUserIds: assignedRepresentativeUserIds,
+        });
+        messageApi.success("Follow-up added to the request.");
+      } else {
+        await createServiceRequest({
+          clientId: client.id,
+          description: values.content.trim(),
+          requestType: "service_request",
+          source: "client_portal",
+          title: values.subject.trim(),
+        });
+        messageApi.success("Request submitted to the workspace.");
+      }
+
+      await loadServiceRequests();
       closeComposer();
     } catch (error) {
       console.error(error);
-      messageApi.error("Could not save the message.");
+      messageApi.error(
+        activeRequest ? "Could not save the request follow-up." : "Could not submit the request.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleAssignmentDecision = async (
+    request: ServiceRequestRecord,
+    decision: "approve" | "reject",
+  ) => {
+    const detail = serviceRequestDetailsById[request.id];
+    const assignmentIds =
+      detail?.assignments
+        .filter((assignment) => assignment.status === "pending_client_approval")
+        .map((assignment) => assignment.id) ?? [];
+
+    if (assignmentIds.length === 0) {
+      messageApi.error("There are no pending assignments to review for this request.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await applyServiceRequestClientDecision(request.id, {
+        assignmentIds,
+        decision,
+      });
+      await loadServiceRequests();
+      messageApi.success(
+        decision === "approve"
+          ? "Assignment approved. The representatives can respond next."
+          : "Assignment rejected. The workspace can prepare a new assignment.",
+      );
+    } catch (error) {
+      console.error(error);
+      messageApi.error("Could not apply the assignment decision.");
     } finally {
       setIsSubmitting(false);
     }
@@ -203,67 +264,86 @@ export const ClientMessageCenter = ({
               Message your account team
             </Typography.Title>
             <Typography.Text className={styles.mutedText}>
-              Send account questions and commercial follow-ups to the representative
-              supporting your workspace.
+              Create real support requests and keep follow-ups attached to the same workflow thread.
             </Typography.Text>
           </div>
           <Button icon={<MailOutlined />} onClick={() => openComposer()} type="primary">
-            Message a representative
+            New request
           </Button>
         </div>
 
-        {clientMessages.length === 0 ? (
+        {requestThreads.length === 0 ? (
           <Empty
-            description="No messages have been sent from this client workspace yet."
+            description="No support requests have been submitted from this client workspace yet."
             image={Empty.PRESENTED_IMAGE_SIMPLE}
           />
         ) : (
           <div className={styles.list}>
-            {clientMessages.slice(0, compact ? 3 : 6).map((note) => (
-              <div className={styles.messageCard} key={note.id}>
-                <div className={styles.messageHeader}>
-                  <div className={styles.metaGroup}>
-                    <Typography.Title className={styles.messageTitle} level={5}>
-                      {note.title}
-                    </Typography.Title>
+            {requestThreads.map((request) => {
+              const detail = serviceRequestDetailsById[request.id];
+              const latestSummary = formatEventSummary(detail);
+              const pendingClientAssignments =
+                detail?.assignments.filter(
+                  (assignment) => assignment.status === "pending_client_approval",
+                ) ?? [];
+
+              return (
+                <div className={styles.messageCard} key={request.id}>
+                  <div className={styles.messageHeader}>
+                    <div className={styles.metaGroup}>
+                      <Typography.Title className={styles.messageTitle} level={5}>
+                        {request.title}
+                      </Typography.Title>
+                      <Space size="small" wrap>
+                        <Tag color={getStatusColor(request.status)}>
+                          {formatStatusLabel(request.status)}
+                        </Tag>
+                        <Tag color="default">{request.updatedAt.split("T")[0]}</Tag>
+                        {pendingClientAssignments.length > 0 ? (
+                          <Tag color="orange">Waiting for your decision</Tag>
+                        ) : null}
+                      </Space>
+                    </div>
                     <Space size="small" wrap>
-                      <Tag color={note.source === "workspace" ? "gold" : "default"}>
-                        {getMessageSourceLabel(note)}
-                      </Tag>
-                      <Tag color="geekblue">{getRepresentativeName(note)}</Tag>
-                      <Tag color={getMessageStatusColor(note.status)}>
-                        {note.status ?? "Sent"}
-                      </Tag>
-                      <Tag color="default">{note.createdDate}</Tag>
+                      {pendingClientAssignments.length > 0 ? (
+                        <>
+                          <Button
+                            loading={isSubmitting}
+                            onClick={() => void handleAssignmentDecision(request, "approve")}
+                            type="primary"
+                          >
+                            Accept assignment
+                          </Button>
+                          <Button
+                            danger
+                            loading={isSubmitting}
+                            onClick={() => void handleAssignmentDecision(request, "reject")}
+                          >
+                            Reject assignment
+                          </Button>
+                        </>
+                      ) : null}
+                      <Button
+                        icon={<SendOutlined />}
+                        onClick={() => openComposer(request)}
+                      >
+                        Follow up
+                      </Button>
                     </Space>
                   </div>
-                  <Button
-                    icon={<SendOutlined />}
-                    onClick={() =>
-                      openComposer(
-                        representativeOptions.find(
-                          (option) =>
-                            option.id === note.representativeId ||
-                            option.name === getRepresentativeName(note),
-                        )?.id,
-                      )
-                    }
-                  >
-                    Follow up
-                  </Button>
+                  <Typography.Paragraph className={styles.messageText}>
+                    {latestSummary ?? request.description}
+                  </Typography.Paragraph>
+                  <Typography.Text className={styles.messageFooter}>
+                    {pendingClientAssignments.length > 0
+                      ? `Assigned reps: ${pendingClientAssignments.map((assignment) => assignment.representativeName).join(", ")}.`
+                      : detail?.events.length
+                        ? `${detail.events.length} workflow update${detail.events.length === 1 ? "" : "s"} recorded.`
+                        : "Awaiting the first workflow update."}
+                  </Typography.Text>
                 </div>
-                <Typography.Paragraph className={styles.messageText}>
-                  {note.content}
-                </Typography.Paragraph>
-                <Typography.Text className={styles.messageFooter}>
-                  {note.source === "workspace"
-                    ? "Shared by your account team."
-                    : note.submittedBy
-                      ? `Sent from ${note.submittedBy}`
-                      : "Submitted from this client workspace."}
-                </Typography.Text>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>
@@ -273,35 +353,23 @@ export const ClientMessageCenter = ({
         onCancel={closeComposer}
         onOk={() => form.submit()}
         okButtonProps={{ loading: isSubmitting }}
-        okText="Send message"
+        okText={activeRequest ? "Send follow-up" : "Submit request"}
         open={isModalOpen}
-        title="Message a representative"
+        title={activeRequest ? "Follow up on request" : "Create support request"}
       >
         <Form className={styles.modalForm} form={form} layout="vertical" onFinish={handleSubmit}>
-          <Form.Item
-            label="Representative"
-            name="representativeId"
-            rules={[{ message: "Please choose a representative", required: true }]}
-          >
-            <Select
-              options={representativeOptions.map((option) => ({
-                label: option.label,
-                value: option.id,
-              }))}
-              placeholder="Choose a representative"
-            />
-          </Form.Item>
+          {activeRequest ? null : (
+            <Form.Item
+              label="Subject"
+              name="subject"
+              rules={[{ message: "Please add a subject", required: true }]}
+            >
+              <Input placeholder="e.g. Proposal clarification" />
+            </Form.Item>
+          )}
 
           <Form.Item
-            label="Subject"
-            name="subject"
-            rules={[{ message: "Please add a subject", required: true }]}
-          >
-            <Input placeholder="e.g. Proposal clarification" />
-          </Form.Item>
-
-          <Form.Item
-            label="Message"
+            label={activeRequest ? "Follow-up message" : "Request details"}
             name="content"
             rules={[{ message: "Please enter your message", required: true }]}
           >

--- a/components/dashboard/messages-panel.tsx
+++ b/components/dashboard/messages-panel.tsx
@@ -158,7 +158,7 @@ const getServiceRequestMessageRecipientSummary = (payload: Record<string, unknow
   if (recipientType === "representative") {
     return representativeNames.length > 0
       ? `To reps: ${representativeNames.join(", ")}`
-      : "To reps";
+      : "To workspace";
   }
 
   return "To client";
@@ -219,7 +219,17 @@ function MessagesPanelContent({
       const clientName =
         clients.find((client) => client.id === request.clientId)?.name ?? "the client";
 
-      return `Review the client request "${request.title}" for ${clientName} (request id ${request.id}), create the right opportunity and proposal if needed, and assign the best reps for this request only.`;
+      return [
+        `Review this exact client request only.`,
+        `Request id: ${request.id}`,
+        `Client: ${clientName}`,
+        `Title: ${request.title}`,
+        `Status: ${request.status}`,
+        `Request type: ${request.requestType}`,
+        `Description: ${request.description}`,
+        `If the workflow needs an opportunity or proposal, create the right ones and assign the best reps for this request only.`,
+        `Ask me to confirm before executing changes.`,
+      ].join("\n");
     },
     [clients],
   );
@@ -1005,17 +1015,7 @@ function MessagesPanelContent({
                       Handle with AI
                     </Button>
                     <Button
-                      onClick={() =>
-                        openReplyComposer({
-                          category: CLIENT_MESSAGE_CATEGORY,
-                          clientId: request.clientId,
-                          content: request.description,
-                          createdDate: request.createdAt.split("T")[0],
-                          id: request.id,
-                          source: request.source,
-                          title: request.title,
-                        } as INoteItem)
-                      }
+                      onClick={() => openServiceRequestReplyComposer(request)}
                     >
                       Reply first
                     </Button>

--- a/lib/server/assistant-openai.ts
+++ b/lib/server/assistant-openai.ts
@@ -624,16 +624,16 @@ const applyClientDecisionForWorkspace = async (
     decision: "approve" | "reject";
   },
 ) =>
-  workspace.isLiveBackend && workspace.sessionToken
-    ? applyLiveServiceRequestClientDecision(
-        createAssistantActor(workspace),
-        workspace.sessionToken,
-        requestId,
-        input,
-      )
-    : Promise.resolve(
-        applyServiceRequestClientDecision(createAssistantActor(workspace), requestId, input),
-      );
+  (
+    workspace.isLiveBackend && workspace.sessionToken
+      ? await applyLiveServiceRequestClientDecision(
+          createAssistantActor(workspace),
+          workspace.sessionToken,
+          requestId,
+          input,
+        )
+      : applyServiceRequestClientDecision(createAssistantActor(workspace), requestId, input)
+  ).request;
 
 const applyRepresentativeDecisionForWorkspace = async (
   workspace: IAssistantWorkspace,
@@ -643,16 +643,16 @@ const applyRepresentativeDecisionForWorkspace = async (
     decision: "accept" | "reject";
   },
 ) =>
-  workspace.isLiveBackend && workspace.sessionToken
-    ? applyLiveServiceRequestRepDecision(
-        createAssistantActor(workspace),
-        workspace.sessionToken,
-        requestId,
-        input,
-      )
-    : Promise.resolve(
-        applyServiceRequestRepDecision(createAssistantActor(workspace), requestId, input),
-      );
+  (
+    workspace.isLiveBackend && workspace.sessionToken
+      ? await applyLiveServiceRequestRepDecision(
+          createAssistantActor(workspace),
+          workspace.sessionToken,
+          requestId,
+          input,
+        )
+      : applyServiceRequestRepDecision(createAssistantActor(workspace), requestId, input)
+  ).request;
 
 const toIsoDate = (value: Date) => value.toISOString().split("T")[0];
 

--- a/lib/server/service-request-backend-store.ts
+++ b/lib/server/service-request-backend-store.ts
@@ -369,6 +369,37 @@ const appendEvent = async (
   return event;
 };
 
+const deriveRequestStatusFromAssignments = (
+  assignments: ServiceRequestAssignmentRecord[],
+  fallbackStatus: ServiceRequestStatus,
+): ServiceRequestStatus => {
+  if (assignments.length === 0) {
+    return fallbackStatus;
+  }
+
+  if (assignments.some((assignment) => assignment.status === "pending_client_approval")) {
+    return "awaiting_client_assignment_approval";
+  }
+
+  if (assignments.some((assignment) => assignment.status === "pending_rep_response")) {
+    return "awaiting_rep_acceptance";
+  }
+
+  if (assignments.some((assignment) => assignment.status === "rep_accepted")) {
+    return "active";
+  }
+
+  if (assignments.some((assignment) => assignment.status === "rep_rejected")) {
+    return "rep_rejected_assignment";
+  }
+
+  if (assignments.every((assignment) => assignment.status === "client_rejected")) {
+    return "client_rejected_assignment";
+  }
+
+  return fallbackStatus;
+};
+
 export const listLiveServiceRequests = async (
   user: IMockUser,
   token: string,
@@ -599,7 +630,7 @@ export const applyLiveServiceRequestClientDecision = async (
     throw new Error("No matching assignments were found for this request.");
   }
 
-  const nextAssignmentStatus =
+  const nextAssignmentStatus: ServiceRequestAssignmentRecord["status"] =
     input.decision === "approve" ? "pending_rep_response" : "client_rejected";
 
   for (const stored of matchingAssignments) {
@@ -618,12 +649,23 @@ export const applyLiveServiceRequestClientDecision = async (
     });
   }
 
+  const nextState = await loadLiveWorkflowState(user, token);
+  const nextAssignments = nextState.assignments
+    .filter((item) => item.assignment.serviceRequestId === request.request.id)
+    .map((item) =>
+      matchingAssignments.some((match) => match.assignment.id === item.assignment.id)
+        ? {
+            ...item.assignment,
+            decisionNote: input.note?.trim() || item.assignment.decisionNote,
+            status: nextAssignmentStatus,
+            updatedAt: nowIso(),
+          }
+        : item.assignment,
+    );
+
   const updatedRequest: ServiceRequestRecord = {
     ...request.request,
-    status:
-      input.decision === "approve"
-        ? "awaiting_rep_acceptance"
-        : "client_rejected_assignment",
+    status: deriveRequestStatusFromAssignments(nextAssignments, request.request.status),
     updatedAt: nowIso(),
   };
 
@@ -640,7 +682,7 @@ export const applyLiveServiceRequestClientDecision = async (
     note: input.note?.trim() || null,
   });
 
-  return clone(updatedRequest);
+  return getLiveServiceRequestDetail(user, token, requestId);
 };
 
 export const applyLiveServiceRequestRepDecision = async (
@@ -688,19 +730,10 @@ export const applyLiveServiceRequestRepDecision = async (
     .map((item) =>
       item.assignment.id === updatedAssignment.id ? updatedAssignment : item.assignment,
     );
-  const hasAccepted = allAssignments.some((item) => item.status === "rep_accepted");
-  const hasPending = allAssignments.some((item) => item.status === "pending_rep_response");
-  const hasRejected = allAssignments.some((item) => item.status === "rep_rejected");
 
   const updatedRequest: ServiceRequestRecord = {
     ...request.request,
-    status: hasRejected
-      ? "rep_rejected_assignment"
-      : hasPending
-        ? "awaiting_rep_acceptance"
-        : hasAccepted
-          ? "active"
-          : request.request.status,
+    status: deriveRequestStatusFromAssignments(allAssignments, request.request.status),
     updatedAt: nowIso(),
   };
 
@@ -717,7 +750,7 @@ export const applyLiveServiceRequestRepDecision = async (
     note: input.note?.trim() || null,
   });
 
-  return clone(updatedRequest);
+  return getLiveServiceRequestDetail(user, token, requestId);
 };
 
 export const addLiveServiceRequestMessage = async (
@@ -741,15 +774,15 @@ export const addLiveServiceRequestMessage = async (
   const representativeUserIds = [
     ...new Set((input.representativeUserIds ?? []).map((value) => value.trim()).filter(Boolean)),
   ];
+  const targetsRepresentatives =
+    recipientType === "representative" || recipientType === "both";
+  const requiresExplicitRepresentatives = user.role !== "Client" && targetsRepresentatives;
 
   if (!["client", "representative", "both"].includes(recipientType)) {
     throw new Error("A valid recipientType is required.");
   }
 
-  if (
-    (recipientType === "representative" || recipientType === "both") &&
-    representativeUserIds.length === 0
-  ) {
+  if (requiresExplicitRepresentatives && representativeUserIds.length === 0) {
     throw new Error("At least one representative recipient is required.");
   }
 
@@ -761,10 +794,7 @@ export const addLiveServiceRequestMessage = async (
     )
     .map((item) => item.assignment.representativeName);
 
-  if (
-    (recipientType === "representative" || recipientType === "both") &&
-    representativeNames.length !== representativeUserIds.length
-  ) {
+  if (representativeUserIds.length > 0 && representativeNames.length !== representativeUserIds.length) {
     throw new Error("Representative recipients must belong to this request.");
   }
 

--- a/lib/server/service-request-store.ts
+++ b/lib/server/service-request-store.ts
@@ -296,6 +296,37 @@ const toServiceRequestDetail = (
 const getAssignmentRecords = (state: ServiceRequestState, requestId: string) =>
   state.assignments.filter((assignment) => assignment.serviceRequestId === requestId);
 
+const deriveRequestStatusFromAssignments = (
+  assignments: ServiceRequestAssignmentRecord[],
+  fallbackStatus: ServiceRequestStatus,
+): ServiceRequestStatus => {
+  if (assignments.length === 0) {
+    return fallbackStatus;
+  }
+
+  if (assignments.some((assignment) => assignment.status === "pending_client_approval")) {
+    return "awaiting_client_assignment_approval";
+  }
+
+  if (assignments.some((assignment) => assignment.status === "pending_rep_response")) {
+    return "awaiting_rep_acceptance";
+  }
+
+  if (assignments.some((assignment) => assignment.status === "rep_accepted")) {
+    return "active";
+  }
+
+  if (assignments.some((assignment) => assignment.status === "rep_rejected")) {
+    return "rep_rejected_assignment";
+  }
+
+  if (assignments.every((assignment) => assignment.status === "client_rejected")) {
+    return "client_rejected_assignment";
+  }
+
+  return fallbackStatus;
+};
+
 export const listServiceRequests = (
   user: IMockUser,
   filters?: { statuses?: ServiceRequestStatus[] },
@@ -691,10 +722,6 @@ export const applyServiceRequestClientDecision = (
   persistServiceRequestStore();
 
   const allAssignments = getAssignmentRecords(state, request.id);
-  const approvedAssignments = allAssignments.filter(
-    (assignment) => assignment.status === "client_approved",
-  );
-
   if (input.decision === "approve") {
     state.assignments = state.assignments.map((assignment) => {
       if (assignment.serviceRequestId !== request.id) {
@@ -714,11 +741,10 @@ export const applyServiceRequestClientDecision = (
     persistServiceRequestStore();
   }
 
+  const nextAssignments = getAssignmentRecords(state, request.id);
+
   const updated = updateRequestRecord(state, request.id, {
-    status:
-      input.decision === "approve" && approvedAssignments.length > 0
-        ? "awaiting_rep_acceptance"
-        : "client_rejected_assignment",
+    status: deriveRequestStatusFromAssignments(nextAssignments, request.status),
   });
 
   if (!updated) {
@@ -731,7 +757,7 @@ export const applyServiceRequestClientDecision = (
     note: input.note?.trim() || null,
   });
 
-  return clone(updated);
+  return toServiceRequestDetail(state, updated);
 };
 
 export const applyServiceRequestRepDecision = (
@@ -768,19 +794,10 @@ export const applyServiceRequestRepDecision = (
   );
   persistServiceRequestStore();
 
-  const allAssignments = getAssignmentRecords(state, request.id);
-  const hasAccepted = allAssignments.some((item) => item.status === "rep_accepted");
-  const hasPending = allAssignments.some((item) => item.status === "pending_rep_response");
-  const hasRejected = allAssignments.some((item) => item.status === "rep_rejected");
+  const nextAssignments = getAssignmentRecords(state, request.id);
 
   const updated = updateRequestRecord(state, request.id, {
-    status: hasRejected
-      ? "rep_rejected_assignment"
-      : hasPending
-        ? "awaiting_rep_acceptance"
-        : hasAccepted
-          ? "active"
-          : request.status,
+    status: deriveRequestStatusFromAssignments(nextAssignments, request.status),
   });
 
   if (!updated) {
@@ -793,7 +810,7 @@ export const applyServiceRequestRepDecision = (
     note: input.note?.trim() || null,
   });
 
-  return clone(updated);
+  return toServiceRequestDetail(state, updated);
 };
 
 export const addServiceRequestMessage = (
@@ -816,15 +833,15 @@ export const addServiceRequestMessage = (
   const representativeUserIds = [
     ...new Set((input.representativeUserIds ?? []).map((value) => value.trim()).filter(Boolean)),
   ];
+  const targetsRepresentatives =
+    recipientType === "representative" || recipientType === "both";
+  const requiresExplicitRepresentatives = isInternalUser(user) && targetsRepresentatives;
 
   if (!["client", "representative", "both"].includes(recipientType)) {
     throw new Error("A valid recipientType is required.");
   }
 
-  if (
-    (recipientType === "representative" || recipientType === "both") &&
-    representativeUserIds.length === 0
-  ) {
+  if (requiresExplicitRepresentatives && representativeUserIds.length === 0) {
     throw new Error("At least one representative recipient is required.");
   }
 
@@ -833,10 +850,7 @@ export const addServiceRequestMessage = (
     .filter((assignment) => representativeUserIds.includes(assignment.representativeUserId))
     .map((assignment) => assignment.representativeName);
 
-  if (
-    (recipientType === "representative" || recipientType === "both") &&
-    representativeNames.length !== representativeUserIds.length
-  ) {
+  if (representativeUserIds.length > 0 && representativeNames.length !== representativeUserIds.length) {
     throw new Error("Representative recipients must belong to this request.");
   }
 


### PR DESCRIPTION
Fixes #288

## Summary
Stabilize the request and message workflow so requests persist correctly, stay in the right tenant, and let admin, AI, client, and rep actions operate on the same service request thread.

## Scope
- persist request workflow data durably through the service request store
- route client follow-ups through real service request threads
- improve Handle with AI request targeting
- fix client and representative decision state transitions
- harden mock user tenant mapping so matching client and admin users stay in the same workspace

## Verification
- `npm run build`
- submit a client request and verify it appears for the matching admin
- confirm Handle with AI opens the right request context
- confirm client accept/reject and rep accept/reject update the same request thread
