### PR TITLE
fix: add full request and message CRUD for clients and sales reps

### DIFF
--- a/app/api/service-requests/[requestId]/messages/[messageId]/route.ts
+++ b/app/api/service-requests/[requestId]/messages/[messageId]/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAuthorizedUser } from "@/lib/server/assistant-auth";
+import { getRequestSessionToken, isLiveSessionToken } from "@/lib/server/request-session-token";
+import {
+  deleteLiveServiceRequestMessage,
+  updateLiveServiceRequestMessage,
+} from "@/lib/server/service-request-backend-store";
+import {
+  deleteServiceRequestMessage,
+  updateServiceRequestMessage,
+} from "@/lib/server/service-request-store";
+
+export const runtime = "nodejs";
+
+export async function PATCH(
+  request: NextRequest,
+  context: { params: Promise<{ messageId: string; requestId: string }> },
+) {
+  const user = await getAuthorizedUser(request);
+  const token = getRequestSessionToken(request);
+
+  if (!user) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { messageId, requestId } = await context.params;
+    const body = (await request.json()) as {
+      content?: unknown;
+    };
+
+    const content = typeof body.content === "string" ? body.content : "";
+    const detail = isLiveSessionToken(token)
+      ? await updateLiveServiceRequestMessage(user, token, requestId, messageId, {
+          content,
+        })
+      : updateServiceRequestMessage(user, requestId, messageId, {
+          content,
+        });
+
+    return NextResponse.json(detail);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "The service request message could not be updated.";
+    const status =
+      /not found/i.test(message) ? 404 : /access|unauthorized|only/i.test(message) ? 403 : 400;
+    return NextResponse.json({ message }, { status });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  context: { params: Promise<{ messageId: string; requestId: string }> },
+) {
+  const user = await getAuthorizedUser(request);
+  const token = getRequestSessionToken(request);
+
+  if (!user) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { messageId, requestId } = await context.params;
+    const detail = isLiveSessionToken(token)
+      ? await deleteLiveServiceRequestMessage(user, token, requestId, messageId)
+      : deleteServiceRequestMessage(user, requestId, messageId);
+
+    return NextResponse.json(detail);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "The service request message could not be deleted.";
+    const status =
+      /not found/i.test(message) ? 404 : /access|unauthorized|only/i.test(message) ? 403 : 400;
+    return NextResponse.json({ message }, { status });
+  }
+}

--- a/app/api/service-requests/[requestId]/route.ts
+++ b/app/api/service-requests/[requestId]/route.ts
@@ -2,8 +2,17 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { getAuthorizedUser } from "@/lib/server/assistant-auth";
 import { getRequestSessionToken, isLiveSessionToken } from "@/lib/server/request-session-token";
-import { getLiveServiceRequestDetail } from "@/lib/server/service-request-backend-store";
-import { getServiceRequestDetail } from "@/lib/server/service-request-store";
+import {
+  deleteLiveServiceRequest,
+  getLiveServiceRequestDetail,
+  updateLiveServiceRequest,
+} from "@/lib/server/service-request-backend-store";
+import {
+  deleteServiceRequest,
+  getServiceRequestDetail,
+  type ServiceRequestPriority,
+  updateServiceRequest,
+} from "@/lib/server/service-request-store";
 
 export const runtime = "nodejs";
 
@@ -28,6 +37,89 @@ export async function GET(
     const message =
       error instanceof Error ? error.message : "The service request could not be loaded.";
     const status = /not found/i.test(message) ? 404 : /access/i.test(message) ? 403 : 400;
+    return NextResponse.json({ message }, { status });
+  }
+}
+
+const VALID_PRIORITIES = new Set<ServiceRequestPriority>([
+  "low",
+  "medium",
+  "high",
+  "critical",
+]);
+
+export async function PATCH(
+  request: NextRequest,
+  context: { params: Promise<{ requestId: string }> },
+) {
+  const user = await getAuthorizedUser(request);
+  const token = getRequestSessionToken(request);
+
+  if (!user) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { requestId } = await context.params;
+    const body = (await request.json()) as {
+      description?: unknown;
+      priority?: unknown;
+      requestType?: unknown;
+      title?: unknown;
+    };
+
+    const detail = isLiveSessionToken(token)
+      ? await updateLiveServiceRequest(user, token, requestId, {
+          description: typeof body.description === "string" ? body.description : undefined,
+          priority:
+            typeof body.priority === "string" && VALID_PRIORITIES.has(body.priority as ServiceRequestPriority)
+              ? (body.priority as ServiceRequestPriority)
+              : undefined,
+          requestType: typeof body.requestType === "string" ? body.requestType : undefined,
+          title: typeof body.title === "string" ? body.title : undefined,
+        })
+      : updateServiceRequest(user, requestId, {
+          description: typeof body.description === "string" ? body.description : undefined,
+          priority:
+            typeof body.priority === "string" && VALID_PRIORITIES.has(body.priority as ServiceRequestPriority)
+              ? (body.priority as ServiceRequestPriority)
+              : undefined,
+          requestType: typeof body.requestType === "string" ? body.requestType : undefined,
+          title: typeof body.title === "string" ? body.title : undefined,
+        });
+
+    return NextResponse.json(detail);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "The service request could not be updated.";
+    const status =
+      /not found/i.test(message) ? 404 : /access|unauthorized|only/i.test(message) ? 403 : 400;
+    return NextResponse.json({ message }, { status });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  context: { params: Promise<{ requestId: string }> },
+) {
+  const user = await getAuthorizedUser(request);
+  const token = getRequestSessionToken(request);
+
+  if (!user) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { requestId } = await context.params;
+    const deleted = isLiveSessionToken(token)
+      ? await deleteLiveServiceRequest(user, token, requestId)
+      : deleteServiceRequest(user, requestId);
+    return NextResponse.json(deleted);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "The service request could not be deleted.";
+    const status =
+      /not found/i.test(message) ? 404 : /access|unauthorized|only/i.test(message) ? 403 : 400;
     return NextResponse.json({ message }, { status });
   }
 }

--- a/components/dashboard/client-message-center.tsx
+++ b/components/dashboard/client-message-center.tsx
@@ -19,10 +19,14 @@ import {
   addServiceRequestMessage,
   applyServiceRequestClientDecision,
   createServiceRequest,
+  deleteServiceRequest,
+  deleteServiceRequestMessage,
   getServiceRequestDetail,
   listServiceRequests,
   type ServiceRequestDetail,
   type ServiceRequestRecord,
+  updateServiceRequest,
+  updateServiceRequestMessage,
 } from "@/lib/client/service-request-api";
 import { useAuthState } from "@/providers/authProvider";
 import { useClientState } from "@/providers/clientProvider";
@@ -36,6 +40,12 @@ type MessageFormValues = {
   content: string;
   subject: string;
 };
+
+type ComposerMode =
+  | "create_request"
+  | "create_follow_up"
+  | "edit_request"
+  | "edit_follow_up";
 
 const getStatusColor = (status: ServiceRequestRecord["status"]) => {
   switch (status) {
@@ -97,6 +107,15 @@ const formatEventSummary = (detail: ServiceRequestDetail | undefined) => {
   return null;
 };
 
+const getLatestClientEditableMessage = (
+  detail: ServiceRequestDetail | undefined,
+  userId: string | undefined,
+) =>
+  detail?.events.find(
+    (event) =>
+      event.eventType === "service_request_message_added" && event.actorUserId === userId,
+  ) ?? null;
+
 export const ClientMessageCenter = ({
   compact = false,
 }: ClientMessageCenterProps) => {
@@ -111,6 +130,8 @@ export const ClientMessageCenter = ({
     Record<string, ServiceRequestDetail>
   >({});
   const [activeRequest, setActiveRequest] = useState<ServiceRequestRecord | null>(null);
+  const [activeMessageId, setActiveMessageId] = useState<string | null>(null);
+  const [composerMode, setComposerMode] = useState<ComposerMode>("create_request");
   const [form] = Form.useForm<MessageFormValues>();
 
   const primaryClientId = user?.clientIds?.[0];
@@ -158,18 +179,40 @@ export const ClientMessageCenter = ({
     [compact, serviceRequests],
   );
 
-  const openComposer = (request?: ServiceRequestRecord) => {
+  const openComposer = (
+    mode: ComposerMode,
+    request?: ServiceRequestRecord,
+    detail?: ServiceRequestDetail,
+  ) => {
+    const editableMessage = getLatestClientEditableMessage(detail, user?.userId);
     form.setFieldsValue({
-      content: request ? "" : client ? `Hello, we need help with ${client.name}.` : "",
-      subject: request?.title ?? (client ? `${client.name} account request` : "Client account request"),
+      content:
+        mode === "edit_follow_up"
+          ? String(editableMessage?.payloadJson.content ?? "")
+          : mode === "edit_request"
+            ? request?.description ?? ""
+            : request
+              ? ""
+              : client
+                ? `Hello, we need help with ${client.name}.`
+                : "",
+      subject:
+        mode === "create_follow_up" || mode === "edit_follow_up"
+          ? request?.title ?? ""
+          : request?.title ??
+            (client ? `${client.name} account request` : "Client account request"),
     });
     setActiveRequest(request ?? null);
+    setActiveMessageId(mode === "edit_follow_up" ? editableMessage?.id ?? null : null);
+    setComposerMode(mode);
     setIsModalOpen(true);
   };
 
   const closeComposer = () => {
     setIsModalOpen(false);
     setActiveRequest(null);
+    setActiveMessageId(null);
+    setComposerMode("create_request");
     form.resetFields();
   };
 
@@ -182,7 +225,18 @@ export const ClientMessageCenter = ({
     setIsSubmitting(true);
 
     try {
-      if (activeRequest) {
+      if (composerMode === "edit_request" && activeRequest) {
+        await updateServiceRequest(activeRequest.id, {
+          description: values.content.trim(),
+          title: values.subject.trim(),
+        });
+        messageApi.success("Request updated.");
+      } else if (composerMode === "edit_follow_up" && activeRequest && activeMessageId) {
+        await updateServiceRequestMessage(activeRequest.id, activeMessageId, {
+          content: values.content.trim(),
+        });
+        messageApi.success("Follow-up updated.");
+      } else if (activeRequest) {
         const assignedRepresentativeUserIds =
           serviceRequestDetailsById[activeRequest.id]?.assignments.map(
             (assignment) => assignment.representativeUserId,
@@ -210,7 +264,13 @@ export const ClientMessageCenter = ({
     } catch (error) {
       console.error(error);
       messageApi.error(
-        activeRequest ? "Could not save the request follow-up." : "Could not submit the request.",
+        composerMode === "create_request"
+          ? "Could not submit the request."
+          : composerMode === "edit_request"
+            ? "Could not update the request."
+            : composerMode === "edit_follow_up"
+              ? "Could not update the follow-up."
+              : "Could not save the request follow-up.",
       );
     } finally {
       setIsSubmitting(false);
@@ -253,6 +313,46 @@ export const ClientMessageCenter = ({
     }
   };
 
+  const handleDeleteRequest = async (request: ServiceRequestRecord) => {
+    setIsSubmitting(true);
+
+    try {
+      await deleteServiceRequest(request.id);
+      await loadServiceRequests();
+      messageApi.success("Request deleted.");
+    } catch (error) {
+      console.error(error);
+      messageApi.error("Could not delete the request.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDeleteLatestFollowUp = async (
+    request: ServiceRequestRecord,
+    detail: ServiceRequestDetail | undefined,
+  ) => {
+    const latestClientMessage = getLatestClientEditableMessage(detail, user?.userId);
+
+    if (!latestClientMessage) {
+      messageApi.error("There is no client follow-up to delete on this request.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await deleteServiceRequestMessage(request.id, latestClientMessage.id);
+      await loadServiceRequests();
+      messageApi.success("Follow-up deleted.");
+    } catch (error) {
+      console.error(error);
+      messageApi.error("Could not delete the follow-up.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
     <Card className={styles.card}>
       {contextHolder}
@@ -267,7 +367,11 @@ export const ClientMessageCenter = ({
               Create real support requests and keep follow-ups attached to the same workflow thread.
             </Typography.Text>
           </div>
-          <Button icon={<MailOutlined />} onClick={() => openComposer()} type="primary">
+          <Button
+            icon={<MailOutlined />}
+            onClick={() => openComposer("create_request")}
+            type="primary"
+          >
             New request
           </Button>
         </div>
@@ -282,6 +386,7 @@ export const ClientMessageCenter = ({
             {requestThreads.map((request) => {
               const detail = serviceRequestDetailsById[request.id];
               const latestSummary = formatEventSummary(detail);
+              const latestClientMessage = getLatestClientEditableMessage(detail, user?.userId);
               const pendingClientAssignments =
                 detail?.assignments.filter(
                   (assignment) => assignment.status === "pending_client_approval",
@@ -324,10 +429,40 @@ export const ClientMessageCenter = ({
                         </>
                       ) : null}
                       <Button
+                        loading={isSubmitting}
+                        onClick={() => openComposer("edit_request", request)}
+                      >
+                        Edit request
+                      </Button>
+                      <Button
                         icon={<SendOutlined />}
-                        onClick={() => openComposer(request)}
+                        onClick={() => openComposer("create_follow_up", request)}
                       >
                         Follow up
+                      </Button>
+                      {latestClientMessage ? (
+                        <>
+                          <Button
+                            loading={isSubmitting}
+                            onClick={() => openComposer("edit_follow_up", request, detail)}
+                          >
+                            Edit follow-up
+                          </Button>
+                          <Button
+                            danger
+                            loading={isSubmitting}
+                            onClick={() => void handleDeleteLatestFollowUp(request, detail)}
+                          >
+                            Delete follow-up
+                          </Button>
+                        </>
+                      ) : null}
+                      <Button
+                        danger
+                        loading={isSubmitting}
+                        onClick={() => void handleDeleteRequest(request)}
+                      >
+                        Delete request
                       </Button>
                     </Space>
                   </div>
@@ -353,12 +488,28 @@ export const ClientMessageCenter = ({
         onCancel={closeComposer}
         onOk={() => form.submit()}
         okButtonProps={{ loading: isSubmitting }}
-        okText={activeRequest ? "Send follow-up" : "Submit request"}
+        okText={
+          composerMode === "create_request"
+            ? "Submit request"
+            : composerMode === "edit_request"
+              ? "Save request"
+              : composerMode === "edit_follow_up"
+                ? "Save follow-up"
+                : "Send follow-up"
+        }
         open={isModalOpen}
-        title={activeRequest ? "Follow up on request" : "Create support request"}
+        title={
+          composerMode === "create_request"
+            ? "Create support request"
+            : composerMode === "edit_request"
+              ? "Edit request"
+              : composerMode === "edit_follow_up"
+                ? "Edit follow-up"
+                : "Follow up on request"
+        }
       >
         <Form className={styles.modalForm} form={form} layout="vertical" onFinish={handleSubmit}>
-          {activeRequest ? null : (
+          {composerMode === "create_follow_up" || composerMode === "edit_follow_up" ? null : (
             <Form.Item
               label="Subject"
               name="subject"
@@ -369,7 +520,11 @@ export const ClientMessageCenter = ({
           )}
 
           <Form.Item
-            label={activeRequest ? "Follow-up message" : "Request details"}
+            label={
+              composerMode === "create_request" || composerMode === "edit_request"
+                ? "Request details"
+                : "Follow-up message"
+            }
             name="content"
             rules={[{ message: "Please enter your message", required: true }]}
           >

--- a/components/dashboard/messages-panel.tsx
+++ b/components/dashboard/messages-panel.tsx
@@ -27,12 +27,16 @@ import {
   addServiceRequestMessage,
   applyServiceRequestRepresentativeDecision,
   createServiceRequestAssignments,
+  deleteServiceRequest,
+  deleteServiceRequestMessage,
   getServiceRequestDetail,
   listServiceRequests,
   type ServiceRequestMessageRecipientType,
   type ServiceRequestAssignmentRecord,
   type ServiceRequestDetail,
   type ServiceRequestRecord,
+  updateServiceRequest,
+  updateServiceRequestMessage,
 } from "@/lib/client/service-request-api";
 import { clearSessionDraft } from "@/lib/client/session-drafts";
 import { useMounted } from "@/lib/client/use-mounted";
@@ -68,6 +72,12 @@ type MessageFormValues = {
 type AssignmentFormValues = {
   representativeIds: string[];
 };
+
+type ReplyComposerMode =
+  | "create_note_reply"
+  | "create_service_request_reply"
+  | "edit_service_request"
+  | "edit_service_request_reply";
 
 const createMessageId = () =>
   `workspace-message-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
@@ -164,6 +174,15 @@ const getServiceRequestMessageRecipientSummary = (payload: Record<string, unknow
   return "To client";
 };
 
+const getLatestEditableServiceRequestMessage = (
+  detail: ServiceRequestDetail | null | undefined,
+  userId: string | undefined,
+) =>
+  detail?.events.find(
+    (event) =>
+      event.eventType === "service_request_message_added" && event.actorUserId === userId,
+  ) ?? null;
+
 type MessagePanelContentProps = Readonly<{
   initialClientId: string;
   initialRepresentativeId: string;
@@ -199,6 +218,11 @@ function MessagesPanelContent({
   const [activeServiceRequest, setActiveServiceRequest] = useState<ServiceRequestRecord | null>(
     null,
   );
+  const [activeServiceRequestMessageId, setActiveServiceRequestMessageId] = useState<string | null>(
+    null,
+  );
+  const [replyComposerMode, setReplyComposerMode] =
+    useState<ReplyComposerMode>("create_note_reply");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [serviceRequests, setServiceRequests] = useState<ServiceRequestRecord[]>([]);
   const [serviceRequestDetailsById, setServiceRequestDetailsById] = useState<
@@ -461,6 +485,14 @@ function MessagesPanelContent({
       ) ?? null
     );
   }, [selectedServiceRequestDetail, user]);
+  const selectedEditableServiceRequestMessage = useMemo(
+    () =>
+      getLatestEditableServiceRequestMessage(
+        selectedServiceRequestDetail,
+        user?.userId,
+      ),
+    [selectedServiceRequestDetail, user?.userId],
+  );
   const activeServiceRequestSummary = useMemo(() => {
     if (!activeServiceRequest) {
       return null;
@@ -563,6 +595,7 @@ function MessagesPanelContent({
       subject: note ? `Re: ${note.title}` : "Client follow-up",
     });
     setActiveThread(note ?? null);
+    setReplyComposerMode("create_note_reply");
     setIsReplyModalOpen(true);
   };
 
@@ -581,6 +614,56 @@ function MessagesPanelContent({
     });
     setActiveThread(null);
     setActiveServiceRequest(request);
+    setActiveServiceRequestMessageId(null);
+    setReplyComposerMode("create_service_request_reply");
+    setIsReplyModalOpen(true);
+  };
+
+  const openServiceRequestEditComposer = (request: ServiceRequestRecord) => {
+    replyForm.setFieldsValue({
+      clientId: request.clientId,
+      content: request.description,
+      recipientType: "client",
+      representativeId: "",
+      representativeIds: [],
+      subject: request.title,
+    });
+    setActiveThread(null);
+    setActiveServiceRequest(request);
+    setActiveServiceRequestMessageId(null);
+    setReplyComposerMode("edit_service_request");
+    setIsReplyModalOpen(true);
+  };
+
+  const openServiceRequestMessageEditComposer = (
+    request: ServiceRequestRecord,
+    detail: ServiceRequestDetail | null | undefined,
+  ) => {
+    const latestEditableMessage = getLatestEditableServiceRequestMessage(detail, user?.userId);
+
+    if (!latestEditableMessage) {
+      messageApi.error("There is no reply from your account on this request to edit.");
+      return;
+    }
+
+    replyForm.setFieldsValue({
+      clientId: request.clientId,
+      content: String(latestEditableMessage.payloadJson.content ?? ""),
+      recipientType: latestEditableMessage.payloadJson.recipientType as
+        | ServiceRequestMessageRecipientType
+        | undefined,
+      representativeId: "",
+      representativeIds: Array.isArray(latestEditableMessage.payloadJson.representativeUserIds)
+        ? latestEditableMessage.payloadJson.representativeUserIds.filter(
+            (value): value is string => typeof value === "string" && value.trim().length > 0,
+          )
+        : [],
+      subject: `Re: ${request.title}`,
+    });
+    setActiveThread(null);
+    setActiveServiceRequest(request);
+    setActiveServiceRequestMessageId(latestEditableMessage.id);
+    setReplyComposerMode("edit_service_request_reply");
     setIsReplyModalOpen(true);
   };
 
@@ -588,6 +671,8 @@ function MessagesPanelContent({
     setIsReplyModalOpen(false);
     setActiveThread(null);
     setActiveServiceRequest(null);
+    setActiveServiceRequestMessageId(null);
+    setReplyComposerMode("create_note_reply");
     replyForm.resetFields();
   };
 
@@ -596,24 +681,55 @@ function MessagesPanelContent({
       setIsSubmitting(true);
 
       try {
-        const detail = await addServiceRequestMessage(activeServiceRequest.id, {
-          content: values.content.trim(),
-          recipientType: values.recipientType ?? "client",
-          representativeUserIds:
-            values.recipientType === "representative" || values.recipientType === "both"
-              ? values.representativeIds ?? []
-              : [],
-        });
+        const detail =
+          replyComposerMode === "edit_service_request"
+            ? await getServiceRequestDetail(
+                (
+                  await updateServiceRequest(activeServiceRequest.id, {
+                    description: values.content.trim(),
+                    title: values.subject.trim(),
+                  })
+                ).id,
+              )
+            : replyComposerMode === "edit_service_request_reply" &&
+                activeServiceRequestMessageId
+              ? await updateServiceRequestMessage(
+                  activeServiceRequest.id,
+                  activeServiceRequestMessageId,
+                  {
+                    content: values.content.trim(),
+                  },
+                )
+              : await addServiceRequestMessage(activeServiceRequest.id, {
+                  content: values.content.trim(),
+                  recipientType: values.recipientType ?? "client",
+                  representativeUserIds:
+                    values.recipientType === "representative" || values.recipientType === "both"
+                      ? values.representativeIds ?? []
+                      : [],
+                });
         setServiceRequestDetailsById((current) => ({
           ...current,
           [activeServiceRequest.id]: detail,
         }));
         await loadServiceRequests();
-        messageApi.success("Reply added to the request conversation.");
+        messageApi.success(
+          replyComposerMode === "edit_service_request"
+            ? "Request updated."
+            : replyComposerMode === "edit_service_request_reply"
+              ? "Reply updated."
+              : "Reply added to the request conversation.",
+        );
         closeReplyComposer();
       } catch (error) {
         console.error(error);
-        messageApi.error("Could not save the request reply.");
+        messageApi.error(
+          replyComposerMode === "edit_service_request"
+            ? "Could not update the request."
+            : replyComposerMode === "edit_service_request_reply"
+              ? "Could not update the request reply."
+              : "Could not save the request reply.",
+        );
       } finally {
         setIsSubmitting(false);
       }
@@ -654,6 +770,50 @@ function MessagesPanelContent({
     } catch (error) {
       console.error(error);
       messageApi.error("Could not save the workspace reply.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDeleteServiceRequest = async (request: ServiceRequestRecord) => {
+    setIsSubmitting(true);
+
+    try {
+      await deleteServiceRequest(request.id);
+      await loadServiceRequests();
+      messageApi.success("Request deleted.");
+    } catch (error) {
+      console.error(error);
+      messageApi.error("Could not delete the request.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDeleteServiceRequestReply = async (
+    request: ServiceRequestRecord,
+    detail: ServiceRequestDetail | null | undefined,
+  ) => {
+    const latestEditableMessage = getLatestEditableServiceRequestMessage(detail, user?.userId);
+
+    if (!latestEditableMessage) {
+      messageApi.error("There is no reply from your account on this request to delete.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const nextDetail = await deleteServiceRequestMessage(request.id, latestEditableMessage.id);
+      setServiceRequestDetailsById((current) => ({
+        ...current,
+        [request.id]: nextDetail,
+      }));
+      await loadServiceRequests();
+      messageApi.success("Reply deleted.");
+    } catch (error) {
+      console.error(error);
+      messageApi.error("Could not delete the request reply.");
     } finally {
       setIsSubmitting(false);
     }
@@ -1142,11 +1302,51 @@ function MessagesPanelContent({
                   </>
                 ) : null}
                 <Button
+                  loading={isSubmitting}
+                  onClick={() => openServiceRequestEditComposer(selectedServiceRequest)}
+                >
+                  Edit request
+                </Button>
+                <Button
+                  danger
+                  loading={isSubmitting}
+                  onClick={() => void handleDeleteServiceRequest(selectedServiceRequest)}
+                >
+                  Delete request
+                </Button>
+                <Button
                   icon={<SendOutlined />}
                   onClick={() => openServiceRequestReplyComposer(selectedServiceRequest)}
                 >
                   Reply
                 </Button>
+                {selectedEditableServiceRequestMessage ? (
+                  <>
+                    <Button
+                      loading={isSubmitting}
+                      onClick={() =>
+                        openServiceRequestMessageEditComposer(
+                          selectedServiceRequest,
+                          selectedServiceRequestDetail,
+                        )
+                      }
+                    >
+                      Edit reply
+                    </Button>
+                    <Button
+                      danger
+                      loading={isSubmitting}
+                      onClick={() =>
+                        void handleDeleteServiceRequestReply(
+                          selectedServiceRequest,
+                          selectedServiceRequestDetail,
+                        )
+                      }
+                    >
+                      Delete reply
+                    </Button>
+                  </>
+                ) : null}
               </Space>
             </div>
 
@@ -1427,39 +1627,26 @@ function MessagesPanelContent({
             onCancel={closeReplyComposer}
             onOk={() => replyForm.submit()}
             okButtonProps={{ loading: isSubmitting }}
-            okText="Send reply"
+            okText={
+              replyComposerMode === "edit_service_request"
+                ? "Save request"
+                : replyComposerMode === "edit_service_request_reply"
+                  ? "Save reply"
+                  : "Send reply"
+            }
             open={isReplyModalOpen}
-            title="Reply from workspace"
+            title={
+              replyComposerMode === "edit_service_request"
+                ? "Edit request"
+                : replyComposerMode === "edit_service_request_reply"
+                  ? "Edit request reply"
+                  : "Reply from workspace"
+            }
           >
             <Form className={styles.modalForm} form={replyForm} layout="vertical" onFinish={handleReplySubmit}>
-              {activeServiceRequest ? null : (
-                <>
-                  <Form.Item
-                    label="Client"
-                    name="clientId"
-                  >
-                    <Select allowClear options={clientOptions} placeholder="No client selected" />
-                  </Form.Item>
-                  <Form.Item
-                    label="Representative"
-                    name="representativeId"
-                  >
-                    <Select
-                      allowClear
-                      options={representativeOptions}
-                      placeholder="No representative selected"
-                    />
-                  </Form.Item>
-                  <Form.Item
-                    label="Subject"
-                    name="subject"
-                    rules={[{ message: "Add a subject", required: true }]}
-                  >
-                    <Input placeholder="Message subject" />
-                  </Form.Item>
-                </>
-              )}
-              {activeServiceRequest ? (
+              {activeServiceRequest &&
+              (replyComposerMode === "create_service_request_reply" ||
+                replyComposerMode === "edit_service_request_reply") ? (
                 <>
                   <Form.Item
                     label="Send to"
@@ -1518,17 +1705,63 @@ function MessagesPanelContent({
                     />
                   </Form.Item>
                 </>
-              ) : null}
+              ) : activeServiceRequest ? (
+                <Form.Item
+                  label="Subject"
+                  name="subject"
+                  rules={[{ message: "Add a subject", required: true }]}
+                >
+                  <Input placeholder="Request subject" />
+                </Form.Item>
+              ) : (
+                <>
+                  <Form.Item
+                    label="Client"
+                    name="clientId"
+                  >
+                    <Select allowClear options={clientOptions} placeholder="No client selected" />
+                  </Form.Item>
+                  <Form.Item
+                    label="Representative"
+                    name="representativeId"
+                  >
+                    <Select
+                      allowClear
+                      options={representativeOptions}
+                      placeholder="No representative selected"
+                    />
+                  </Form.Item>
+                  <Form.Item
+                    label="Subject"
+                    name="subject"
+                    rules={[{ message: "Add a subject", required: true }]}
+                  >
+                    <Input placeholder="Message subject" />
+                  </Form.Item>
+                </>
+              )}
               <Form.Item
-                label={activeServiceRequest ? "Reply" : "Message"}
+                label={
+                  activeServiceRequest &&
+                  (replyComposerMode === "create_service_request_reply" ||
+                    replyComposerMode === "edit_service_request_reply")
+                    ? "Reply"
+                    : activeServiceRequest
+                      ? "Request details"
+                      : "Message"
+                }
                 name="content"
                 rules={[{ message: "Enter the message", required: true }]}
               >
                 <Input.TextArea
                   placeholder={
-                    activeServiceRequest
+                    activeServiceRequest &&
+                    (replyComposerMode === "create_service_request_reply" ||
+                      replyComposerMode === "edit_service_request_reply")
                       ? "Write your response to this request"
-                      : "Write the reply"
+                      : activeServiceRequest
+                        ? "Update the request details"
+                        : "Write the reply"
                   }
                   rows={5}
                 />

--- a/lib/client/service-request-api.ts
+++ b/lib/client/service-request-api.ts
@@ -163,6 +163,25 @@ export const createServiceRequest = async (payload: {
 export const getServiceRequestDetail = async (requestId: string) =>
   serviceRequestApi<ServiceRequestDetail>(`/api/service-requests/${requestId}`);
 
+export const updateServiceRequest = async (
+  requestId: string,
+  payload: {
+    description?: string;
+    priority?: ServiceRequestPriority;
+    requestType?: string;
+    title?: string;
+  },
+) =>
+  serviceRequestApi<ServiceRequestRecord>(`/api/service-requests/${requestId}`, {
+    body: JSON.stringify(payload),
+    method: "PATCH",
+  });
+
+export const deleteServiceRequest = async (requestId: string) =>
+  serviceRequestApi<ServiceRequestRecord>(`/api/service-requests/${requestId}`, {
+    method: "DELETE",
+  });
+
 export const createServiceRequestAssignments = async (
   requestId: string,
   payload: {
@@ -216,3 +235,26 @@ export const addServiceRequestMessage = async (
     body: JSON.stringify(payload),
     method: "POST",
   });
+
+export const updateServiceRequestMessage = async (
+  requestId: string,
+  messageId: string,
+  payload: {
+    content: string;
+  },
+) =>
+  serviceRequestApi<ServiceRequestDetail>(
+    `/api/service-requests/${requestId}/messages/${messageId}`,
+    {
+      body: JSON.stringify(payload),
+      method: "PATCH",
+    },
+  );
+
+export const deleteServiceRequestMessage = async (requestId: string, messageId: string) =>
+  serviceRequestApi<ServiceRequestDetail>(
+    `/api/service-requests/${requestId}/messages/${messageId}`,
+    {
+      method: "DELETE",
+    },
+  );

--- a/lib/server/assistant-openai.ts
+++ b/lib/server/assistant-openai.ts
@@ -81,8 +81,10 @@ import {
   attachProposalToServiceRequest,
   createServiceRequest,
   createServiceRequestAssignments,
+  deleteServiceRequest,
   getServiceRequestDetail,
   markServiceRequestUnderReview,
+  updateServiceRequest,
 } from "@/lib/server/service-request-store";
 import {
   applyLiveServiceRequestClientDecision,
@@ -91,8 +93,10 @@ import {
   attachLiveProposalToServiceRequest,
   createLiveServiceRequest,
   createLiveServiceRequestAssignments,
+  deleteLiveServiceRequest,
   getLiveServiceRequestDetail,
   markLiveServiceRequestUnderReview,
+  updateLiveServiceRequest,
 } from "@/lib/server/service-request-backend-store";
 
 export type AssistantMessage = {
@@ -7531,6 +7535,9 @@ const createToolset = (
     "create_pricing_request",
     "update_pricing_request",
     "delete_pricing_request",
+    "create_service_request",
+    "update_service_request",
+    "delete_service_request",
     "create_note",
     "create_message",
     "update_note",
@@ -8219,6 +8226,70 @@ const createToolset = (
     );
   };
 
+  const findServiceRequestByReference = (reference: unknown) => {
+    if (typeof reference !== "string" || !reference.trim()) {
+      return null;
+    }
+
+    const normalizedReference = normalizeLookupValue(reference);
+
+    return (
+      workspace.serviceRequests.find(
+        (request) => normalizeLookupValue(request.id) === normalizedReference,
+      ) ??
+      workspace.serviceRequests.find(
+        (request) => normalizeLookupValue(request.title) === normalizedReference,
+      ) ??
+      workspace.serviceRequests.find((request) =>
+        [request.title, request.description, request.requestType]
+          .filter(Boolean)
+          .some((value) => normalizeLookupValue(String(value)).includes(normalizedReference)),
+      ) ??
+      null
+    );
+  };
+
+  const resolveServiceRequest = (
+    args: Record<string, unknown>,
+    options?: { allowRecentFallback?: boolean },
+  ) => {
+    const directRequest =
+      findServiceRequestByReference(args.requestId) ??
+      findServiceRequestByReference(args.requestTitle) ??
+      findServiceRequestByReference(args.title);
+
+    if (directRequest) {
+      return directRequest;
+    }
+
+    if (options?.allowRecentFallback) {
+      const recentRequest = workspace.serviceRequests[0] ?? null;
+
+      if (recentRequest) {
+        return recentRequest;
+      }
+    }
+
+    throw new Error(
+      "No matching service request was found in your current workspace. Provide a valid request title or id.",
+    );
+  };
+
+  const ensureMessageMutationAccess = (note: (typeof notes)[number]) => {
+    if (!isClientScopedActor) {
+      return;
+    }
+
+    const ownsMessage =
+      note.kind === "client_message" &&
+      note.source === "client_portal" &&
+      note.submittedBy === workspace.userEmail;
+
+    if (!ownsMessage) {
+      throw new Error("Clients can only update or delete their own sent messages.");
+    }
+  };
+
   const resolveOpportunityReferences = (references: unknown) => {
     if (!Array.isArray(references)) {
       return [];
@@ -8701,6 +8772,55 @@ const createToolset = (
         properties: {
           pricingRequestId: { type: "string" },
           pricingRequestTitle: { type: "string" },
+          title: { type: "string" },
+        },
+        type: "object",
+      },
+    },
+    {
+      description:
+        "Create a client request or service request when the user explicitly asks to submit a request to the workspace or account team.",
+      name: "create_service_request",
+      parameters: {
+        additionalProperties: false,
+        properties: {
+          clientId: { type: "string" },
+          clientName: { type: "string" },
+          description: { type: "string" },
+          priority: { type: "string" },
+          requestType: { type: "string" },
+          title: { type: "string" },
+        },
+        required: ["description", "title"],
+        type: "object",
+      },
+    },
+    {
+      description:
+        "Update an existing client request when the user explicitly asks to change its title, details, priority, or request type.",
+      name: "update_service_request",
+      parameters: {
+        additionalProperties: false,
+        properties: {
+          description: { type: "string" },
+          priority: { type: "string" },
+          requestId: { type: "string" },
+          requestTitle: { type: "string" },
+          requestType: { type: "string" },
+          title: { type: "string" },
+        },
+        type: "object",
+      },
+    },
+    {
+      description:
+        "Delete an existing client request when the user explicitly asks to remove it from the workspace queue.",
+      name: "delete_service_request",
+      parameters: {
+        additionalProperties: false,
+        properties: {
+          requestId: { type: "string" },
+          requestTitle: { type: "string" },
           title: { type: "string" },
         },
         type: "object",
@@ -10023,6 +10143,135 @@ const createToolset = (
           },
         };
       }
+      case "create_service_request": {
+        const client =
+          hasValueReference(args.clientId) ||
+          hasValueReference(args.clientName) ||
+          hasValueReference(args.organizationName) ||
+          hasValueReference(args.accountName)
+            ? resolveClient(args, { allowRecentFallback: true })
+            : isClientScopedActor && workspace.clientIds?.[0]
+              ? salesData.clients.find((item) => item.id === workspace.clientIds?.[0]) ?? null
+              : null;
+
+        if (!client) {
+          throw new Error(
+            "No matching client was found for this request. Provide a valid client name first.",
+          );
+        }
+
+        const requestInput = {
+          clientId: client.id,
+          description: String(args.description ?? "").trim(),
+          priority:
+            typeof args.priority === "string" &&
+            ["low", "medium", "high", "critical"].includes(args.priority)
+              ? (args.priority as "low" | "medium" | "high" | "critical")
+              : "medium",
+          requestType:
+            typeof args.requestType === "string" && args.requestType.trim().length > 0
+              ? args.requestType.trim()
+              : "service_request",
+          source: (isClientScopedActor ? "client_portal" : "workspace") as
+            | "client_portal"
+            | "workspace",
+          title: String(args.title ?? "").trim(),
+        };
+
+        if (!requestInput.title || !requestInput.description) {
+          throw new Error("A service request needs both a title and a description.");
+        }
+
+        const serviceRequest =
+          workspace.isLiveBackend && workspace.sessionToken
+            ? await createLiveServiceRequest(actor, workspace.sessionToken, requestInput)
+            : createServiceRequest(actor, requestInput);
+
+        workspace.serviceRequests = [serviceRequest, ...workspace.serviceRequests.filter(
+          (item) => item.id !== serviceRequest.id,
+        )];
+
+        return {
+          mutation: {
+            entityId: serviceRequest.id,
+            entityType: "note" as const,
+            operation: "create" as const,
+            record: serviceRequest as unknown as Record<string, unknown>,
+            title: serviceRequest.title,
+          },
+          serviceRequest,
+        };
+      }
+      case "update_service_request": {
+        const existingRequest = resolveServiceRequest(args, { allowRecentFallback: true });
+        const serviceRequest =
+          workspace.isLiveBackend && workspace.sessionToken
+            ? await updateLiveServiceRequest(actor, workspace.sessionToken, existingRequest.id, {
+                description:
+                  typeof args.description === "string" ? args.description : undefined,
+                priority:
+                  typeof args.priority === "string" &&
+                  ["low", "medium", "high", "critical"].includes(args.priority)
+                    ? (args.priority as "low" | "medium" | "high" | "critical")
+                    : undefined,
+                requestType:
+                  typeof args.requestType === "string" ? args.requestType : undefined,
+                title: typeof args.title === "string" ? args.title : undefined,
+              })
+            : updateServiceRequest(actor, existingRequest.id, {
+                description:
+                  typeof args.description === "string" ? args.description : undefined,
+                priority:
+                  typeof args.priority === "string" &&
+                  ["low", "medium", "high", "critical"].includes(args.priority)
+                    ? (args.priority as "low" | "medium" | "high" | "critical")
+                    : undefined,
+                requestType:
+                  typeof args.requestType === "string" ? args.requestType : undefined,
+                title: typeof args.title === "string" ? args.title : undefined,
+              });
+
+        workspace.serviceRequests = workspace.serviceRequests
+          .filter((item) => item.id !== serviceRequest.id)
+          .concat(serviceRequest);
+
+        return {
+          mutation: {
+            entityId: serviceRequest.id,
+            entityType: "note" as const,
+            operation: "update" as const,
+            record: serviceRequest as unknown as Record<string, unknown>,
+            title: serviceRequest.title,
+          },
+          serviceRequest,
+        };
+      }
+      case "delete_service_request": {
+        const serviceRequest = resolveServiceRequest(args, { allowRecentFallback: true });
+
+        if (workspace.isLiveBackend && workspace.sessionToken) {
+          await deleteLiveServiceRequest(actor, workspace.sessionToken, serviceRequest.id);
+        } else {
+          deleteServiceRequest(actor, serviceRequest.id);
+        }
+
+        workspace.serviceRequests = workspace.serviceRequests.filter(
+          (item) => item.id !== serviceRequest.id,
+        );
+
+        return {
+          deletedServiceRequest: {
+            id: serviceRequest.id,
+            title: serviceRequest.title,
+          },
+          mutation: {
+            entityId: serviceRequest.id,
+            entityType: "note" as const,
+            operation: "delete" as const,
+            title: serviceRequest.title,
+          },
+        };
+      }
       case "create_note": {
         const client =
           hasValueReference(args.clientId) ||
@@ -10263,29 +10512,97 @@ const createToolset = (
         };
       }
       case "update_message": {
-        const message = await runTool(
-          "update_note",
-          JSON.stringify({
-            ...args,
+        const existingMessage = resolveNote(
+          {
             noteId: args.noteId ?? args.messageId,
             noteTitle: args.noteTitle ?? args.messageTitle ?? args.title,
             title: args.subject ?? args.title,
-          }),
+          },
+          { allowRecentFallback: true },
         );
+        ensureMessageMutationAccess(existingMessage);
+        const note =
+          workspace.isLiveBackend && workspace.sessionToken
+            ? await updateLiveNote(workspace.sessionToken, {
+                ...existingMessage,
+                content:
+                  typeof args.content === "string" ? args.content : existingMessage.content,
+                status:
+                  typeof args.status === "string" &&
+                  ["Acknowledged", "Sent"].includes(args.status)
+                    ? (args.status as "Acknowledged" | "Sent")
+                    : existingMessage.status,
+                title:
+                  typeof args.subject === "string"
+                    ? args.subject
+                    : typeof args.title === "string"
+                      ? args.title
+                      : existingMessage.title,
+              })
+            : updateMockNote(workspace.tenantId, existingMessage.id, {
+                content: typeof args.content === "string" ? args.content : undefined,
+                status:
+                  typeof args.status === "string" &&
+                  ["Acknowledged", "Sent"].includes(args.status)
+                    ? (args.status as "Acknowledged" | "Sent")
+                    : undefined,
+                title:
+                  typeof args.subject === "string"
+                    ? args.subject
+                    : typeof args.title === "string"
+                      ? args.title
+                      : undefined,
+              });
 
-        return message;
+        if (!note) {
+          throw new Error("The message could not be updated.");
+        }
+
+        workspace.notes = workspace.isLiveBackend
+          ? workspace.notes.filter((item) => item.id !== note.id).concat(note)
+          : listMockNotes(workspace.tenantId);
+
+        return {
+          message: note,
+          mutation: {
+            entityId: note.id,
+            entityType: "note" as const,
+            operation: "update" as const,
+            record: note as unknown as Record<string, unknown>,
+            title: note.title,
+          },
+        };
       }
       case "delete_message": {
-        const message = await runTool(
-          "delete_note",
-          JSON.stringify({
-            ...args,
+        const message = resolveNote(
+          {
             noteId: args.noteId ?? args.messageId,
             noteTitle: args.noteTitle ?? args.messageTitle ?? args.title,
-          }),
+            title: args.title,
+          },
+          { allowRecentFallback: true },
         );
+        ensureMessageMutationAccess(message);
 
-        return message;
+        if (workspace.isLiveBackend && workspace.sessionToken) {
+          await deleteLiveNote(workspace.sessionToken, message.id);
+        } else {
+          deleteMockNote(workspace.tenantId, message.id);
+        }
+        workspace.notes = workspace.notes.filter((item) => item.id !== message.id);
+
+        return {
+          deletedMessage: {
+            id: message.id,
+            title: message.title,
+          },
+          mutation: {
+            entityId: message.id,
+            entityType: "note" as const,
+            operation: "delete" as const,
+            title: message.title,
+          },
+        };
       }
       case "delete_opportunity": {
         const opportunity = resolveOpportunity(args, {
@@ -10472,7 +10789,12 @@ const createToolset = (
           "list_proposals",
           "list_follow_ups",
           "search_workspace_records",
+          "create_service_request",
+          "update_service_request",
+          "delete_service_request",
           "create_message",
+          "update_message",
+          "delete_message",
         ].includes(tool.name),
       );
 
@@ -10510,34 +10832,61 @@ async function createConfirmedGenericMutationLocalResult(
 
   const resultRecord = output as Record<string, unknown>;
   const responseMessage = (() => {
-    switch (localRequest.toolName) {
-      case "delete_client":
-        return `Deleted client ${String(mutation.title ?? "Untitled client")}.`;
-      case "delete_opportunity":
-        return `Deleted opportunity ${String(mutation.title ?? "Untitled opportunity")}.`;
-      case "delete_proposal":
-        return `Deleted proposal ${String(mutation.title ?? "Untitled proposal")}.`;
-      case "create_note":
-        return `Created note ${String(mutation.title ?? "Untitled note")}.`;
-      case "update_note":
-        return `Updated note ${String(mutation.title ?? "Untitled note")}.`;
-      case "delete_note":
-        return `Deleted note ${String(mutation.title ?? "Untitled note")}.`;
-      case "create_pricing_request":
-        return `Created pricing request ${String(mutation.title ?? "Untitled pricing request")}.`;
-      case "update_pricing_request":
-        return `Updated pricing request ${String(mutation.title ?? "Untitled pricing request")}.`;
-      case "delete_pricing_request":
-        return `Deleted pricing request ${String(mutation.title ?? "Untitled pricing request")}.`;
-      case "create_activity":
-        return `Created follow-up ${String(mutation.title ?? "Untitled activity")}.`;
-      case "update_activity":
-        return `Updated follow-up ${String(mutation.title ?? "Untitled activity")}.`;
-      case "delete_activity":
-        return `Deleted follow-up ${String(mutation.title ?? "Untitled activity")}.`;
-      default:
-        return "Completed the requested workspace change.";
+    const toolName = String(localRequest.toolName);
+
+    if (toolName === "delete_client") {
+      return `Deleted client ${String(mutation.title ?? "Untitled client")}.`;
     }
+    if (toolName === "delete_opportunity") {
+      return `Deleted opportunity ${String(mutation.title ?? "Untitled opportunity")}.`;
+    }
+    if (toolName === "delete_proposal") {
+      return `Deleted proposal ${String(mutation.title ?? "Untitled proposal")}.`;
+    }
+    if (toolName === "create_service_request") {
+      return `Created request ${String(mutation.title ?? "Untitled request")}.`;
+    }
+    if (toolName === "update_service_request") {
+      return `Updated request ${String(mutation.title ?? "Untitled request")}.`;
+    }
+    if (toolName === "delete_service_request") {
+      return `Deleted request ${String(mutation.title ?? "Untitled request")}.`;
+    }
+    if (toolName === "create_note") {
+      return `Created note ${String(mutation.title ?? "Untitled note")}.`;
+    }
+    if (toolName === "update_note") {
+      return `Updated note ${String(mutation.title ?? "Untitled note")}.`;
+    }
+    if (toolName === "delete_note") {
+      return `Deleted note ${String(mutation.title ?? "Untitled note")}.`;
+    }
+    if (toolName === "update_message") {
+      return `Updated message ${String(mutation.title ?? "Untitled message")}.`;
+    }
+    if (toolName === "delete_message") {
+      return `Deleted message ${String(mutation.title ?? "Untitled message")}.`;
+    }
+    if (toolName === "create_pricing_request") {
+      return `Created pricing request ${String(mutation.title ?? "Untitled pricing request")}.`;
+    }
+    if (toolName === "update_pricing_request") {
+      return `Updated pricing request ${String(mutation.title ?? "Untitled pricing request")}.`;
+    }
+    if (toolName === "delete_pricing_request") {
+      return `Deleted pricing request ${String(mutation.title ?? "Untitled pricing request")}.`;
+    }
+    if (toolName === "create_activity") {
+      return `Created follow-up ${String(mutation.title ?? "Untitled activity")}.`;
+    }
+    if (toolName === "update_activity") {
+      return `Updated follow-up ${String(mutation.title ?? "Untitled activity")}.`;
+    }
+    if (toolName === "delete_activity") {
+      return `Deleted follow-up ${String(mutation.title ?? "Untitled activity")}.`;
+    }
+
+    return "Completed the requested workspace change.";
   })();
 
   return {
@@ -10762,6 +11111,16 @@ const filterGeminiToolDefinitions = (
     selected.add("create_message");
     selected.add("update_message");
     selected.add("delete_message");
+  }
+
+  if (
+    normalized.includes("request") ||
+    normalized.includes("service request") ||
+    normalized.includes("account team")
+  ) {
+    selected.add("create_service_request");
+    selected.add("update_service_request");
+    selected.add("delete_service_request");
   }
 
   if (

--- a/lib/server/service-request-backend-store.ts
+++ b/lib/server/service-request-backend-store.ts
@@ -111,6 +111,19 @@ const requireClientUser = (user: IMockUser) => {
   }
 };
 
+const canManageRequest = (user: IMockUser, request: ServiceRequestRecord) =>
+  user.role !== "Client" || request.submittedByUserId === user.id;
+
+const canManageMessageEvent = (
+  user: IMockUser,
+  request: ServiceRequestRecord,
+  event: WorkflowEventRecord,
+) =>
+  user.role !== "Client" ||
+  (event.eventType === "service_request_message_added" &&
+    event.actorUserId === user.id &&
+    canManageRequest(user, request));
+
 const extractErrorMessage = (value: unknown) => {
   if (typeof value === "string" && value.trim()) {
     return value;
@@ -242,6 +255,12 @@ const updateWorkflowNote = async (
       isPrivate: false,
     }),
     method: "PUT",
+  });
+};
+
+const deleteWorkflowNote = async (token: string, noteId: string) => {
+  await fetchBackend<void>(token, `/api/Notes/${noteId}`, {
+    method: "DELETE",
   });
 };
 
@@ -804,6 +823,169 @@ export const addLiveServiceRequestMessage = async (
     representativeNames,
     representativeUserIds,
   });
+
+  return getLiveServiceRequestDetail(user, token, requestId);
+};
+
+export const updateLiveServiceRequest = async (
+  user: IMockUser,
+  token: string,
+  requestId: string,
+  input: {
+    description?: string;
+    priority?: ServiceRequestPriority;
+    requestType?: string;
+    title?: string;
+  },
+) => {
+  const { request } = await getVisibleRequestOrThrow(user, token, requestId);
+
+  if (!canManageRequest(user, request.request)) {
+    throw new Error("You do not have access to update this service request.");
+  }
+
+  const title = typeof input.title === "string" ? input.title.trim() : request.request.title;
+  const description =
+    typeof input.description === "string"
+      ? input.description.trim()
+      : request.request.description;
+  const requestType =
+    typeof input.requestType === "string" && input.requestType.trim().length > 0
+      ? input.requestType.trim()
+      : request.request.requestType;
+  const priority = input.priority ?? request.request.priority;
+
+  if (!title || !description) {
+    throw new Error("title and description are required.");
+  }
+
+  const updatedRequest: ServiceRequestRecord = {
+    ...request.request,
+    description,
+    priority,
+    requestType,
+    title,
+    updatedAt: nowIso(),
+  };
+
+  await updateWorkflowNote(token, request.noteId, {
+    kind: "request",
+    request: updatedRequest,
+    schema: "service-request-workflow-v1",
+    tenantId: user.tenantId,
+  });
+
+  await appendEvent(token, updatedRequest, user, "service_request_updated", {
+    description,
+    priority,
+    requestType,
+    title,
+  });
+
+  return clone(updatedRequest);
+};
+
+export const deleteLiveServiceRequest = async (
+  user: IMockUser,
+  token: string,
+  requestId: string,
+) => {
+  const { request, state } = await getVisibleRequestOrThrow(user, token, requestId);
+
+  if (!canManageRequest(user, request.request)) {
+    throw new Error("You do not have access to delete this service request.");
+  }
+
+  await deleteWorkflowNote(token, request.noteId);
+
+  for (const assignment of state.assignments.filter(
+    (item) => item.assignment.serviceRequestId === request.request.id,
+  )) {
+    await deleteWorkflowNote(token, assignment.noteId);
+  }
+
+  for (const event of state.events.filter(
+    (item) => item.event.serviceRequestId === request.request.id,
+  )) {
+    await deleteWorkflowNote(token, event.noteId);
+  }
+
+  return clone(request.request);
+};
+
+export const updateLiveServiceRequestMessage = async (
+  user: IMockUser,
+  token: string,
+  requestId: string,
+  messageId: string,
+  input: {
+    content: string;
+  },
+) => {
+  const content = input.content.trim();
+
+  if (!content) {
+    throw new Error("Message content is required.");
+  }
+
+  const { request, state } = await getVisibleRequestOrThrow(user, token, requestId);
+  const storedEvent = state.events.find(
+    (item) =>
+      item.event.id === messageId &&
+      item.event.serviceRequestId === request.request.id &&
+      item.event.eventType === "service_request_message_added",
+  );
+
+  if (!storedEvent) {
+    throw new Error("Service request message not found.");
+  }
+
+  if (!canManageMessageEvent(user, request.request, storedEvent.event)) {
+    throw new Error("You do not have access to update this service request message.");
+  }
+
+  const updatedEvent: WorkflowEventRecord = {
+    ...storedEvent.event,
+    payloadJson: {
+      ...storedEvent.event.payloadJson,
+      content,
+      editedAt: nowIso(),
+    },
+  };
+
+  await updateWorkflowNote(token, storedEvent.noteId, {
+    event: updatedEvent,
+    kind: "event",
+    schema: "service-request-workflow-v1",
+    tenantId: user.tenantId,
+  });
+
+  return getLiveServiceRequestDetail(user, token, requestId);
+};
+
+export const deleteLiveServiceRequestMessage = async (
+  user: IMockUser,
+  token: string,
+  requestId: string,
+  messageId: string,
+) => {
+  const { request, state } = await getVisibleRequestOrThrow(user, token, requestId);
+  const storedEvent = state.events.find(
+    (item) =>
+      item.event.id === messageId &&
+      item.event.serviceRequestId === request.request.id &&
+      item.event.eventType === "service_request_message_added",
+  );
+
+  if (!storedEvent) {
+    throw new Error("Service request message not found.");
+  }
+
+  if (!canManageMessageEvent(user, request.request, storedEvent.event)) {
+    throw new Error("You do not have access to delete this service request message.");
+  }
+
+  await deleteWorkflowNote(token, storedEvent.noteId);
 
   return getLiveServiceRequestDetail(user, token, requestId);
 };

--- a/lib/server/service-request-store.ts
+++ b/lib/server/service-request-store.ts
@@ -280,6 +280,19 @@ const requireClientUser = (user: IMockUser) => {
   }
 };
 
+const canManageRequest = (user: IMockUser, request: ServiceRequestRecord) =>
+  isInternalUser(user) || request.submittedByUserId === user.id;
+
+const canManageMessageEvent = (
+  user: IMockUser,
+  request: ServiceRequestRecord,
+  event: WorkflowEventRecord,
+) =>
+  isInternalUser(user) ||
+  (event.eventType === "service_request_message_added" &&
+    event.actorUserId === user.id &&
+    canManageRequest(user, request));
+
 const toServiceRequestDetail = (
   state: ServiceRequestState,
   request: ServiceRequestRecord,
@@ -860,6 +873,145 @@ export const addServiceRequestMessage = (
     representativeNames,
     representativeUserIds,
   });
+
+  return getServiceRequestDetail(user, requestId);
+};
+
+export const updateServiceRequest = (
+  user: IMockUser,
+  requestId: string,
+  input: {
+    description?: string;
+    priority?: ServiceRequestPriority;
+    requestType?: string;
+    title?: string;
+  },
+) => {
+  const { request, state } = getVisibleRequestOrThrow(user, requestId);
+
+  if (!canManageRequest(user, request)) {
+    throw new Error("You do not have access to update this service request.");
+  }
+
+  const title = typeof input.title === "string" ? input.title.trim() : request.title;
+  const description =
+    typeof input.description === "string" ? input.description.trim() : request.description;
+  const requestType =
+    typeof input.requestType === "string" && input.requestType.trim().length > 0
+      ? input.requestType.trim()
+      : request.requestType;
+  const priority = input.priority ?? request.priority;
+
+  if (!title || !description) {
+    throw new Error("title and description are required.");
+  }
+
+  const updated = updateRequestRecord(state, request.id, {
+    description,
+    priority,
+    requestType,
+    title,
+  });
+
+  if (!updated) {
+    throw new Error("Service request not found.");
+  }
+
+  appendEvent(state, updated, user, "service_request_updated", {
+    description,
+    priority,
+    requestType,
+    title,
+  });
+
+  return clone(updated);
+};
+
+export const deleteServiceRequest = (user: IMockUser, requestId: string) => {
+  const { request, state } = getVisibleRequestOrThrow(user, requestId);
+
+  if (!canManageRequest(user, request)) {
+    throw new Error("You do not have access to delete this service request.");
+  }
+
+  state.requests = state.requests.filter((item) => item.id !== request.id);
+  state.assignments = state.assignments.filter(
+    (assignment) => assignment.serviceRequestId !== request.id,
+  );
+  state.events = state.events.filter((event) => event.serviceRequestId !== request.id);
+  persistServiceRequestStore();
+
+  return clone(request);
+};
+
+export const updateServiceRequestMessage = (
+  user: IMockUser,
+  requestId: string,
+  messageId: string,
+  input: {
+    content: string;
+  },
+) => {
+  const content = input.content.trim();
+
+  if (!content) {
+    throw new Error("Message content is required.");
+  }
+
+  const { request, state } = getVisibleRequestOrThrow(user, requestId);
+  const eventIndex = state.events.findIndex(
+    (event) =>
+      event.id === messageId &&
+      event.serviceRequestId === request.id &&
+      event.eventType === "service_request_message_added",
+  );
+
+  if (eventIndex < 0) {
+    throw new Error("Service request message not found.");
+  }
+
+  const event = state.events[eventIndex];
+
+  if (!canManageMessageEvent(user, request, event)) {
+    throw new Error("You do not have access to update this service request message.");
+  }
+
+  state.events[eventIndex] = {
+    ...event,
+    payloadJson: {
+      ...event.payloadJson,
+      content,
+      editedAt: nowIso(),
+    },
+  };
+  persistServiceRequestStore();
+
+  return getServiceRequestDetail(user, requestId);
+};
+
+export const deleteServiceRequestMessage = (
+  user: IMockUser,
+  requestId: string,
+  messageId: string,
+) => {
+  const { request, state } = getVisibleRequestOrThrow(user, requestId);
+  const event = state.events.find(
+    (item) =>
+      item.id === messageId &&
+      item.serviceRequestId === request.id &&
+      item.eventType === "service_request_message_added",
+  );
+
+  if (!event) {
+    throw new Error("Service request message not found.");
+  }
+
+  if (!canManageMessageEvent(user, request, event)) {
+    throw new Error("You do not have access to delete this service request message.");
+  }
+
+  state.events = state.events.filter((item) => item.id !== messageId);
+  persistServiceRequestStore();
 
   return getServiceRequestDetail(user, requestId);
 };


### PR DESCRIPTION
Fixes #304

## Summary
Add full request and message CRUD coverage for client and sales-rep workflows.

## Scope
- add request update/delete support in the service-request API
- add request-thread message update/delete support
- wire client message center to edit/delete requests and follow-ups
- wire sales-rep messages panel to edit/delete requests and request replies
- allow safe assistant-side request/message CRUD for client-scoped users and reps

## Verification
- npm run build
