### PR TITLE
fix: surface login auth errors on sign-in

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -13,7 +13,7 @@ type LoginValues = {
 export const LoginForm = () => {
   const { styles } = useStyles();
   const { login } = useAuthActions();
-  const { isError, isPending } = useAuthState();
+  const { errorMessage, isError, isPending } = useAuthState();
   const [form] = Form.useForm<LoginValues>();
 
   const onFinish = async (values: LoginValues) => {
@@ -34,7 +34,7 @@ export const LoginForm = () => {
       {isError ? (
         <Alert
           className={styles.alert}
-          message="We could not sign you in with those credentials."
+          message={errorMessage || "We could not sign you in with those credentials."}
           type="error"
         />
       ) : null}


### PR DESCRIPTION
Fixes #296

## Summary
Show the actual authentication failure message on the login form instead of always falling back to a generic sign-in error.

## Scope
- surface provider auth error messages on the login form
- keep the existing login flow unchanged otherwise

## Verification
- npm run build
