### PR TITLE
fix: resolve browser-created mock clients in backend auth paths

### DIFF
--- a/app/api/backend/[...path]/route.ts
+++ b/app/api/backend/[...path]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { readMockUsersFromCookies } from "@/app/api/Auth/mock-user-cookie";
 import { AUTH_COOKIE_NAME, AUTH_COOKIE_OPTIONS } from "@/app/api/Auth/session-cookie";
 import { type IMockUser } from "@/app/api/Auth/mock-users";
 import { getUserFromSessionToken } from "@/lib/auth/session-user";
@@ -111,8 +112,11 @@ const proxyRequest = async (
   const { path } = await context.params;
   const cookieToken = request.cookies.get(AUTH_COOKIE_NAME)?.value;
   const bearerToken = request.headers.get("authorization")?.replace(/^Bearer\s+/i, "").trim();
+  const browserMockUsers = readMockUsersFromCookies(request.cookies);
   const sessionToken = cookieToken || bearerToken || "";
-  const mockUser = sessionToken ? getUserFromSessionToken(sessionToken) : null;
+  const mockUser = sessionToken
+    ? getUserFromSessionToken(sessionToken, browserMockUsers)
+    : null;
 
   if (mockUser && sessionToken.startsWith("mock-token::")) {
     return handleMockRequest(request, path, mockUser);

--- a/lib/server/assistant-auth.ts
+++ b/lib/server/assistant-auth.ts
@@ -3,6 +3,7 @@ import "server-only";
 import type { NextRequest } from "next/server";
 
 import { createBackendUrl } from "@/lib/server/backend-url";
+import { readMockUsersFromCookies } from "@/app/api/Auth/mock-user-cookie";
 import type { IMockUser } from "@/app/api/Auth/mock-users";
 import { AUTH_COOKIE_NAME } from "@/app/api/Auth/session-cookie";
 import type { AuthSessionUser } from "@/lib/auth/auth-contract";
@@ -61,12 +62,13 @@ const fetchAuthorizedUserFromBackend = async (token: string) => {
 export const getAuthorizedUser = async (request: NextRequest): Promise<IMockUser | null> => {
   const cookieToken = request.cookies.get(AUTH_COOKIE_NAME)?.value;
   const authHeader = request.headers.get("authorization");
+  const browserMockUsers = readMockUsersFromCookies(request.cookies);
   const token = authHeader?.startsWith("Bearer ")
     ? authHeader.slice("Bearer ".length).trim()
     : cookieToken?.trim() ?? "";
 
   if (cookieToken) {
-    const directUser = getUserFromSessionToken(cookieToken);
+    const directUser = getUserFromSessionToken(cookieToken, browserMockUsers);
 
     if (directUser && (directUser.clientIds?.length ?? 0) > 0) {
       return directUser;
@@ -77,7 +79,7 @@ export const getAuthorizedUser = async (request: NextRequest): Promise<IMockUser
     return null;
   }
 
-  const directUser = getUserFromSessionToken(token);
+  const directUser = getUserFromSessionToken(token, browserMockUsers);
   const enrichedUser = await fetchAuthorizedUserFromBackend(token);
 
   if (enrichedUser) {


### PR DESCRIPTION
Fixes #298

## Summary
Fix backend-side mock session resolution so browser-created client accounts are recognized consistently across protected backend routes, assistant auth, and session restore flows.

## Scope
- read the browser mock-user registry during backend auth resolution
- keep protected backend proxy routes aligned with /api/Auth/me session lookup
- keep assistant authorization aligned with browser-created mock clients

## Verification
- npm run build
