### PR TITLE
fix: remove demo login credential helpers from sign-in

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -20,10 +20,6 @@ export const LoginForm = () => {
     await login(values);
   };
 
-  const applyMockCredentials = (values: LoginValues) => {
-    form.setFieldsValue(values);
-  };
-
   return (
     <Card className={styles.card}>
       <div className={styles.intro}>
@@ -31,52 +27,8 @@ export const LoginForm = () => {
           Welcome back
         </Typography.Title>
         <Typography.Paragraph className={styles.mutedText}>
-          Sign in with your organisation account to manage your sales workspace. For local testing, use the shared demo admin account below or one of the local mock inboxes.
+          Sign in with your organisation account to manage your sales workspace.
         </Typography.Paragraph>
-        <Typography.Text className={styles.helperRow}>
-          Shared demo admin: <strong>admin@autosales.com</strong> / <strong>Admin123</strong>
-        </Typography.Text>
-        <Typography.Text className={styles.helperRow}>
-          Mock client viewer: <strong>clients@autosales.com</strong> / <strong>Clients123</strong>
-        </Typography.Text>
-        <Typography.Text className={styles.helperRow}>
-          Mock rep inbox: <strong>lebo.dlamini@autosales.com</strong> / <strong>Sales123</strong>
-        </Typography.Text>
-        <Typography.Text className={styles.helperSmall}>
-          Client-facing rep inboxes use <strong>{`first.last@autosales.com`}</strong> with password <strong>Sales123</strong>.
-        </Typography.Text>
-        <div className={styles.quickFill}>
-          <Button
-            onClick={() =>
-              applyMockCredentials({
-                email: "admin@autosales.com",
-                password: "Admin123",
-              })
-            }
-          >
-            Use mock admin
-          </Button>
-          <Button
-            onClick={() =>
-              applyMockCredentials({
-                email: "clients@autosales.com",
-                password: "Clients123",
-              })
-            }
-          >
-            Use client tester
-          </Button>
-          <Button
-            onClick={() =>
-              applyMockCredentials({
-                email: "lebo.dlamini@autosales.com",
-                password: "Sales123",
-              })
-            }
-          >
-            Use rep inbox
-          </Button>
-        </div>
       </div>
 
       {isError ? (


### PR DESCRIPTION
Fixes #290

## Summary
Remove the login-page demo credential helpers so production-facing users are not shown autofill shortcuts or visible mock account details.

## Scope
- remove demo autofill buttons from the login form
- remove visible demo credential text from the login page
- keep normal manual sign-in flow intact

## Verification
- npm run build
