### PR TITLE
fix: lock public signup to clients and persist deployed mock registrations

### DIFF
--- a/app/api/Auth/login/route.ts
+++ b/app/api/Auth/login/route.ts
@@ -4,7 +4,8 @@ import type { AuthLoginRequestDto } from "@/lib/auth/auth-contract";
 import { shouldUseUpstreamAuth } from "@/lib/server/auth-mode";
 import { createBackendUrl } from "@/lib/server/backend-url";
 
-import { findUserByEmail, toAuthPayload } from "../mock-users";
+import { readMockUsersFromCookies } from "../mock-user-cookie";
+import { findMockUserByEmail, toAuthPayload } from "../mock-users";
 import {
   AUTH_COOKIE_NAME,
   AUTH_COOKIE_OPTIONS,
@@ -18,14 +19,19 @@ const readJsonBody = async (response: Response) => {
     return {} as Record<string, unknown>;
   }
 
-  return JSON.parse(text) as Record<string, unknown>;
+  try {
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return { message: text } as Record<string, unknown>;
+  }
 };
 
 export const POST = async (request: NextRequest) => {
   const rawBody = await request.text();
   const credentials = JSON.parse(rawBody) as AuthLoginRequestDto;
   const email = credentials.email?.trim().toLowerCase() ?? "";
-  const mockUser = email ? findUserByEmail(email) : undefined;
+  const browserMockUsers = readMockUsersFromCookies(request.cookies);
+  const mockUser = email ? findMockUserByEmail(email, browserMockUsers) : undefined;
 
   if (mockUser && credentials.password === mockUser.password) {
     const payload = toAuthPayload(mockUser);

--- a/app/api/Auth/me/route.ts
+++ b/app/api/Auth/me/route.ts
@@ -6,6 +6,7 @@ import { shouldUseUpstreamAuth } from "@/lib/server/auth-mode";
 import { createBackendUrl } from "@/lib/server/backend-url";
 import { syncMockUserWorkspaceProfile } from "@/lib/server/mock-workspace-store";
 
+import { readMockUsersFromCookies, upsertMockUserCookie } from "../mock-user-cookie";
 import { toAuthPayload, updateMockUser } from "../mock-users";
 import {
   AUTH_COOKIE_NAME,
@@ -16,9 +17,10 @@ import {
 export const GET = async (request: NextRequest) => {
   const authHeader = request.headers.get("authorization");
   const cookieToken = request.cookies.get(AUTH_COOKIE_NAME)?.value;
+  const browserMockUsers = readMockUsersFromCookies(request.cookies);
   const token =
     authHeader?.replace(/^Bearer\s+/i, "").trim() || cookieToken || "";
-  const mockUser = token ? getUserFromSessionToken(token) : null;
+  const mockUser = token ? getUserFromSessionToken(token, browserMockUsers) : null;
 
   if (mockUser && token.startsWith("mock-token::")) {
     return NextResponse.json(sanitizeAuthPayload(toAuthPayload(mockUser)), {
@@ -67,9 +69,10 @@ export const GET = async (request: NextRequest) => {
 export const PATCH = async (request: NextRequest) => {
   const authHeader = request.headers.get("authorization");
   const cookieToken = request.cookies.get(AUTH_COOKIE_NAME)?.value;
+  const browserMockUsers = readMockUsersFromCookies(request.cookies);
   const token =
     authHeader?.replace(/^Bearer\s+/i, "").trim() || cookieToken || "";
-  const mockUser = token ? getUserFromSessionToken(token) : null;
+  const mockUser = token ? getUserFromSessionToken(token, browserMockUsers) : null;
   const body = (await request.json().catch(() => null)) as
     | { firstName?: unknown; lastName?: unknown; organizationName?: unknown }
     | null;
@@ -98,10 +101,13 @@ export const PATCH = async (request: NextRequest) => {
 
     syncMockUserWorkspaceProfile(updatedUser, { organizationName });
 
-    return NextResponse.json(
+    const response = NextResponse.json(
       sanitizeAuthPayload(toAuthPayload(updatedUser)),
       { status: 200 },
     );
+    upsertMockUserCookie(response.cookies, browserMockUsers, updatedUser);
+
+    return response;
   }
 
   if (!shouldUseUpstreamAuth()) {

--- a/app/api/Auth/mock-user-cookie.ts
+++ b/app/api/Auth/mock-user-cookie.ts
@@ -1,0 +1,87 @@
+import type { RequestCookies, ResponseCookies } from "next/dist/compiled/@edge-runtime/cookies";
+
+import type { IMockUser } from "./mock-users";
+
+export const MOCK_USER_REGISTRY_COOKIE_NAME = "autosales_mock_users";
+
+const MOCK_USER_REGISTRY_COOKIE_OPTIONS = {
+  httpOnly: true,
+  maxAge: 60 * 60 * 24 * 30,
+  path: "/",
+  sameSite: "lax" as const,
+  secure: process.env.NODE_ENV === "production",
+};
+
+const encodeRegistry = (users: IMockUser[]) =>
+  Buffer.from(JSON.stringify(users), "utf8").toString("base64url");
+
+const decodeRegistry = (value: string) => {
+  try {
+    const json = Buffer.from(value, "base64url").toString("utf8");
+    const parsed = JSON.parse(json);
+
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+const isMockUser = (value: unknown): value is IMockUser => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<IMockUser>;
+
+  return (
+    typeof candidate.email === "string" &&
+    typeof candidate.firstName === "string" &&
+    typeof candidate.id === "string" &&
+    typeof candidate.lastName === "string" &&
+    typeof candidate.password === "string" &&
+    typeof candidate.role === "string" &&
+    typeof candidate.tenantId === "string" &&
+    typeof candidate.tenantName === "string"
+  );
+};
+
+export const readMockUsersFromCookies = (cookies: RequestCookies): IMockUser[] => {
+  const value = cookies.get(MOCK_USER_REGISTRY_COOKIE_NAME)?.value;
+
+  if (!value) {
+    return [];
+  }
+
+  return decodeRegistry(value).filter(isMockUser).map((user) => ({
+    ...user,
+    clientIds: Array.isArray(user.clientIds)
+      ? user.clientIds.filter((clientId): clientId is string => typeof clientId === "string")
+      : [],
+    email: user.email.trim().toLowerCase(),
+  }));
+};
+
+export const writeMockUsersCookie = (
+  cookies: ResponseCookies,
+  users: IMockUser[],
+) => {
+  cookies.set(
+    MOCK_USER_REGISTRY_COOKIE_NAME,
+    encodeRegistry(users),
+    MOCK_USER_REGISTRY_COOKIE_OPTIONS,
+  );
+};
+
+export const upsertMockUserCookie = (
+  cookies: ResponseCookies,
+  existingUsers: IMockUser[],
+  user: IMockUser,
+) => {
+  const normalizedEmail = user.email.trim().toLowerCase();
+  const nextUsers = [
+    ...existingUsers.filter((item) => item.email.trim().toLowerCase() !== normalizedEmail),
+    { ...user, email: normalizedEmail },
+  ];
+
+  writeMockUsersCookie(cookies, nextUsers);
+};

--- a/app/api/Auth/mock-users.ts
+++ b/app/api/Auth/mock-users.ts
@@ -232,14 +232,28 @@ let nextId = deriveNextId();
 
 export const findUserByEmail = (email: string) => users.get(email.toLowerCase());
 
+export const findMockUserByEmail = (
+  email: string,
+  additionalUsers: IMockUser[] = [],
+) =>
+  additionalUsers.find((user) => user.email.toLowerCase() === email.toLowerCase()) ??
+  findUserByEmail(email);
+
 export const createMockToken = (email: string) =>
   `mock-token::${email.toLowerCase()}::${Date.now()}`;
 
-export const getUserFromToken = (token: string) => {
+export const getMockUserEmailFromToken = (token: string) => {
   const parts = token.split("::");
-  const email = parts[1];
+  return parts[1]?.toLowerCase() ?? "";
+};
 
-  return email ? findUserByEmail(email) : undefined;
+export const getUserFromToken = (
+  token: string,
+  additionalUsers: IMockUser[] = [],
+) => {
+  const email = getMockUserEmailFromToken(token);
+
+  return email ? findMockUserByEmail(email, additionalUsers) : undefined;
 };
 
 export const registerMockUser = ({
@@ -247,6 +261,7 @@ export const registerMockUser = ({
   firstName,
   lastName,
   password,
+  clientIds,
   role,
   tenantId,
   tenantName,
@@ -255,6 +270,7 @@ export const registerMockUser = ({
   firstName: string;
   lastName: string;
   password: string;
+  clientIds?: string[];
   role: MockUserRole;
   tenantId?: string;
   tenantName?: string;
@@ -275,7 +291,7 @@ export const registerMockUser = ({
     (normalizedTenantId ? findTenantNameById(normalizedTenantId) || normalizedTenantId : SHARED_DEMO_TENANT_NAME);
 
   const user: IMockUser = {
-    clientIds: [],
+    clientIds: clientIds ?? [],
     email: normalizedEmail,
     firstName,
     id: String(nextId++),
@@ -295,7 +311,7 @@ export const registerMockUser = ({
 
 export const updateMockUser = (
   email: string,
-  updates: Partial<Pick<IMockUser, "firstName" | "lastName" | "tenantName">>,
+  updates: Partial<Pick<IMockUser, "clientIds" | "firstName" | "lastName" | "tenantName">>,
 ) => {
   const normalizedEmail = email.toLowerCase();
   const existingUser = users.get(normalizedEmail);
@@ -306,6 +322,7 @@ export const updateMockUser = (
 
   const nextUser: IMockUser = {
     ...existingUser,
+    clientIds: updates.clientIds ?? existingUser.clientIds,
     firstName: updates.firstName ?? existingUser.firstName,
     lastName: updates.lastName ?? existingUser.lastName,
     tenantName: updates.tenantName ?? existingUser.tenantName,

--- a/app/api/Auth/register/route.ts
+++ b/app/api/Auth/register/route.ts
@@ -2,10 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { shouldUseUpstreamAuth } from "@/lib/server/auth-mode";
 import { createBackendUrl } from "@/lib/server/backend-url";
+import { provisionMockClientWorkspace } from "@/lib/server/mock-workspace-store";
 
+import { readMockUsersFromCookies, upsertMockUserCookie } from "../mock-user-cookie";
 import {
   registerMockUser,
   toAuthPayload,
+  updateMockUser,
   type MockUserRole,
 } from "../mock-users";
 import {
@@ -21,13 +24,18 @@ const readJsonBody = async (response: Response) => {
     return {} as Record<string, unknown>;
   }
 
-  return JSON.parse(text) as Record<string, unknown>;
+  try {
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return { message: text } as Record<string, unknown>;
+  }
 };
 
 export async function POST(request: NextRequest) {
   const rawBody = await request.text();
 
   if (!shouldUseUpstreamAuth()) {
+    const browserMockUsers = readMockUsersFromCookies(request.cookies);
     const payload = JSON.parse(rawBody) as {
       email?: unknown;
       firstName?: unknown;
@@ -62,6 +70,16 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    if (role !== "Client") {
+      return NextResponse.json(
+        {
+          message:
+            "Public registration is limited to client accounts. Employee accounts must be created by an administrator.",
+        },
+        { status: 403 },
+      );
+    }
+
     const user = registerMockUser({
       email,
       firstName,
@@ -79,11 +97,26 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const responsePayload = toAuthPayload(user);
+    const resolvedUser =
+      role === "Client"
+        ? (() => {
+            const client = provisionMockClientWorkspace(user, {
+              organizationName: tenantName || user.tenantName,
+            });
+
+            return (
+              updateMockUser(user.email, {
+                clientIds: [client.id],
+              }) ?? user
+            );
+          })()
+        : user;
+    const responsePayload = toAuthPayload(resolvedUser);
     const response = NextResponse.json(
       sanitizeAuthPayload(responsePayload),
       { status: 200 },
     );
+    upsertMockUserCookie(response.cookies, browserMockUsers, resolvedUser);
 
     if (responsePayload.token) {
       response.cookies.set(

--- a/components/auth/register-form.styles.ts
+++ b/components/auth/register-form.styles.ts
@@ -18,6 +18,11 @@ export const useStyles = createStyles(({ token, css }) => ({
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   `,
+  helperText: css`
+    color: ${token.colorTextDescription} !important;
+    margin-bottom: ${token.marginLG}px !important;
+    margin-top: -${token.marginSM}px !important;
+  `,
   intro: css`
     display: flex;
     flex-direction: column;

--- a/components/auth/register-form.tsx
+++ b/components/auth/register-form.tsx
@@ -6,7 +6,6 @@ import { useAuthActions, useAuthState } from "@/providers/authProvider";
 import { useStyles } from "./register-form.styles";
 
 type RegistrationScenario = "existing-tenant" | "new-tenant" | "shared-tenant";
-type RegistrationRole = "SalesRep" | "SalesManager" | "BusinessDevelopmentManager";
 
 type RegisterValues = {
   email: string;
@@ -14,7 +13,6 @@ type RegisterValues = {
   lastName: string;
   password: string;
   phoneNumber?: string;
-  role?: RegistrationRole;
   scenario: RegistrationScenario;
   tenantId?: string;
   tenantName?: string;
@@ -24,8 +22,15 @@ export const RegisterForm = () => {
   const { styles } = useStyles();
   const [form] = Form.useForm<RegisterValues>();
   const { register } = useAuthActions();
-  const { isError, isPending } = useAuthState();
+  const { errorMessage, isError, isPending } = useAuthState();
   const scenario = Form.useWatch("scenario", form) ?? "new-tenant";
+
+  const scenarioDescription =
+    scenario === "new-tenant"
+      ? "Create a client account and a client workspace for your organisation. Internal employee accounts should be created by an admin."
+      : scenario === "existing-tenant"
+        ? "Use this if someone has already given you a tenant ID and you need client access to that existing workspace."
+        : "Use the shared demo workspace for testing the product without creating a separate organisation.";
 
   const onFinish = async (values: RegisterValues) => {
     const { scenario: nextScenario, ...rest } = values;
@@ -33,7 +38,7 @@ export const RegisterForm = () => {
     if (nextScenario === "new-tenant") {
       await register({
         ...rest,
-        role: undefined,
+        role: "Client",
         tenantId: undefined,
         tenantName: values.tenantName,
       });
@@ -43,7 +48,7 @@ export const RegisterForm = () => {
     if (nextScenario === "existing-tenant") {
       await register({
         ...rest,
-        role: values.role,
+        role: "Client",
         tenantId: values.tenantId,
         tenantName: undefined,
       });
@@ -52,7 +57,7 @@ export const RegisterForm = () => {
 
     await register({
       ...rest,
-      role: values.role,
+      role: "Client",
       tenantId: undefined,
       tenantName: undefined,
     });
@@ -62,24 +67,24 @@ export const RegisterForm = () => {
     <Card className={styles.card}>
       <div className={styles.intro}>
         <Typography.Title level={2} className={styles.title}>
-          Create your workspace
+          Create your client account
         </Typography.Title>
         <Typography.Paragraph className={styles.mutedText}>
-          Create a new organisation, join an existing tenant, or use the shared test workspace.
+          Register for client access to messages, documents, proposals, contracts, profile, and assistant support.
         </Typography.Paragraph>
       </div>
 
       {isError ? (
         <Alert
           className={styles.alert}
-          message="We could not create your account right now."
+          message={errorMessage || "We could not create your account right now."}
           type="error"
         />
       ) : null}
 
       <Form
         form={form}
-        initialValues={{ role: "SalesRep", scenario: "new-tenant" }}
+        initialValues={{ scenario: "new-tenant" }}
         layout="vertical"
         onFinish={onFinish}
         requiredMark={false}
@@ -98,6 +103,12 @@ export const RegisterForm = () => {
             size="large"
           />
         </Form.Item>
+        <Typography.Paragraph className={styles.helperText}>
+          {scenarioDescription}
+        </Typography.Paragraph>
+        <Typography.Paragraph className={styles.helperText}>
+          Public signup creates client-scoped access only. Employee and admin accounts must be created internally by an administrator.
+        </Typography.Paragraph>
 
         <div className={styles.fieldsGrid}>
           <Form.Item
@@ -149,27 +160,6 @@ export const RegisterForm = () => {
             >
               <Input
                 placeholder="11111111-1111-1111-1111-111111111111"
-                size="large"
-              />
-            </Form.Item>
-          ) : null}
-
-          {scenario !== "new-tenant" ? (
-            <Form.Item
-              label="Role"
-              name="role"
-              rules={[{ message: "Role is required", required: true }]}
-            >
-              <Select
-                options={[
-                  { label: "Sales Rep", value: "SalesRep" },
-                  { label: "Sales Manager", value: "SalesManager" },
-                  {
-                    label: "Business Development Manager",
-                    value: "BusinessDevelopmentManager",
-                  },
-                ]}
-                placeholder="Choose a role"
                 size="large"
               />
             </Form.Item>

--- a/lib/auth/session-user.ts
+++ b/lib/auth/session-user.ts
@@ -151,5 +151,8 @@ const getJwtUserFromToken = (token: string): IMockUser | null => {
   };
 };
 
-export const getUserFromSessionToken = (token: string): IMockUser | null =>
-  getUserFromToken(token) ?? getJwtUserFromToken(token) ?? null;
+export const getUserFromSessionToken = (
+  token: string,
+  additionalUsers: IMockUser[] = [],
+): IMockUser | null =>
+  getUserFromToken(token, additionalUsers) ?? getJwtUserFromToken(token) ?? null;

--- a/lib/server/mock-workspace-store.ts
+++ b/lib/server/mock-workspace-store.ts
@@ -294,6 +294,41 @@ export const createMockContact = (user: IMockUser, input: Omit<IContact, "id">) 
   return clone(contact);
 };
 
+export const provisionMockClientWorkspace = (
+  user: IMockUser,
+  options: {
+    organizationName?: string;
+  } = {},
+) => {
+  const workspace = getWorkspaceState(user.tenantId);
+  const existingClient = workspace.salesData.clients.find(
+    (item) => (user.clientIds ?? []).includes(item.id),
+  );
+
+  if (existingClient) {
+    return clone(existingClient);
+  }
+
+  const organizationName = options.organizationName?.trim() || user.tenantName || `${user.firstName} ${user.lastName}`.trim();
+  const client = createMockClient(user, {
+    industry: "General",
+    name: organizationName,
+  });
+
+  createMockContact(user, {
+    clientId: client.id,
+    createdAt: new Date().toISOString(),
+    email: user.email,
+    firstName: user.firstName,
+    isPrimaryContact: true,
+    lastName: user.lastName,
+    phoneNumber: undefined,
+    position: "Primary contact",
+  });
+
+  return client;
+};
+
 export const updateMockContact = (
   tenantId: string,
   contactId: string,

--- a/providers/authProvider/actions.tsx
+++ b/providers/authProvider/actions.tsx
@@ -23,6 +23,7 @@ export enum AuthActionEnums {
 export const loginPending = createAction<Partial<IAuthStateContext>>(
   AuthActionEnums.loginPending,
   () => ({
+    errorMessage: null,
     isError: false,
     isPending: true,
     isSuccess: false,
@@ -44,9 +45,13 @@ export const loginSuccess = createAction<
   }),
 );
 
-export const loginError = createAction<Partial<IAuthStateContext>>(
+export const loginError = createAction<
+  Partial<IAuthStateContext>,
+  string | undefined
+>(
   AuthActionEnums.loginError,
-  () => ({
+  (errorMessage?: string) => ({
+    errorMessage: errorMessage ?? "Unable to sign in.",
     isAuthenticated: false,
     isError: true,
     isPending: false,
@@ -58,6 +63,7 @@ export const loginError = createAction<Partial<IAuthStateContext>>(
 export const registerPending = createAction<Partial<IAuthStateContext>>(
   AuthActionEnums.registerPending,
   () => ({
+    errorMessage: null,
     isError: false,
     isPending: true,
     isSuccess: false,
@@ -79,9 +85,13 @@ export const registerSuccess = createAction<
   }),
 );
 
-export const registerError = createAction<Partial<IAuthStateContext>>(
+export const registerError = createAction<
+  Partial<IAuthStateContext>,
+  string | undefined
+>(
   AuthActionEnums.registerError,
-  () => ({
+  (errorMessage?: string) => ({
+    errorMessage: errorMessage ?? "Unable to create your account.",
     isAuthenticated: false,
     isError: true,
     isPending: false,
@@ -93,6 +103,7 @@ export const registerError = createAction<Partial<IAuthStateContext>>(
 export const logoutPending = createAction<Partial<IAuthStateContext>>(
   AuthActionEnums.logoutPending,
   () => ({
+    errorMessage: null,
     isAuthenticated: false,
     isError: false,
     isPending: true,
@@ -103,6 +114,7 @@ export const logoutPending = createAction<Partial<IAuthStateContext>>(
 export const logoutSuccess = createAction<Partial<IAuthStateContext>>(
   AuthActionEnums.logoutSuccess,
   () => ({
+    errorMessage: null,
     isAuthenticated: false,
     isError: false,
     isPending: false,
@@ -114,6 +126,7 @@ export const logoutSuccess = createAction<Partial<IAuthStateContext>>(
 export const logoutError = createAction<Partial<IAuthStateContext>>(
   AuthActionEnums.logoutError,
   () => ({
+    errorMessage: null,
     isAuthenticated: false,
     isError: true,
     isPending: false,
@@ -125,6 +138,7 @@ export const logoutError = createAction<Partial<IAuthStateContext>>(
 export const getMePending = createAction<Partial<IAuthStateContext>>(
   AuthActionEnums.getMePending,
   () => ({
+    errorMessage: null,
     isAuthenticated: false,
     isError: false,
     isPending: true,
@@ -138,6 +152,7 @@ export const getMeSuccess = createAction<
 >(
   AuthActionEnums.getMeSuccess,
   (user: IUserLoginResponse) => ({
+    errorMessage: null,
     isAuthenticated: true,
     isError: false,
     isPending: false,
@@ -149,6 +164,7 @@ export const getMeSuccess = createAction<
 export const getMeError = createAction<Partial<IAuthStateContext>>(
   AuthActionEnums.getMeError,
   () => ({
+    errorMessage: null,
     isAuthenticated: false,
     isError: true,
     isPending: false,

--- a/providers/authProvider/context.tsx
+++ b/providers/authProvider/context.tsx
@@ -13,6 +13,7 @@ export type IUserRegisterRequest = AuthRegisterRequestDto;
 export type IUserLoginResponse = AuthSessionUser;
 
 export interface IAuthStateContext {
+  errorMessage?: string | null;
   isAuthenticated: boolean;
   isError: boolean;
   isPending: boolean;
@@ -28,6 +29,7 @@ export interface IAuthActionContext {
 }
 
 export const INITIAL_STATE: IAuthStateContext = {
+  errorMessage: null,
   isAuthenticated: false,
   isError: false,
   isPending: true,

--- a/providers/authProvider/index.tsx
+++ b/providers/authProvider/index.tsx
@@ -44,6 +44,18 @@ class AuthRequestError extends Error {
   }
 }
 
+const getErrorMessage = (error: unknown, fallback: string) => {
+  if (error instanceof AuthRequestError) {
+    return error.message || fallback;
+  }
+
+  if (error instanceof Error) {
+    return error.message || fallback;
+  }
+
+  return fallback;
+};
+
 export const useAuthState = () => {
   const context = useContext(AuthStateContext);
 
@@ -145,7 +157,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         );
       })
       .catch((error: unknown) => {
-        dispatch(loginError());
+        dispatch(loginError(getErrorMessage(error, "Unable to sign in.")));
         console.error(error);
       });
   };
@@ -165,7 +177,9 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         );
       })
       .catch((error: unknown) => {
-        dispatch(registerError());
+        dispatch(
+          registerError(getErrorMessage(error, "We could not create your account right now.")),
+        );
         console.error(error);
       });
   };


### PR DESCRIPTION
Fixes #294

## Summary
Lock public registration down to client accounts and make deployed mock registrations durable for the same browser so signup and login work reliably on the deployed mock site.

## Scope
- restrict public signup to client accounts only
- reject employee role self-registration server-side
- improve registration flow copy so the public path is clearly client-only
- persist deployed mock accounts in a browser-backed registry for login and session restore
- provision client-scoped workspace linkage for new client signups
- surface backend auth errors more clearly during login and registration

## Verification
- npm run build
