### PR TITLE
fix: add mock auth diagnostics for deployed login failures

### DIFF
--- a/app/api/Auth/login/route.ts
+++ b/app/api/Auth/login/route.ts
@@ -5,7 +5,7 @@ import { shouldUseUpstreamAuth } from "@/lib/server/auth-mode";
 import { createBackendUrl } from "@/lib/server/backend-url";
 
 import { readMockUsersFromCookies } from "../mock-user-cookie";
-import { findMockUserByEmail, toAuthPayload } from "../mock-users";
+import { findMockUserByEmail, findUserByEmail, toAuthPayload } from "../mock-users";
 import {
   AUTH_COOKIE_NAME,
   AUTH_COOKIE_OPTIONS,
@@ -31,7 +31,11 @@ export const POST = async (request: NextRequest) => {
   const credentials = JSON.parse(rawBody) as AuthLoginRequestDto;
   const email = credentials.email?.trim().toLowerCase() ?? "";
   const browserMockUsers = readMockUsersFromCookies(request.cookies);
-  const mockUser = email ? findMockUserByEmail(email, browserMockUsers) : undefined;
+  const browserMockUser = email
+    ? browserMockUsers.find((user) => user.email === email)
+    : undefined;
+  const builtInMockUser = email ? findUserByEmail(email) : undefined;
+  const mockUser = browserMockUser ?? builtInMockUser;
 
   if (mockUser && credentials.password === mockUser.password) {
     const payload = toAuthPayload(mockUser);
@@ -51,6 +55,23 @@ export const POST = async (request: NextRequest) => {
   }
 
   if (!shouldUseUpstreamAuth()) {
+    if (browserMockUser) {
+      return NextResponse.json(
+        { message: "Incorrect password for this client account." },
+        { status: 401 },
+      );
+    }
+
+    if (!builtInMockUser && email) {
+      return NextResponse.json(
+        {
+          message:
+            "No registered client account was found for this email in this browser on this site URL.",
+        },
+        { status: 401 },
+      );
+    }
+
     return NextResponse.json(
       { message: "Invalid email or password." },
       { status: 401 },

--- a/app/api/Auth/status/route.ts
+++ b/app/api/Auth/status/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { readMockUsersFromCookies } from "../mock-user-cookie";
+import {
+  AUTH_COOKIE_NAME,
+  sanitizeAuthPayload,
+} from "../session-cookie";
+import {
+  findMockUserByEmail,
+  getMockUserEmailFromToken,
+  toAuthPayload,
+} from "../mock-users";
+
+export const GET = async (request: NextRequest) => {
+  const authHeader = request.headers.get("authorization");
+  const cookieToken = request.cookies.get(AUTH_COOKIE_NAME)?.value?.trim() ?? "";
+  const browserMockUsers = readMockUsersFromCookies(request.cookies);
+  const token =
+    authHeader?.replace(/^Bearer\s+/i, "").trim() || cookieToken || "";
+  const mockSessionEmail = token.startsWith("mock-token::")
+    ? getMockUserEmailFromToken(token)
+    : "";
+  const resolvedMockUser = mockSessionEmail
+    ? findMockUserByEmail(mockSessionEmail, browserMockUsers)
+    : undefined;
+
+  return NextResponse.json({
+    authCookiePresent: Boolean(cookieToken),
+    mockRegistryCookiePresent:
+      request.cookies.get("autosales_mock_users")?.value?.trim().length
+        ? true
+        : false,
+    mockRegistryUserCount: browserMockUsers.length,
+    mockSessionEmail: mockSessionEmail || null,
+    resolvedMockSession: resolvedMockUser
+      ? sanitizeAuthPayload(toAuthPayload(resolvedMockUser))
+      : null,
+    storedMockEmails: browserMockUsers.map((user) => user.email),
+  });
+};


### PR DESCRIPTION
Fixes #302

## Summary
Add a lightweight auth status endpoint and clearer mock-login failure messages so deployed mock auth failures can be diagnosed precisely.

## Scope
- add an auth status route for inspecting mock session and browser-backed mock user state
- distinguish missing registered mock accounts from incorrect passwords during login
- keep the existing auth flow unchanged otherwise

## Verification
- npm run build
